### PR TITLE
docs: correct stale README Tech Stack and Project Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ A modern web application for designing and managing football plays.
 
 ## Tech Stack
 
-- **Frontend**: React 18 + TypeScript + Vite
-- **Styling**: Tailwind CSS
-- **Canvas**: Fabric.js for interactive drawing
-- **Backend**: Supabase (database, auth, storage)
+- **Frontend**: React 18 + TypeScript + Vite, React Router v6
+- **Styling**: Tailwind CSS (dark theme)
+- **Canvas**: HTML5 Canvas 2D — the play designer draws directly to a `<canvas>`
+  (play data stored in normalized 0–1 coordinates); not Fabric.js
+- **Backend**: Supabase (Postgres, auth, storage)
 - **Icons**: Lucide React
 
 ## Development
@@ -72,11 +73,17 @@ This app is configured for deployment on Vercel:
 
 ```
 src/
+├── App.tsx           # Routes + top-level layout
+├── main.tsx          # Entry point
 ├── components/
-│   ├── designer/     # Play designer components
-│   ├── ui/           # Reusable UI components
-│   └── layout/       # Layout components
-├── lib/              # Utilities and configurations
-├── types/            # TypeScript type definitions
-└── pages/            # Page components
+│   ├── designer/     # Play designer (canvas, toolbar, save/load)
+│   ├── plays/        # Play library
+│   ├── playbooks/    # Playbook management + PDF export
+│   ├── community/    # Community feed
+│   ├── blog/         # Blog
+│   ├── auth/         # Auth & account settings
+│   ├── admin/        # Admin dashboard
+│   └── *.tsx         # Landing-page sections (Navbar, Hero, Pricing, …)
+├── lib/              # Shared Supabase client, entitlements, errors, analytics
+└── types/            # TypeScript type definitions
 ```


### PR DESCRIPTION
## What changed and why

A quick documentation-accuracy pass — two claims in `README.md` had drifted from the code:

1. **Tech Stack said "Canvas: Fabric.js for interactive drawing."** The play designer (`Canvas.tsx`) draws directly to an **HTML5 Canvas 2D context** (`getContext('2d')`), matching `CLAUDE.md`'s architecture note. Fabric isn't involved in the designer. Corrected the line (and noted it's *not* Fabric to preempt the confusion).
2. **Project Structure listed `src/components/ui/`, `src/components/layout/`, and `src/pages/`** — none of which exist. Replaced the tree with the real layout: `designer`, `plays`, `playbooks`, `community`, `blog`, `auth`, `admin` (+ top-level landing sections), plus `lib` and `types`.

Also aligned two small details with `CLAUDE.md` (React Router v6, dark theme).

**Scope:** `README.md` only. No build/test surface (markdown), so verify was not run.

## Correction to my earlier note

On PR #2 I wrote that Fabric.js "isn't used" — that was **wrong**, and this audit is how I caught it. Fabric.js **is** a dependency (`fabric ^6.7.1`), imported by `src/components/designer/FormationSelector.tsx`. But `FormationSelector` is **orphaned** — nothing imports or renders it (`git grep FormationSelector` returns only the file itself). So Fabric's only consumer is dead code.

## Discovered follow-up (not in this PR)

**Remove orphaned `FormationSelector.tsx` + drop the `fabric` / `@types/fabric` deps.** It's unreferenced dead code and the sole reason Fabric is still in `package.json`; removing it would shrink the dependency surface. This is a code change (not docs), so it belongs in its own item — suggest adding it to the backlog. I've left `package.json` untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS

---
_Generated by [Claude Code](https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS)_