### PR TITLE
[nightly] B-2: gate playbook PDF export behind Pro, keep single-play free

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,13 +22,6 @@ section); schema context lives in `supabase/SCHEMA.md`.
 
 ## Up next
 
-### B-2 · UI export gates (Pro features)
-Gate playbook PDF export (detailed + grid) and wristband export behind
-`useEntitlement().isPro` with an upgrade prompt for free users. Free single-play
-PDF stays available but gets a small "Made with playbuilderpro.com" footer
-credit; Pro output is clean. **Acceptance:** gates verified in browser for both
-a free and a pro state (pro state may be simulated by mocking the entitlement).
-
 ### B-3 · Stripe Checkout + Customer Portal + webhook (scaffold)
 Supabase Edge Function for a signature-verified Stripe webhook writing to
 `subscriptions` (service role); checkout session creation for the $39/yr
@@ -112,6 +105,23 @@ sends a verification email to the new address). Auth-adjacent → human review.
 
 ## Done
 
+- **2026-07-05 · B-2: UI export gates (Pro features)** — Playbook PDF export
+  (all formats: `ExportModal`'s detailed/grid layouts and `PlaybooksPage`'s
+  simple/detailed/grid playbook export, which all print multiple plays) now
+  requires `useEntitlement().isPro`; a free user sees a "Pro" lock badge on
+  those options and a new shared `UpgradePrompt` modal (`src/components/
+  UpgradePrompt.tsx`) instead of the print flow, linking back to the homepage
+  Pricing section. The single-play PDF sheet in `ExportModal` stays free for
+  everyone and now stamps a small "Made with playbuilderpro.com" footer credit
+  when the exporting user isn't Pro (Pro output has no footer). Also fixed a
+  latent bug this surfaced: `ExportModal` was unconditionally mounted in
+  `PlayDesigner.tsx` (toggled via an `isOpen` prop rather than being
+  conditionally rendered), so its new entitlement lookup fired on every
+  Designer page load instead of only when the modal opens — changed to mount
+  only while open. **Note:** wristband export isn't implemented anywhere in
+  the app yet (only referenced in marketing copy and a couple of type unions),
+  so there was nothing to gate for it — flagging rather than stubbing a
+  feature that doesn't exist.
 - **2026-07-04 · Hotfix: Account Settings page rendered blank** — a type-only
   `User` import was used as a JSX component (line 360), `undefined` at runtime,
   crashing the whole `/account` route (this was one of the B-5 tsc errors —

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Lock, X } from 'lucide-react';
+
+interface UpgradePromptProps {
+  isOpen: boolean;
+  onClose: () => void;
+  feature: string;
+  description: string;
+}
+
+/** Preventive Pro gate shown when a free user tries a Pro-only export. */
+export function UpgradePrompt({ isOpen, onClose, feature, description }: UpgradePromptProps) {
+  const navigate = useNavigate();
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 text-center">
+        <div className="fixed inset-0 bg-black bg-opacity-75" onClick={onClose} />
+        <div className="inline-block w-full max-w-sm overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl border border-primary/40">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
+            <div className="flex items-center gap-2">
+              <Lock className="h-5 w-5 text-primary shrink-0" />
+              <h3 className="text-lg font-bold text-chalk">{feature} is a Pro feature</h3>
+            </div>
+            <button onClick={onClose} className="text-chalk/70 hover:text-chalk transition-colors shrink-0">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+          <div className="p-6">
+            <p className="text-sm text-chalk/70">{description}</p>
+          </div>
+          <div className="px-6 py-4 border-t border-chalk/10 flex justify-end gap-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-chalk bg-board border border-chalk/20 rounded-md hover:bg-board-light"
+            >
+              Maybe later
+            </button>
+            <button
+              onClick={() => { onClose(); navigate('/'); }}
+              className="px-4 py-2 text-sm font-medium bg-primary text-white rounded-md hover:bg-primary/90"
+            >
+              See Pro Plans
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -1,8 +1,12 @@
 import React, { useState } from 'react';
-import { X, FileText, Printer, BookOpen, Settings, Image, User, Tag, Grid3X3, Layout } from 'lucide-react';
+import { X, FileText, Printer, BookOpen, Settings, Image, User, Tag, Grid3X3, Layout, Lock } from 'lucide-react';
 
 // Import LocalPlayMetadata from the PlayDesigner component
 import type { PlayMetadata } from '../../types/play';
+import { useEntitlement } from '../../lib/entitlements';
+import { UpgradePrompt } from '../UpgradePrompt';
+
+const PRO_ONLY_FORMATS = new Set(['detailed-playbook', 'grid-playbook']);
 
 interface PlayData {
   metadata: PlayMetadata;
@@ -44,6 +48,8 @@ export function ExportModal({
   const [selectedFormat, setSelectedFormat] = useState<'single-play' | 'detailed-playbook' | 'grid-playbook'>('single-play');
   const [metadata, setMetadata] = useState<PlayMetadata>(playMetadata);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
+  const { isPro, loading: entitlementLoading } = useEntitlement();
 
   if (!isOpen) return null;
   
@@ -200,7 +206,14 @@ export function ExportModal({
       font-weight: bold;
       color: #374151;
     }
-    
+
+    .free-footer {
+      margin-top: 15px;
+      text-align: center;
+      font-size: 8pt;
+      color: #9ca3af;
+    }
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
     }
@@ -234,6 +247,7 @@ export function ExportModal({
         </div>
       </div>
     </div>
+    ${!isPro ? '<div class="free-footer">Made with playbuilderpro.com</div>' : ''}
   </div>
 </body>
 </html>`;
@@ -541,6 +555,10 @@ export function ExportModal({
   };
 
   const handleFormatClick = (formatId: string) => {
+    if (PRO_ONLY_FORMATS.has(formatId) && !entitlementLoading && !isPro) {
+      setShowUpgradePrompt(true);
+      return;
+    }
     setSelectedFormat(formatId as 'single-play' | 'detailed-playbook' | 'grid-playbook');
     setShowMetadataEditor(true);
   };
@@ -784,23 +802,31 @@ export function ExportModal({
               Choose a print format:
             </p>
             <div className="space-y-3">
-              {printFormatOptions.map((option) => (
-                <button
-                  key={option.id}
-                  onClick={() => handleFormatClick(option.id)}
-                  className="w-full flex items-center p-4 bg-board hover:bg-board-light border border-chalk/10 rounded-lg transition-colors"
-                >
-                  <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary/10 text-primary">
-                    <option.icon className="h-6 w-6" />
-                  </div>
-                  <div className="ml-4 text-left">
-                    <h4 className="text-lg font-medium text-chalk">
-                      {option.name}
-                    </h4>
-                    <p className="text-sm text-chalk/70">{option.description}</p>
-                  </div>
-                </button>
-              ))}
+              {printFormatOptions.map((option) => {
+                const locked = PRO_ONLY_FORMATS.has(option.id) && !entitlementLoading && !isPro;
+                return (
+                  <button
+                    key={option.id}
+                    onClick={() => handleFormatClick(option.id)}
+                    className="w-full flex items-center p-4 bg-board hover:bg-board-light border border-chalk/10 rounded-lg transition-colors"
+                  >
+                    <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary/10 text-primary">
+                      <option.icon className="h-6 w-6" />
+                    </div>
+                    <div className="ml-4 text-left">
+                      <h4 className="text-lg font-medium text-chalk flex items-center gap-2">
+                        {option.name}
+                        {locked && (
+                          <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                            <Lock className="h-3 w-3" /> Pro
+                          </span>
+                        )}
+                      </h4>
+                      <p className="text-sm text-chalk/70">{option.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
             <div className="mt-6 flex justify-end">
               <button
@@ -813,6 +839,12 @@ export function ExportModal({
           </div>
         </div>
       </div>
+      <UpgradePrompt
+        isOpen={showUpgradePrompt}
+        onClose={() => setShowUpgradePrompt(false)}
+        feature="Playbook PDF export"
+        description="Detailed and grid playbook layouts are part of Playbuilder Pro ($39/yr). Single-play export stays free."
+      />
     </div>
   );
 }

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -426,15 +426,17 @@ export function PlayDesigner() {
       </div>
 
       {/* ── MODALS ─────────────────────────────────────────────── */}
-      <ExportModal
-        isOpen={showExportModal}
-        onClose={() => setShowExportModal(false)}
-        onExport={handleExportToPDF}
-        canvasRef={canvasRef}
-        playMetadata={currentPlayMetadata}
-        onUpdateMetadata={setCurrentPlayMetadata}
-        userHasAccount={!!user}
-      />
+      {showExportModal && (
+        <ExportModal
+          isOpen={showExportModal}
+          onClose={() => setShowExportModal(false)}
+          onExport={handleExportToPDF}
+          canvasRef={canvasRef}
+          playMetadata={currentPlayMetadata}
+          onUpdateMetadata={setCurrentPlayMetadata}
+          userHasAccount={!!user}
+        />
+      )}
       <SavePlayModal
         isOpen={showSaveModal}
         onClose={() => setShowSaveModal(false)}

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -18,10 +18,13 @@ import {
   Download,
   ChevronDown,
   FileText,
-  LayoutGrid
+  LayoutGrid,
+  Lock
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
+import { useEntitlement } from '../../lib/entitlements';
+import { UpgradePrompt } from '../UpgradePrompt';
 
 interface Playbook {
   id: string;
@@ -54,6 +57,8 @@ export function PlaybooksPage() {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
+  const { isPro, loading: entitlementLoading } = useEntitlement();
   const [newPlaybookName, setNewPlaybookName] = useState('');
   const [newPlaybookDescription, setNewPlaybookDescription] = useState('');
   const [createPlaybookError, setCreatePlaybookError] = useState<string | null>(null);
@@ -662,6 +667,12 @@ export function PlaybooksPage() {
       return;
     }
 
+    if (!entitlementLoading && !isPro) {
+      setShowExportMenu(false);
+      setShowUpgradePrompt(true);
+      return;
+    }
+
     try {
       let htmlContent = '';
 
@@ -925,8 +936,15 @@ export function PlaybooksPage() {
                                   className="w-full flex items-center gap-3 px-4 py-2 text-left text-chalk hover:bg-board transition-colors"
                                 >
                                   <FileText className="h-4 w-4 text-primary" />
-                                  <div>
-                                    <div className="font-medium">Simple (1 per page)</div>
+                                  <div className="flex-1">
+                                    <div className="font-medium flex items-center gap-2">
+                                      Simple (1 per page)
+                                      {!entitlementLoading && !isPro && (
+                                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                                          <Lock className="h-3 w-3" /> Pro
+                                        </span>
+                                      )}
+                                    </div>
                                     <div className="text-xs text-chalk/70">Play name + diagram only</div>
                                   </div>
                                 </button>
@@ -935,8 +953,15 @@ export function PlaybooksPage() {
                                   className="w-full flex items-center gap-3 px-4 py-2 text-left text-chalk hover:bg-board transition-colors"
                                 >
                                   <BookOpen className="h-4 w-4 text-primary" />
-                                  <div>
-                                    <div className="font-medium">Detailed (1 per page)</div>
+                                  <div className="flex-1">
+                                    <div className="font-medium flex items-center gap-2">
+                                      Detailed (1 per page)
+                                      {!entitlementLoading && !isPro && (
+                                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                                          <Lock className="h-3 w-3" /> Pro
+                                        </span>
+                                      )}
+                                    </div>
                                     <div className="text-xs text-chalk/70">Full metadata + diagram</div>
                                   </div>
                                 </button>
@@ -945,8 +970,15 @@ export function PlaybooksPage() {
                                   className="w-full flex items-center gap-3 px-4 py-2 text-left text-chalk hover:bg-board transition-colors"
                                 >
                                   <LayoutGrid className="h-4 w-4 text-primary" />
-                                  <div>
-                                    <div className="font-medium">Grid (all on one page)</div>
+                                  <div className="flex-1">
+                                    <div className="font-medium flex items-center gap-2">
+                                      Grid (all on one page)
+                                      {!entitlementLoading && !isPro && (
+                                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                                          <Lock className="h-3 w-3" /> Pro
+                                        </span>
+                                      )}
+                                    </div>
                                     <div className="text-xs text-chalk/70">Compact grid layout</div>
                                   </div>
                                 </button>
@@ -1116,12 +1148,18 @@ export function PlaybooksPage() {
 
         {/* Click outside to close export menu */}
         {showExportMenu && (
-          <div 
-            className="fixed inset-0 z-5" 
+          <div
+            className="fixed inset-0 z-5"
             onClick={() => setShowExportMenu(false)}
           />
         )}
       </div>
+      <UpgradePrompt
+        isOpen={showUpgradePrompt}
+        onClose={() => setShowUpgradePrompt(false)}
+        feature="Playbook PDF export"
+        description="Exporting a full playbook to PDF is part of Playbuilder Pro ($39/yr). You can still export any single play for free from the Play Designer."
+      />
     </div>
   );
 }

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -378,3 +378,66 @@ test('loads a saved defensive play via /designer?play= (mocked backend)', async 
   await expect(btn(page, 'Player S')).toBeVisible();
   await expect(page.getByRole('button', { name: 'defense', exact: true })).toBeDisabled();
 });
+
+test('export gates (B-2): playbook PDF formats are Pro-locked, single-play stays free', async ({ page }) => {
+  // Anonymous users resolve to the free plan without a subscriptions row.
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+
+  await expect(page.getByText('Single Play Sheet')).toBeVisible();
+  await expect(page.getByText('Pro', { exact: true }).first()).toBeVisible();
+
+  // Locked format shows the upgrade prompt instead of advancing to the print screen.
+  await page.getByText('Playbook Grid').click();
+  await expect(page.getByText('Playbook PDF export is a Pro feature')).toBeVisible();
+  await page.getByRole('button', { name: 'Maybe later' }).click();
+
+  // Free single-play export is unaffected.
+  await page.getByText('Single Play Sheet').click();
+  await expect(page.getByRole('button', { name: /Print Play/ })).toBeVisible();
+});
+
+test('export gates (B-2): Pro accounts see playbook formats unlocked', async ({ page }) => {
+  const userJson = {
+    id: '22222222-2222-2222-2222-222222222222',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'pro-coach@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '2025-09-01T00:00:00Z',
+  };
+
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }),
+  );
+  // Entitlement is mocked (simulated Pro), per B-2's acceptance criteria.
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ plan: 'pro', current_period_end: null }),
+    }),
+  );
+
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+
+  await expect(page.getByText('Single Play Sheet')).toBeVisible();
+  await expect(page.getByText('Pro', { exact: true })).toHaveCount(0);
+
+  await page.getByText('Playbook Grid').click();
+  await expect(page.getByRole('button', { name: /Print Playbook/ })).toBeVisible();
+  await expect(page.getByText('is a Pro feature')).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed

Implements BACKLOG.md **B-2 · UI export gates (Pro features)**.

- **Playbook PDF export is now Pro-gated** in both places it exists:
  - `src/components/designer/ExportModal.tsx` — the "Detailed Playbook" and "Grid Playbook" formats.
  - `src/components/playbooks/PlaybooksPage.tsx` — its "Simple", "Detailed", and "Grid" export menu items (all three print the *whole playbook*, i.e. multiple plays, so all three are gated — only `ExportModal`'s single-play sheet is the free path per the monetization plan in `CLAUDE.md`).
  - Free users see a small "Pro" lock badge on the gated options; clicking one opens a new shared `src/components/UpgradePrompt.tsx` modal instead of proceeding, with a "See Pro Plans" CTA that navigates to the homepage Pricing section (no fake checkout — Stripe/B-3 isn't live yet).
- **Single-play PDF stays free** and now stamps a small "Made with playbuilderpro.com" footer credit on the printed HTML when the exporting user isn't Pro (Pro users get clean output, per `Pricing.tsx`'s existing copy).
- **Bug fix surfaced by this change:** `ExportModal` was unconditionally mounted in `PlayDesigner.tsx` (visibility toggled via an `isOpen` prop) rather than conditionally rendered. Once it started calling `useEntitlement()`, that meant an extra Supabase auth/subscriptions lookup fired on *every* Designer page load, not just when the export modal opens — this broke an unrelated smoke test (`free-tier play limit`) by interfering with the mocked auth session. Fixed by rendering `<ExportModal>` only while `showExportModal` is true.

**Not gated:** wristband export. It isn't implemented anywhere in the codebase yet — the only references are in marketing copy (`Pricing.tsx`) and a couple of type unions (`'single' | 'multiple' | 'wristband'`), with no actual UI/feature behind it. Flagging this rather than building a stub feature outside B-2's scope.

## Why

Per the monetization plan (`CLAUDE.md`): Free = single-play PDF; Pro = full playbook PDFs + wristband export. This closes the gap between that plan and the actual export UI, which previously let free users print entire playbooks.

## Verify

- `npx tsc --noEmit` — same pre-existing errors as `main` (BACKLOG.md B-5, all in files this PR doesn't touch: `UserMenu.tsx`, `AddToPlaybookModal.tsx`, `SavePlayModal.tsx`, `AddToPlaybookButton.tsx`). No new errors.
- `npm run build` — ✅ passes.
- `npm run smoke` (Playwright) — ✅ **10/10 pass**, including 2 new tests added for this change:
  - `export gates (B-2): playbook PDF formats are Pro-locked, single-play stays free` — anonymous/free user sees "Pro" badges, clicking a gated format shows the upgrade prompt, single-play format still reaches the print screen.
  - `export gates (B-2): Pro accounts see playbook formats unlocked` — mocks a `subscriptions` row with `plan: 'pro'` (per the acceptance criterion allowing the Pro state to be simulated) and confirms no lock badges / no upgrade prompt.
  - All 8 pre-existing smoke tests also pass (including the previously-broken `free-tier play limit` test, now fixed by the `ExportModal` mount change above).

  Note: this sandbox has no real `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` and no `.env` file, and the pre-installed Playwright browser revision didn't match the pinned `@playwright/test` version. Both were worked around locally with a throwaway `.env` (fake, non-committed placeholder values — the smoke suite mocks all Supabase REST calls, so no real project was needed) and a temporary `executablePath` override, neither of which are part of this diff.
- Manual UI check wasn't possible in this headless sandbox beyond what the smoke suite exercises; the two new smoke tests directly assert the gate/upgrade-prompt visibility in a real rendered browser page, per B-2's acceptance criterion ("gates verified in browser for both a free and a pro state").

## Backlog

Moved B-2 to Done in `BACKLOG.md` with today's date.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DL1D2vdzqrZQuWABx3g68i)_