### PR TITLE
Fix Account Settings page rendering blank (runtime crash) + wire up password change

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -44,13 +44,13 @@ account UI. `useEntitlement().isFoundingMember` already exists. ⚠ requires SQL
 run. **Note:** run the backfill only right before Pro gates go live (B-1/B-2),
 so signups until then are included.
 
-### B-5 · Fix the 12 pre-existing tsc errors, then add tsc to verify
-`npx tsc --noEmit` currently fails in: `AccountSettings.tsx` (null `user`,
-`User` used as value), `UserMenu.tsx` (`icon_url` on `never`),
+### B-5 · Fix the remaining pre-existing tsc errors, then add tsc to verify
+`npx tsc --noEmit` currently fails in: `UserMenu.tsx` (`icon_url` on `never`),
 `AddToPlaybookModal.tsx` (null `user`), `SavePlayModal.tsx` (missing `playName`),
-`AddToPlaybookButton.tsx` (Set iteration). Fix all, then change the `verify`
-script to `tsc --noEmit && build && smoke`. **Acceptance:** `npx tsc --noEmit`
-exits 0.
+`AddToPlaybookButton.tsx` (Set iteration). (`AccountSettings.tsx`'s errors were
+fixed in the blank-page hotfix — one of them was crashing the page at runtime,
+proof these aren't cosmetic.) Fix all, then change the `verify` script to
+`tsc --noEmit && build && smoke`. **Acceptance:** `npx tsc --noEmit` exits 0.
 
 ### B-6 · Repair eslint (flat-config migration)
 `npm run lint` crashes: a config object uses `extends`, unsupported in eslint 9
@@ -90,8 +90,40 @@ Wire it to voting data and re-enable. **Blocked on:** B-10.
 publish (never fabricate — house rule). Human collects quotes; agent then wires
 them in.
 
+### B-13 · Account page: Plan & usage section
+Card on `/account` showing current plan (Free / Pro / **Founding Member** badge —
+overlaps B-4's badge), live usage meters ("9 of 15 plays · 1 of 2 playbooks"
+via `useEntitlement()` + `FREE_LIMITS` + count queries), and an upgrade CTA for
+free users. This section is also the future home of B-3's Stripe Customer
+Portal link. **Acceptance:** free user sees meters + CTA; founding user sees
+badge and no CTA.
+
+### B-14 · Team identity settings (name/logo on exports)
+Account settings for team name and optional logo, stamped onto single-play PDFs,
+playbook PDFs, and wristband exports. Include default game format (5v5/7v7) to
+prefill `SavePlayModal`. Needs a `user_preferences` store (new idempotent SQL +
+SCHEMA.md). ⚠ requires SQL run.
+
+### B-15 · Save & export default preferences
+Account settings for: default play visibility (private/public), default play
+type, paper size (Letter/A4), and default playbook export style (simple/
+detailed/grid). Store alongside B-14's preferences. **Blocked on:** B-14
+(shares the preferences store).
+
+### B-16 · Email change on account page
+`supabase.auth.updateUser({ email })` + confirmation-flow messaging (Supabase
+sends a verification email to the new address). Auth-adjacent → human review.
+
 ## Done
 
+- **2026-07-04 · Hotfix: Account Settings page rendered blank** — a type-only
+  `User` import was used as a JSX component (line 360), `undefined` at runtime,
+  crashing the whole `/account` route (this was one of the B-5 tsc errors —
+  `vite build` doesn't type-check, so it shipped). Same PR: wired up the
+  password-change form (its fields were previously ignored by save), removed
+  the self-report avatar flag (impossible by DB constraint:
+  `reporter_id != reported_user_id`), fixed the remaining AccountSettings tsc
+  errors, and added a smoke test that `/account` renders for a signed-in user.
 - **2026-07-03 · B-1: Server-enforced free-tier limits (15 plays / 2 playbooks)**
   — `supabase/free_tier_limits.sql` adds `BEFORE INSERT` triggers on `plays`/
   `playbooks` blocking a 16th play / 3rd playbook for non-`is_pro()` users

--- a/src/components/auth/AccountSettings.tsx
+++ b/src/components/auth/AccountSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import type { User } from '@supabase/supabase-js';
-import { User as UserIcon, Lock, AlertTriangle, Calendar, Trash2, Upload, Image, Save, Flag } from 'lucide-react';
+import { User as UserIcon, Lock, AlertTriangle, Calendar, Trash2, Upload, Image, Save } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { ImageCropModal } from './ImageCropModal';
@@ -12,7 +12,6 @@ export default function AccountSettings() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [username, setUsername] = useState('');
-  const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
@@ -83,20 +82,38 @@ export default function AccountSettings() {
 
   // Check for changes
   useEffect(() => {
-    const hasUnsavedChanges = 
+    const hasUnsavedChanges =
       username !== initialValues.username ||
       avatarType !== initialValues.avatarType ||
       avatarUrl !== initialValues.avatarUrl ||
-      selectedIconId !== initialValues.selectedIconId;
-    
+      selectedIconId !== initialValues.selectedIconId ||
+      newPassword !== '';
+
     setHasChanges(hasUnsavedChanges);
-  }, [username, avatarType, avatarUrl, selectedIconId, initialValues]);
+  }, [username, avatarType, avatarUrl, selectedIconId, newPassword, initialValues]);
 
   const handleSaveChanges = async () => {
+    if (!user) return;
     try {
       setError('');
       setSuccess('');
-      
+
+      // Update password if a new one was entered
+      if (newPassword) {
+        if (newPassword !== confirmPassword) {
+          throw new Error('New password and confirmation do not match.');
+        }
+        if (newPassword.length < 6) {
+          throw new Error('Password must be at least 6 characters.');
+        }
+        const { error: passwordError } = await supabase.auth.updateUser({
+          password: newPassword
+        });
+        if (passwordError) throw passwordError;
+        setNewPassword('');
+        setConfirmPassword('');
+      }
+
       // Update username if changed
       if (username !== initialValues.username) {
         const { error: usernameError } = await supabase.auth.updateUser({
@@ -199,18 +216,6 @@ export default function AccountSettings() {
     setAvatarUrl('');
   };
 
-  const handleReportImage = async (url: string, userId?: string | null) => {
-    try {
-      if (!url) return;
-      // Minimal reporting: insert into reported_images table (adjust schema as needed)
-      await supabase.from('reported_images').insert({ url, reported_by: userId || null });
-      setSuccess('Image reported. Thank you.');
-    } catch (err) {
-      console.error('Report failed', err);
-      setError(getSafeErrorMessage(err, 'Failed to report image'));
-    }
-  };
-
   const handleDeleteAccount = async () => {
     try {
       const { error } = await supabase.rpc('delete_user');
@@ -229,6 +234,10 @@ export default function AccountSettings() {
       </div>
     );
   }
+
+  // getUser() redirects to /auth when signed out, so user is set by the time
+  // loading clears — this narrows the type for the JSX below.
+  if (!user) return null;
 
   return (
     <div className="min-h-screen bg-board py-12">
@@ -292,21 +301,12 @@ export default function AccountSettings() {
               {avatarType === 'custom' ? (
                 <div className="space-y-4">
                   {avatarUrl && (
-                    <div className="relative">
-                      <div className="w-24 h-24 rounded-full overflow-hidden">
-                        <img
-                          src={avatarUrl}
-                          alt="Profile"
-                          className="w-full h-full object-cover"
-                        />
-                      </div>
-                      <button
-                        onClick={() => handleReportImage(avatarUrl, user.id)}
-                        className="absolute -top-2 -right-2 p-1 bg-red-500 text-white rounded-full hover:bg-red-600 transition-colors"
-                        title="Report inappropriate content"
-                      >
-                        <Flag className="h-4 w-4" />
-                      </button>
+                    <div className="w-24 h-24 rounded-full overflow-hidden">
+                      <img
+                        src={avatarUrl}
+                        alt="Profile"
+                        className="w-full h-full object-cover"
+                      />
                     </div>
                   )}
                   <div>
@@ -357,7 +357,7 @@ export default function AccountSettings() {
                 </label>
                 <div className="mt-1 relative">
                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center">
-                    <User className="h-5 w-5 text-chalk/50" />
+                    <UserIcon className="h-5 w-5 text-chalk/50" />
                   </div>
                   <input
                     type="text"

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -182,6 +182,58 @@ test('free-tier play limit: server rejection surfaces as an upgrade prompt', asy
   ).toBeVisible();
 });
 
+test('account settings page renders for a signed-in user (mocked backend)', async ({ page }) => {
+  // Regression test: the page previously rendered blank because a type-only
+  // `User` import was used as a JSX component (undefined at runtime), which
+  // crashed the whole route after "Loading..." cleared.
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+
+  const userJson = {
+    id: '11111111-1111-1111-1111-111111111111',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'coach@example.com',
+    app_metadata: {},
+    user_metadata: { username: 'coach' },
+    created_at: '2025-09-01T00:00:00Z',
+  };
+
+  await page.addInitScript((user) => {
+    localStorage.setItem('sb-your-project-auth-token', JSON.stringify({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user,
+    }));
+  }, userJson);
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }),
+  );
+  await page.route('**/rest/v1/user_reputation**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ avatar_type: 'icon', avatar_url: null, avatar_icon_id: null }),
+    }),
+  );
+  await page.route('**/rest/v1/avatar_icons**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+
+  await page.goto('/account');
+
+  await expect(page.getByRole('heading', { name: 'Account Settings' })).toBeVisible();
+  await expect(page.getByText('Member Since')).toBeVisible();
+  // The username section is where the crash happened (icon next to the input)
+  await expect(page.locator('#username')).toBeVisible();
+  await expect(page.getByText('Delete Account').first()).toBeVisible();
+  expect(errors, errors.map((e) => e.message).join('\n')).toHaveLength(0);
+});
+
 test('loads a saved defensive play via /designer?play= (mocked backend)', async ({ page }) => {
   // Covers the client half of the save→reload seam without needing an
   // authenticated Supabase session: version-3 canvas_data with icons, a


### PR DESCRIPTION
## What changed and why

**The `/account` page rendered blank for every user.** The code had a full settings page (avatar, username, password, delete account) — it just crashed before painting. Root cause: `AccountSettings.tsx` imported Supabase's `User` **as a type only** and Lucide's `User` icon renamed to `UserIcon`, but line 360 rendered `<User />` — the type. Type-only imports are erased at build time, so the component was `undefined` at runtime; React threw and tore down the whole route the moment "Loading..." cleared. `vite build` doesn't type-check, which is how it shipped — **this was one of the known B-5 tsc errors**, now demonstrably not cosmetic.

### Fixes (all on this one page)
1. **Blank-page crash** — render the already-imported `UserIcon` instead of the erased `User` type.
2. **Password change silently did nothing** — the form's fields were never read by `handleSaveChanges`. Now: entering a new password shows the Save button, validates (match + min 6 chars), and calls `supabase.auth.updateUser({ password })`. Fields clear on success. *(Auth-adjacent — please eyeball this part per the house rule.)*
3. **Removed the self-report avatar flag** — it inserted into a nonexistent table (`reported_images`; the real one is `image_reports`), and `image_reports` has `CHECK (reporter_id != reported_user_id)`, so reporting your **own** avatar can never succeed by design. Reporting belongs on other users' avatars in community views.
4. **Fixed the remaining AccountSettings tsc errors** (null-`user` narrowing after the loading gate + guard in save). Repo-wide `tsc --noEmit` errors drop **12 → 7**; zero remain in this file. B-5 rescoped accordingly.

### New regression test
`tests/smoke/designer.spec.ts` — "account settings page renders for a signed-in user": mocks the auth session + REST endpoints, asserts the heading, Member Since, the **username input (the exact crash site)**, and zero `pageerror` events. This test fails on `main` and passes on this branch.

### BACKLOG
- Hotfix recorded in Done; B-5 rescoped to the 4 remaining files.
- Appended discovered items from the account-settings review: **B-13** Plan & usage section (meters vs `FREE_LIMITS`, Founding badge, future Stripe-portal home), **B-14** team identity on PDF/wristband exports (⚠ will require SQL), **B-15** save/export default preferences, **B-16** email change (human review — auth).

## Verification

- `npm run build` — ✅ pass
- `npx tsc --noEmit` — ✅ 0 errors in touched files (7 pre-existing B-5 errors remain in untouched files)
- `npm run smoke` — ✅ **6/6 pass**, including the new `/account` regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS

---
_Generated by [Claude Code](https://claude.ai/code/session_012wRvknSBs6k1Pum6oA39cS)_