### PR TITLE
[nightly] B-4: Founding Member backfill + account badge

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,13 +30,6 @@ Stripe account, price ID, and deploys the function — the PR delivers code +
 step-by-step setup doc. **Blocked on:** Stripe account decisions. Human review
 mandatory (money).
 
-### B-4 · Founding Member backfill + badge
-Idempotent SQL inserting all existing users into `subscriptions` as founding
-members (per the grandfathering decision), plus a "Founding Member" badge in the
-account UI. `useEntitlement().isFoundingMember` already exists. ⚠ requires SQL
-run. **Note:** run the backfill only right before Pro gates go live (B-1/B-2),
-so signups until then are included.
-
 ### B-5 · Fix the remaining pre-existing tsc errors, then add tsc to verify
 `npx tsc --noEmit` currently fails in: `UserMenu.tsx` (`icon_url` on `never`),
 `AddToPlaybookModal.tsx` (null `user`), `SavePlayModal.tsx` (missing `playName`),
@@ -112,6 +105,18 @@ focused.
 
 ## Done
 
+- **2026-07-08 · B-4: Founding Member backfill + badge** — `supabase/
+  founding_member_backfill.sql` re-runs the idempotent grandfathering `INSERT`
+  from `subscriptions.sql` to catch users who signed up between that original
+  backfill and now (free-tier gates are live, so anyone missed it defaults to
+  'free' and loses the grandfathering promise). ⚠ requires SQL run. Added a
+  "Founding Member" badge next to the `/account` page header. **Note:** the
+  badge reads `subscriptions.plan` directly with the `user` this component
+  already resolved, rather than via `useEntitlement()` — that hook makes its
+  own `supabase.auth.getUser()` call, and running it concurrently with
+  `AccountSettings`'s own `getUser()` effect deadlocks gotrue-js's internal
+  session lock (reproduced: page hangs on "Loading..." forever). Extended
+  `tests/smoke/` to cover both the founding-member and free-plan badge states.
 - **2026-07-05 · B-2: UI export gates (Pro features)** — Playbook PDF export
   (all formats: `ExportModal`'s detailed/grid layouts and `PlaybooksPage`'s
   simple/detailed/grid playbook export, which all print multiple plays) now

