### PR TITLE
[nightly] B-5: fix pre-existing tsc errors, add typecheck to verify

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,14 +30,6 @@ Stripe account, price ID, and deploys the function — the PR delivers code +
 step-by-step setup doc. **Blocked on:** Stripe account decisions. Human review
 mandatory (money).
 
-### B-5 · Fix the remaining pre-existing tsc errors, then add tsc to verify
-`npx tsc --noEmit` currently fails in: `UserMenu.tsx` (`icon_url` on `never`),
-`AddToPlaybookModal.tsx` (null `user`), `SavePlayModal.tsx` (missing `playName`),
-`AddToPlaybookButton.tsx` (Set iteration). (`AccountSettings.tsx`'s errors were
-fixed in the blank-page hotfix — one of them was crashing the page at runtime,
-proof these aren't cosmetic.) Fix all, then change the `verify` script to
-`tsc --noEmit && build && smoke`. **Acceptance:** `npx tsc --noEmit` exits 0.
-
 ### B-6 · Repair eslint (flat-config migration)
 `npm run lint` crashes: a config object uses `extends`, unsupported in eslint 9
 flat config. Migrate `eslint.config.js`, fix or explicitly disable surfaced
@@ -105,6 +97,21 @@ focused.
 
 ## Done
 
+- **2026-07-11 · B-5: Fix remaining pre-existing tsc errors, add typecheck to
+  verify** — `UserMenu.tsx`: the `avatar_icons` join result is now explicitly
+  typed (`{icon_url: string} | {icon_url: string}[] | null`) before the
+  array/object branch, since Supabase's select-string parser inferred the
+  non-array branch as `never` without a `Database` generic. `AddToPlaybookModal.tsx`:
+  `fetchPlaybooks` and `handleAddToPlaybook` now guard on `user` being non-null
+  at the top (both are only ever invoked once a signed-in `user` is present, so
+  no behavior change). `SavePlayModal.tsx`: both `metadata` initializations now
+  include `playName: ''` to satisfy `PlayMetadata` — it's immediately
+  overwritten by the caller (`PlayDesigner.handleSavePlay`) with the modal's own
+  `name` field, so this is a type-only fix. `AddToPlaybookButton.tsx`: replaced
+  `new Set([...prev, id])` (spreads a `Set`, needs `--downlevelIteration` under
+  the root `tsconfig.json`'s `es5` target) with `new Set(prev).add(id)`. Added
+  `npm run typecheck` (`tsc --noEmit`) and put it first in `verify`.
+  **Acceptance met:** `npx tsc --noEmit` exits 0.
 - **2026-07-08 · B-4: Founding Member backfill + badge** — `supabase/
   founding_member_backfill.sql` re-runs the idempotent grandfathering `INSERT`
   from `subscriptions.sql` to catch users who signed up between that original

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "smoke": "playwright test",
-    "verify": "npm run build && npm run smoke"
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run typecheck && npm run build && npm run smoke"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.0",

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -37,9 +37,13 @@ export function UserMenu({ user }: UserMenuProps) {
           setAvatarUrl(userRep.avatar_url);
         } else if (userRep.avatar_type === 'icon') {
           // avatar_icons may be returned as an array (joined rows) or an object depending on select
-          const iconUrl = Array.isArray(userRep.avatar_icons)
-            ? userRep.avatar_icons[0]?.icon_url
-            : userRep.avatar_icons?.icon_url;
+          const avatarIcons = userRep.avatar_icons as
+            | { icon_url: string }
+            | { icon_url: string }[]
+            | null;
+          const iconUrl = Array.isArray(avatarIcons)
+            ? avatarIcons[0]?.icon_url
+            : avatarIcons?.icon_url;
           if (iconUrl) setAvatarUrl(iconUrl);
         }
       }

--- a/src/components/designer/AddToPlaybookModal.tsx
+++ b/src/components/designer/AddToPlaybookModal.tsx
@@ -46,6 +46,7 @@ export const AddToPlaybookModal: React.FC<AddToPlaybookModalProps> = ({
   }, [isOpen, user]);
 
   const fetchPlaybooks = async () => {
+    if (!user) return;
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -64,7 +65,7 @@ export const AddToPlaybookModal: React.FC<AddToPlaybookModalProps> = ({
   };
 
   const handleAddToPlaybook = async () => {
-    if (!selectedPlaybook) return;
+    if (!selectedPlaybook || !user) return;
 
     try {
       setSaving(true);

--- a/src/components/designer/SavePlayModal.tsx
+++ b/src/components/designer/SavePlayModal.tsx
@@ -44,7 +44,8 @@ export function SavePlayModal({
     formation: '',
     difficulty: 'beginner',
     tags: [],
-    description: ''
+    description: '',
+    playName: ''
   });
 
   // Load playbooks when modal opens
@@ -98,7 +99,8 @@ export function SavePlayModal({
       formation: '',
       difficulty: 'beginner',
       tags: [],
-      description: ''
+      description: '',
+      playName: ''
     });
     setIsPublic(false);
     setSelectedPlaybook('');

--- a/src/components/plays/AddToPlaybookButton.tsx
+++ b/src/components/plays/AddToPlaybookButton.tsx
@@ -101,8 +101,8 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
       if (error) throw error;
 
       // Update local state
-      setPlayInPlaybooks(prev => new Set([...prev, playbookId]));
-      setJustAdded(prev => new Set([...prev, playbookId]));
+      setPlayInPlaybooks(prev => new Set(prev).add(playbookId));
+      setJustAdded(prev => new Set(prev).add(playbookId));
 
       // Call success callback
       onSuccess?.();


### PR DESCRIPTION
## What changed

Fixes the 6 pre-existing `npx tsc --noEmit` errors called out in BACKLOG.md's B-5, then wires typechecking into `verify`:

- **`src/components/auth/UserMenu.tsx`** — the Supabase-joined `avatar_icons` result is now explicitly typed as `{icon_url: string} | {icon_url: string}[] | null` before the array/object branch. Without a `Database` generic on the client, Supabase's select-string parser inferred the non-array branch as `never`, so `.icon_url` didn't type-check even though the runtime dual-shape handling (comment left in place) is real Postgrest behavior.
- **`src/components/designer/AddToPlaybookModal.tsx`** — `fetchPlaybooks` and `handleAddToPlaybook` now guard on `user` being non-null at the top of each function. No behavior change: both were already only reachable once a signed-in `user` was present (the effect only fires `fetchPlaybooks` when `user` is truthy, and the playbook-picker UI that triggers `handleAddToPlaybook` only renders once `fetchPlaybooks` has populated playbooks).
- **`src/components/designer/SavePlayModal.tsx`** — both `metadata` state initializations now include `playName: ''` to satisfy the `PlayMetadata` type. This is a type-only fix: the modal's own `name` field (from its separate `playName` local state) is what actually gets used — `PlayDesigner.handleSavePlay` immediately overwrites `metadata.playName` with `playData.name` after save.
- **`src/components/plays/AddToPlaybookButton.tsx`** — replaced `new Set([...prev, id])` with `new Set(prev).add(id)` in two spots. The former spreads a `Set`, which needs `--downlevelIteration` or an ES2015+ target; the root `tsconfig.json` (the one `tsc --noEmit` picks up, per CLAUDE.md's note that `vite build` doesn't type-check) targets `es5`.
- **`package.json`** — added `npm run typecheck` (`tsc --noEmit`) and put it first in `verify`, so `verify` is now `typecheck && build && smoke`.

Also moved B-5 to Done in `BACKLOG.md` with a summary of the above.

No schema changes — no SQL file, no SCHEMA.md update needed.

## Verification

- `npx tsc --noEmit` — **pass** (0 errors, previously 6 across 4 files).
- `npm run build` — **pass**.
- `npm run smoke` (Playwright, 12 tests) — **pass**, all 12 green. This environment had no `.env` / `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`, which the smoke suite needs to derive its mocked-session storage key (see `tests/smoke/designer.spec.ts`) — I created a local, gitignored `.env` with placeholder (non-real) Supabase values to run it; every test in the suite mocks its network calls via `page.route(...)`, so no real Supabase project is needed. That `.env` is not part of this PR (git-ignored, never committed). The pre-installed Chromium build in this sandbox (`chromium-1194`) didn't match this `@playwright/test` version's expected `chromium-headless-shell` revision (`1228`), so I ran the suite once with a temporary local config forcing `launchOptions.executablePath` at the full (non-headless-shell) Chromium binary — that config file was not committed either.
- `npm run lint` — not run; it's independently broken per BACKLOG.md B-6 (unrelated flat-config migration issue), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9YaWpsK93nZSgs7qZCMUv

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9YaWpsK93nZSgs7qZCMUv)_