### PR TITLE
[nightly] B-9: Delete legacy vercel.json

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -72,10 +72,6 @@ confirm icons/zones/routes reload intact. (The smoke suite covers this flow with
 a mocked backend; this checks the real DB round trip once.) **Human task** —
 agents skip.
 
-### B-9 · Delete legacy `vercel.json`
-Deploys are Netlify; SPA routing is `public/_redirects`. `vercel.json` is dead
-config that misleads readers. Delete it and confirm nothing references it.
-
 ### B-10 · Play voting
 Upvotes on public/community plays: schema (new SQL file + SCHEMA.md), RLS
 (one vote per user per play), and UI on community cards. Prerequisite for B-11.
@@ -92,6 +88,10 @@ them in.
 
 ## Done
 
+- **2026-07-04 · B-9: Delete legacy `vercel.json`** — removed the dead Vercel
+  config (deploys are Netlify via `public/_redirects`). Also corrected the
+  now-stale Vercel deployment instructions in `README.md` to describe the
+  Netlify flow, and dropped the dangling `vercel.json` reference in `CLAUDE.md`.
 - **2026-07-03 · B-1: Server-enforced free-tier limits (15 plays / 2 playbooks)**
   — `supabase/free_tier_limits.sql` adds `BEFORE INSERT` triggers on `plays`/
   `playbooks` blocking a 16th play / 3rd playbook for non-`is_pro()` users

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ playbooks, and print/share them. Live at **playbuilderpro.com**.
 - **Backend:** Supabase (Postgres, Auth, Storage). Client in `src/lib/supabase.ts` —
   always import the shared client; never call `createClient` in components.
 - **Deploy:** Netlify, auto-deploys on push to `main`. SPA routing relies on
-  `public/_redirects` (`/* /index.html 200`) — NOT `vercel.json` (legacy, ignored).
+  `public/_redirects` (`/* /index.html 200`).
 - **Env:** `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` (and the GA tag is
   hardcoded in `index.html`). `.env` is git-ignored; never commit secrets.
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ npm run preview
 
 ## Deployment
 
-This app is configured for deployment on Vercel:
+This app is deployed on Netlify and auto-deploys on every push to `main`:
 
 1. Push your code to GitHub
-2. Connect your repository to Vercel
-3. Set environment variables in Vercel dashboard:
+2. Connect your repository to Netlify
+3. Set environment variables in the Netlify dashboard:
    - `VITE_SUPABASE_URL`
    - `VITE_SUPABASE_ANON_KEY`
 4. Deploy!
+
+SPA routing (so deep links like `/designer` don't 404) relies on
+`public/_redirects` (`/* /index.html 200`), which Netlify picks up automatically.
 
 ## Environment Variables
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "framework": "vite",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
-}


### PR DESCRIPTION
## What changed and why

Implements backlog item **B-9**. Deploys run on **Netlify** (SPA routing via `public/_redirects`, `/* /index.html 200`). `vercel.json` was dead config — Netlify never reads it — that only misleads readers. This deletes it and cleans up the references that pointed at Vercel:

- **`vercel.json`** — deleted.
- **`README.md`** — the Deployment section still walked contributors through a **Vercel** setup (connect repo to Vercel, set env vars in the Vercel dashboard). Rewritten to describe the actual Netlify flow and note that `public/_redirects` handles SPA deep-link routing. *(This was the reference most likely to actually mislead a human — it read as current setup instructions.)*
- **`CLAUDE.md`** — dropped the now-dangling "NOT `vercel.json` (legacy, ignored)" aside, since the file it referenced no longer exists.
- **`BACKLOG.md`** — B-9 moved to Done.

B-9's acceptance criterion is "delete it and confirm nothing references it." After this change, `git grep -in vercel` returns only the BACKLOG Done entry — no remaining config or doc references.

## Verification

- `npm run build` — ✅ pass (confirms the app builds fine without `vercel.json`, which it never used).
- Smoke suite **not** re-run — no application or runtime code changed; this PR is docs + removal of an unused config file only.

## Note (out of scope, flagging only)

While confirming references, I noticed `README.md` also lists **"Canvas: Fabric.js"** under Tech Stack, but the canvas is actually pure HTML Canvas (per `CLAUDE.md` and `Canvas.tsx`) — Fabric.js isn't used. I left it untouched to keep this PR scoped to B-9. Happy to fix it in a follow-up or you can add it to the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS

---
_Generated by [Claude Code](https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS)_