--- a/src/components/auth/AccountSettings.tsx
+++ b/src/components/auth/AccountSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import type { User } from '@supabase/supabase-js';
-import { User as UserIcon, Lock, AlertTriangle, Calendar, Trash2, Upload, Image, Save } from 'lucide-react';
+import { User as UserIcon, Lock, AlertTriangle, Calendar, Trash2, Upload, Image, Save, Trophy } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { ImageCropModal } from './ImageCropModal';
@@ -8,6 +8,7 @@ import { getSafeErrorMessage } from '../../lib/errors';
 import { supabase } from '../../lib/supabase';
 
 export default function AccountSettings() {
+  const [isFoundingMember, setIsFoundingMember] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -43,6 +44,17 @@ export default function AccountSettings() {
       setUser(currentUser);
       const initialUsername = currentUser.user_metadata?.username || '';
       setUsername(initialUsername);
+
+      // Reads the subscriptions row directly rather than via useEntitlement():
+      // that hook makes its own supabase.auth.getUser() call, and running it
+      // concurrently with this effect's getUser() call deadlocks gotrue-js's
+      // internal session lock.
+      const { data: sub } = await supabase
+        .from('subscriptions')
+        .select('plan')
+        .eq('user_id', currentUser.id)
+        .maybeSingle();
+      setIsFoundingMember(sub?.plan === 'founding');
 
       // Fetch user's avatar preferences
       const { data: userRep } = await supabase
@@ -244,7 +256,15 @@ export default function AccountSettings() {
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-board-light rounded-xl shadow-lg border border-chalk/10 overflow-hidden">
           <div className="px-6 py-4 border-b border-chalk/10 flex justify-between items-center">
-            <h2 className="text-2xl font-bold text-chalk">Account Settings</h2>
+            <div className="flex items-center gap-3">
+              <h2 className="text-2xl font-bold text-chalk">Account Settings</h2>
+              {isFoundingMember && (
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/40 text-primary text-xs font-semibold">
+                  <Trophy className="h-3.5 w-3.5" />
+                  Founding Member
+                </span>
+              )}
+            </div>
             {hasChanges && (
               <button
                 onClick={handleSaveChanges}

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -20,6 +20,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `security_hardening.sql` | **verify applied** | Pins `search_path` on `is_admin()`/`is_pro()`; drops the unsafe `user_reputation` write policy; switches `image_reports` moderator policies to `is_admin()`. |
 | `community_authors.sql` | **verify applied** | `get_community_authors(uuid[])` for Community post author display. |
 | `free_tier_limits.sql` | **verify applied** | `BEFORE INSERT` triggers on `plays`/`playbooks` blocking free-plan users past `FREE_LIMITS` (15 plays / 2 playbooks). |
+| `founding_member_backfill.sql` | **needs running** | Re-runs the Founding Member grandfathering `INSERT` from `subscriptions.sql` to catch users who signed up between that original run and now (free-tier gates went live in the meantime). Idempotent — safe to run again. |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.

--- a/supabase/founding_member_backfill.sql
+++ b/supabase/founding_member_backfill.sql
@@ -1,0 +1,15 @@
+-- B-4: re-run the Founding Member grandfathering backfill.
+-- Run this once in the Supabase SQL Editor, right before free-tier gates
+-- (B-1/B-2) are relied on for enforcement.
+--
+-- subscriptions.sql already grandfathered every user that existed at the time
+-- IT was run. Anyone who signed up after that (but before this file runs) has
+-- no subscriptions row and defaults to 'free' -- incorrectly losing the
+-- grandfathering promise now that free-tier limits are live. This file is
+-- idempotent (ON CONFLICT DO NOTHING) and safe to run again: it only inserts
+-- users who still have no subscriptions row, so anyone who signed up after
+-- THIS runs is correctly left as a normal free user.
+
+INSERT INTO subscriptions (user_id, plan)
+SELECT id, 'founding' FROM auth.users
+ON CONFLICT (user_id) DO NOTHING;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -351,6 +351,9 @@ test('account settings page renders for a signed-in user (mocked backend)', asyn
   await page.route('**/rest/v1/avatar_icons**', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
   );
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'founding' }) }),
+  );
 
   await page.goto('/account');
 
@@ -359,7 +362,55 @@ test('account settings page renders for a signed-in user (mocked backend)', asyn
   // The username section is where the crash happened (icon next to the input)
   await expect(page.locator('#username')).toBeVisible();
   await expect(page.getByText('Delete Account').first()).toBeVisible();
+  // B-4: Founding Member badge (grandfathered subscriptions row)
+  await expect(page.getByText('Founding Member')).toBeVisible();
   expect(errors, errors.map((e) => e.message).join('\n')).toHaveLength(0);
+});
+
+test('account settings: free-plan user sees no Founding Member badge', async ({ page }) => {
+  const userJson = {
+    id: '22222222-2222-2222-2222-222222222222',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'freeuser@example.com',
+    app_metadata: {},
+    user_metadata: { username: 'freeuser' },
+    created_at: '2025-09-01T00:00:00Z',
+  };
+
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }),
+  );
+  await page.route('**/rest/v1/user_reputation**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ avatar_type: 'icon', avatar_url: null, avatar_icon_id: null }),
+    }),
+  );
+  await page.route('**/rest/v1/avatar_icons**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  // No subscriptions row for this user (free plan) -- PostgREST returns 200 + null for maybeSingle().
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }),
+  );
+
+  await page.goto('/account');
+
+  await expect(page.getByRole('heading', { name: 'Account Settings' })).toBeVisible();
+  await expect(page.getByText('Founding Member')).toHaveCount(0);
 });
 
 test('loads a saved defensive play via /designer?play= (mocked backend)', async ({ page }) => {


### PR DESCRIPTION
## ⚠ requires SQL run
This PR adds `supabase/founding_member_backfill.sql` — run it once in the Supabase SQL Editor.

`subscriptions.sql` already grandfathered every user that existed **at the time it was run**. The free-tier gates (B-1/B-2) have since shipped (2026-07-03 / 2026-07-05), so anyone who signed up between that original backfill and now has no `subscriptions` row and defaults to `'free'` — incorrectly losing the "existing users are grandfathered as Founding Members" promise. This file re-runs the same idempotent `INSERT ... ON CONFLICT DO NOTHING`, so it only affects users who still have no row; anyone who signs up after this runs is correctly left as a normal free user. `supabase/SCHEMA.md` updated with this migration.

## What changed
- **New migration:** `supabase/founding_member_backfill.sql` (idempotent, safe to run again).
- **Account UI:** a "Founding Member" badge next to the `/account` page header, for users whose `subscriptions.plan = 'founding'`.
- **Note on implementation:** the badge reads `subscriptions.plan` directly using the `user` `AccountSettings` already resolves in its own effect, rather than via the shared `useEntitlement()` hook. I initially wired it through `useEntitlement()` (matching `Pricing.tsx`/`ExportModal.tsx`/`PlaybooksPage.tsx`) but that hook makes its own independent `supabase.auth.getUser()` call — running it concurrently with `AccountSettings`'s own `getUser()` effect deadlocks gotrue-js's internal session lock (`_acquireLock`). Reproduced locally: the `/account` page hung on "Loading..." indefinitely with that wiring, and passed once switched to a direct query. `useEntitlement()` itself is unchanged — this is scoped to how `AccountSettings` sources the flag.

## Verify
- `npm install` — ok
- `npx tsc --noEmit` — no new errors in touched files (repo has 9 pre-existing errors in unrelated files per B-5, unchanged by this PR)
- `npm run build` — pass
- `npm run smoke` (Playwright, 12/12 pass):
  - all pre-existing tests pass unchanged
  - extended "account settings page renders for a signed-in user" to mock `subscriptions` (`plan: 'founding'`) and assert the badge is visible
  - added "account settings: free-plan user sees no Founding Member badge" (no `subscriptions` row → badge absent)
- **Note on this environment:** no `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` or `.env` file were present in this sandbox, so build/smoke were run against a local-only placeholder `.env` (not committed, matches `.env.example`) purely to exercise the app; this doesn't touch real credentials. Also had to point Playwright at the sandbox's pre-installed Chromium binary via a local (uncommitted) config override, since `npx playwright install` couldn't reach the download host from this environment — unrelated to the app itself.

## Backlog
Moved B-4 to Done in `BACKLOG.md` with today's date.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CUX1tHjQi6FkKp5A2XxQk5)_