### PR TITLE
[nightly] B-1: Server-enforced free-tier limits (15 plays / 2 playbooks) — ⚠ requires SQL run

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,15 +22,6 @@ section); schema context lives in `supabase/SCHEMA.md`.
 
 ## Up next
 
-### B-1 · Server-enforced free-tier limits (15 plays / 2 playbooks)
-New idempotent SQL file: RLS policy or trigger blocking INSERT into `plays`
-beyond 15 rows (and `playbooks` beyond 2) for users where `is_pro()` is false.
-Client: catch the rejection in the save flows and show a friendly upgrade prompt
-(use `useEntitlement()` + `FREE_LIMITS` from `src/lib/entitlements.ts`), never a
-raw Postgres error. **Acceptance:** free user's 16th play insert fails
-server-side; UI shows an upgrade message; Pro/Founding users unaffected.
-⚠ requires SQL run.
-
 ### B-2 · UI export gates (Pro features)
 Gate playbook PDF export (detailed + grid) and wristband export behind
 `useEntitlement().isPro` with an upgrade prompt for free users. Free single-play
@@ -101,6 +92,18 @@ them in.
 
 ## Done
 
+- **2026-07-03 · B-1: Server-enforced free-tier limits (15 plays / 2 playbooks)**
+  — `supabase/free_tier_limits.sql` adds `BEFORE INSERT` triggers on `plays`/
+  `playbooks` blocking a 16th play / 3rd playbook for non-`is_pro()` users
+  (raises custom `PBP01`/`PBP02` codes). Client: `getSafeErrorMessage()`
+  (`src/lib/errors.ts`) maps those codes to the trigger's friendly
+  upgrade-prompt message instead of a generic DB error — also fixed a latent
+  bug there where Postgrest errors (thrown as plain `{code,message,...}`
+  objects, not `Error` instances, since this codebase doesn't use
+  `.throwOnError()`) were falling through to the generic fallback message
+  entirely. `PlaybooksPage.tsx`'s `createPlaybook` now surfaces its error in
+  the create-playbook modal (previously silently console-logged only).
+  ⚠ requires SQL run.
 - **2026-07-02 · Playwright smoke suite + `verify` script** — `tests/smoke/`,
   `npm run smoke`, `npm run verify`; covers designer offense/defense flows,
   undo, and the play-load path with a mocked backend.

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -21,6 +21,7 @@ import {
   LayoutGrid
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { getSafeErrorMessage } from '../../lib/errors';
 
 interface Playbook {
   id: string;
@@ -55,6 +56,7 @@ export function PlaybooksPage() {
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [newPlaybookName, setNewPlaybookName] = useState('');
   const [newPlaybookDescription, setNewPlaybookDescription] = useState('');
+  const [createPlaybookError, setCreatePlaybookError] = useState<string | null>(null);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -139,6 +141,7 @@ export function PlaybooksPage() {
     if (!newPlaybookName.trim()) return;
 
     try {
+      setCreatePlaybookError(null);
       const { data: playbook, error } = await supabase
         .from('playbooks')
         .insert([
@@ -159,6 +162,7 @@ export function PlaybooksPage() {
       loadPlaybooks();
     } catch (error) {
       console.error('Error creating playbook:', error);
+      setCreatePlaybookError(getSafeErrorMessage(error, 'Failed to create playbook'));
     }
   };
 
@@ -777,7 +781,7 @@ export function PlaybooksPage() {
                 New Play
               </button>
               <button
-                onClick={() => setShowCreateModal(true)}
+                onClick={() => { setCreatePlaybookError(null); setShowCreateModal(true); }}
                 className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors"
               >
                 <Plus className="h-4 w-4" />
@@ -832,7 +836,7 @@ export function PlaybooksPage() {
                     <BookOpen className="h-12 w-12 text-chalk/30 mx-auto mb-3" />
                     <p className="text-chalk/70 mb-4">No playbooks found</p>
                     <button
-                      onClick={() => setShowCreateModal(true)}
+                      onClick={() => { setCreatePlaybookError(null); setShowCreateModal(true); }}
                       className="text-sm text-primary hover:text-primary/80"
                     >
                       Create your first playbook
@@ -1060,6 +1064,11 @@ export function PlaybooksPage() {
                   </button>
                 </div>
                 <div className="p-6 space-y-4">
+                  {createPlaybookError && (
+                    <div className="text-red-500 text-sm bg-red-500/10 p-3 rounded-lg">
+                      {createPlaybookError}
+                    </div>
+                  )}
                   <div>
                     <label className="block text-sm font-medium text-chalk mb-2">
                       Playbook Name *

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -8,17 +8,29 @@
  * logged for debugging). Supabase Auth errors and our own hand-written
  * `throw new Error('...')` validation messages are already written to be
  * user-facing, so they pass through unchanged.
+ *
+ * Note: this codebase's `.insert()/.update()` calls don't use `.throwOnError()`,
+ * so the caught value is the raw parsed Postgrest error JSON
+ * (`{code, message, details, hint}`), not an `Error`/`PostgrestError`
+ * instance — detect it by shape rather than by `instanceof`/`.name`.
  */
 export function getSafeErrorMessage(
   err: unknown,
   fallback = 'Something went wrong. Please try again.',
 ): string {
-  if (err instanceof Error && err.name === 'PostgrestError') {
+  const isPostgrestError =
+    typeof err === 'object' && err !== null &&
+    'code' in err && 'message' in err && 'details' in err && 'hint' in err;
+
+  if (isPostgrestError) {
     console.error('Database error:', err);
-    const code = (err as Error & { code?: string }).code;
+    const { code, message } = err as { code: unknown; message: unknown };
     if (code === '23505') return 'That already exists.';
     if (code === '23503') return 'That item could not be found or no longer exists.';
-    if (code === '42501' || /row-level security/i.test(err.message)) {
+    // Free-tier limit triggers (see supabase/free_tier_limits.sql) raise these
+    // custom codes with an already user-safe, upgrade-prompt message.
+    if (code === 'PBP01' || code === 'PBP02') return String(message);
+    if (code === '42501' || (typeof message === 'string' && /row-level security/i.test(message))) {
       return "You don't have permission to do that.";
     }
     return fallback;

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -19,6 +19,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `subscriptions.sql` | applied | `subscriptions` table, `is_pro()`, Founding-Member backfill. |
 | `security_hardening.sql` | **verify applied** | Pins `search_path` on `is_admin()`/`is_pro()`; drops the unsafe `user_reputation` write policy; switches `image_reports` moderator policies to `is_admin()`. |
 | `community_authors.sql` | **verify applied** | `get_community_authors(uuid[])` for Community post author display. |
+| `free_tier_limits.sql` | **verify applied** | `BEFORE INSERT` triggers on `plays`/`playbooks` blocking free-plan users past `FREE_LIMITS` (15 plays / 2 playbooks). |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.
@@ -39,8 +40,8 @@ idempotent `.sql` file and update this doc in the same change.
 ### Play design
 | Table | Key columns | RLS summary |
 |---|---|---|
-| `plays` | `id`, `user_id`, `name`, `type play_type`, `formation_id`, `canvas_data text` (JSON `{version,paths,playerIcons}`), `description`, `thumbnail`, `is_public bool`, `metadata jsonb`, timestamps | Owner full access (`auth.uid()=user_id`); admins manage all; **anyone** (anon+auth) can SELECT where `is_public=true`. |
-| `playbooks` | `id`, `user_id`, `name`, `description`, timestamps | Owner full access. |
+| `plays` | `id`, `user_id`, `name`, `type play_type`, `formation_id`, `canvas_data text` (JSON `{version,paths,playerIcons}`), `description`, `thumbnail`, `is_public bool`, `metadata jsonb`, timestamps | Owner full access (`auth.uid()=user_id`); admins manage all; **anyone** (anon+auth) can SELECT where `is_public=true`. `BEFORE INSERT` trigger blocks a 16th row for non-`is_pro()` users (`free_tier_limits.sql`). |
+| `playbooks` | `id`, `user_id`, `name`, `description`, timestamps | Owner full access. `BEFORE INSERT` trigger blocks a 3rd row for non-`is_pro()` users (`free_tier_limits.sql`). |
 | `playbook_plays` | `id`, `playbook_id`, `play_id`, `order_position`; UNIQUE`(playbook_id,play_id)` & `(playbook_id,order_position)` | Access via owning playbook (`playbooks.user_id=auth.uid()`). |
 | `formations` | `id`, `user_id`, `name`, `type`, `template`, `is_system bool` | Read if `is_system` or owner; manage own non-system rows. |
 | `categories` | `id`, `name`, `type`, `parent_id`, `playbook_id`, `order_position` | Access via owning playbook. |
@@ -76,6 +77,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `admin_list_feedback()` | Admin-gated; feedback rows joined to submitter email. |
 | `delete_user(target_user_id uuid)` | Admin-gated; deletes the auth account (cascades). Blocks self-deletion. |
 | `get_community_authors(target_ids uuid[])` | Returns `id, username, avatar_url` for a batch of authors (Community page; avoids embedding a nonexistent `profiles` table). Granted to anon+authenticated. |
+| `enforce_plays_free_limit()` / `enforce_playbooks_free_limit()` | Trigger fns: raise `PBP01`/`PBP02` (custom SQLSTATE, user-safe message) when a non-`is_pro()` user's insert would exceed `FREE_LIMITS.plays`/`FREE_LIMITS.playbooks`. Client maps these codes to an upgrade prompt in `src/lib/errors.ts`. |
 | `handle_new_user_signup()` | Trigger fn: on `auth.users` insert, creates a `user_reputation` row with a default avatar. |
 | `update_updated_at_column()` | Generic `updated_at` touch trigger. |
 | `update_user_reputation()` | Trigger fn: bumps poster reputation on new post/comment. |

--- a/supabase/free_tier_limits.sql
+++ b/supabase/free_tier_limits.sql
@@ -1,0 +1,49 @@
+-- B-1: server-enforced free-tier limits (15 plays / 2 playbooks).
+-- Run this once in the Supabase SQL Editor. Idempotent — safe to re-run.
+--
+-- Why a trigger instead of an RLS policy: RLS WITH CHECK failures surface as
+-- a generic 42501 "row-level security" error, which the client already maps
+-- to "You don't have permission to do that." (see src/lib/errors.ts) — not
+-- an accurate message for a plan-limit block. A BEFORE INSERT trigger lets us
+-- raise a distinct, friendly error the client can recognize and show as an
+-- upgrade prompt instead.
+--
+-- Limits must stay in sync with FREE_LIMITS in src/lib/entitlements.ts.
+
+CREATE OR REPLACE FUNCTION enforce_plays_free_limit()
+RETURNS trigger AS $$
+BEGIN
+  IF NOT is_pro(NEW.user_id) AND (
+    SELECT count(*) FROM plays WHERE user_id = NEW.user_id
+  ) >= 15 THEN
+    RAISE EXCEPTION 'Free plan is limited to 15 plays. Upgrade to Pro for unlimited plays.'
+      USING ERRCODE = 'PBP01';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS enforce_plays_free_limit_trigger ON plays;
+CREATE TRIGGER enforce_plays_free_limit_trigger
+  BEFORE INSERT ON plays
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_plays_free_limit();
+
+CREATE OR REPLACE FUNCTION enforce_playbooks_free_limit()
+RETURNS trigger AS $$
+BEGIN
+  IF NOT is_pro(NEW.user_id) AND (
+    SELECT count(*) FROM playbooks WHERE user_id = NEW.user_id
+  ) >= 2 THEN
+    RAISE EXCEPTION 'Free plan is limited to 2 playbooks. Upgrade to Pro for unlimited playbooks.'
+      USING ERRCODE = 'PBP02';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS enforce_playbooks_free_limit_trigger ON playbooks;
+CREATE TRIGGER enforce_playbooks_free_limit_trigger
+  BEFORE INSERT ON playbooks
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_playbooks_free_limit();

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -122,6 +122,66 @@ test('defense: place a safety and drag a zone of responsibility', async ({ page 
   await expect(page.getByRole('button', { name: 'offense', exact: true })).toBeDisabled();
 });
 
+test('free-tier play limit: server rejection surfaces as an upgrade prompt', async ({ page }) => {
+  // Covers the client half of B-1 (server-enforced free-tier limits): when
+  // the enforce_plays_free_limit() trigger (supabase/free_tier_limits.sql)
+  // rejects a 16th play insert with its custom PBP01 code, the UI must show
+  // the trigger's friendly message rather than a raw/generic DB error. The
+  // trigger itself runs only against a real Supabase instance and isn't
+  // covered by this mocked-backend suite.
+  await page.addInitScript(() => {
+    const session = {
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user: {
+        id: '11111111-1111-1111-1111-111111111111',
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'coach@example.com',
+        app_metadata: {},
+        user_metadata: {},
+        created_at: new Date(0).toISOString(),
+      },
+    };
+    localStorage.setItem('sb-your-project-auth-token', JSON.stringify(session));
+  });
+
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/rest/v1/plays**', (route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    return route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 'PBP01',
+        message: 'Free plan is limited to 15 plays. Upgrade to Pro for unlimited plays.',
+        details: null,
+        hint: null,
+      }),
+    });
+  });
+
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+
+  await page.locator('button[title="Save play"]:visible').click();
+  await page.getByPlaceholder('Enter play name...').fill('16th Play');
+  await page.getByRole('button', { name: 'Next: Choose Playbook' }).click();
+  await page.getByRole('button', { name: 'Save Play' }).click();
+
+  await expect(
+    page.getByText('Free plan is limited to 15 plays. Upgrade to Pro for unlimited plays.'),
+  ).toBeVisible();
+});
+
 test('loads a saved defensive play via /designer?play= (mocked backend)', async ({ page }) => {
   // Covers the client half of the save→reload seam without needing an
   // authenticated Supabase session: version-3 canvas_data with icons, a


### PR DESCRIPTION
## What changed and why

Implements backlog item **B-1**: free-tier limits (15 plays / 2 playbooks) enforced **server-side**, so the client can't be bypassed.

- **`supabase/free_tier_limits.sql`** (new, idempotent): `BEFORE INSERT` triggers on `plays` and `playbooks`. For users where `is_pro()` is false, a 16th play / 3rd playbook insert raises a friendly error with custom SQLSTATE codes `PBP01`/`PBP02`. Pro/Founding users are unaffected. A trigger was chosen over an RLS `WITH CHECK` policy because RLS failures surface as a generic 42501 that the client maps to "You don't have permission to do that." — wrong message for a plan limit.
- **`src/lib/errors.ts`**: `getSafeErrorMessage()` maps `PBP01`/`PBP02` to the trigger's upgrade-prompt message. This also **fixes a latent bug**: the codebase never uses `.throwOnError()`, so caught Postgrest errors are plain `{code,message,details,hint}` objects, not `Error` instances — the old `err instanceof Error && err.name === 'PostgrestError'` check never matched, and *every* DB error fell through to the generic fallback. Detection is now by shape.
- **`src/components/playbooks/PlaybooksPage.tsx`**: `createPlaybook` failures now render in the create-playbook modal (previously console-only), using the existing error-banner style.
- **`src/components/designer/PlayDesigner.tsx`** save flow needed no change — it already routes errors through `getSafeErrorMessage()` into a visible toast.
- **`supabase/SCHEMA.md`** and **`BACKLOG.md`** updated (B-1 → Done).

## ⚠ requires SQL run

Run **`supabase/free_tier_limits.sql`** once in the Supabase SQL Editor (idempotent, safe to re-run). **Sequencing note:** run the B-4 Founding Member backfill first (or verify it's current) — any existing non-backfilled user with ≥15 plays would otherwise be blocked immediately. Until the SQL is run, this PR is a no-op for users.

## Verification

Environment had no Supabase credentials; build/tests ran against a placeholder `.env` (mocked backend).

- `npm run build` — ✅ pass
- `npx tsc --noEmit` — ✅ no errors in touched files (the 12 pre-existing errors tracked in B-5 remain in untouched files)
- `npm run smoke` — ✅ 5/5 pass:
  - home page renders without uncaught errors — pass
  - offense: place player, draw route, undo both — pass
  - defense: place safety, drag zone — pass
  - **free-tier play limit: server rejection surfaces as an upgrade prompt — pass (new test)** — mocks a `PBP01` 400 on `POST /rest/v1/plays` and asserts the friendly message renders
  - loads saved defensive play via `/designer?play=` — pass

**Not verified (needs real Supabase):** the trigger SQL itself — the smoke suite covers the client half only. After running the SQL, a free-user 16th-play insert and Pro-user unaffectedness should be spot-checked (pairs naturally with the B-8 manual QA pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS

---
_Generated by [Claude Code](https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS)_