### PR TITLE
[nightly] B-23: fix PlaybooksPage concurrent gotrue auth calls, add smoke coverage

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,21 +55,6 @@ agents skip.
 publish (never fabricate — house rule). Human collects quotes; agent then wires
 them in.
 
-### B-23 · Investigate PlaybooksPage dev-mode loading hang under Playwright
-Spun out of B-22's smoke-test work: `PlaybooksPage.tsx`'s `getSession()` +
-`onAuthStateChange` mount effect, combined with React 18 StrictMode's
-dev-mode double-invoke, can leave `loadPlaybooks()`'s awaited `.from()` query
-never settling when driven by a mocked/unreachable Supabase backend under
-`npm run dev` — reproduced consistently in a Playwright smoke test (page
-stuck on "Loading playbooks..." indefinitely, no network request ever
-observed, no error/rejection surfaced). Not reproduced with `PlaysPage.tsx`'s
-`getUser()`-based mount pattern. Unclear whether this can occur against a
-**real** Supabase backend (production doesn't run in StrictMode-affected dev
-mode) — needs investigation before ruling it out as dev/test-only. Until
-understood, B-22's PlaybooksPage usage-nudge banner has no automated smoke
-coverage (see the comment in `tests/smoke/designer.spec.ts` near the other
-B-22 tests).
-
 ### B-24 · Formation templates (11v11 gap #1 — the retention feature)
 From the 2026-07-17 "11v11 coach" product evaluation: the single biggest gap
 for tackle-football coaches is having to hand-place all 11 icons (including a
@@ -190,6 +175,31 @@ copy update goes through human review.
 
 ## Done
 
+- **2026-07-18 · B-23: Investigate + fix PlaybooksPage dev-mode loading hang**
+  — root-cause finding: `PlaybooksPage.tsx` resolved its user via its own
+  `getSession()` + `onAuthStateChange` mount effect **and** a separate
+  `useEntitlement()` call (which independently does its own `getUser()` +
+  `onAuthStateChange`) — two concurrent gotrue-js auth calls on mount, which
+  is the exact same class of client-side session-lock deadlock already
+  documented for `AccountSettings`/`PlaysPage`/`SavePlayModal` (the B-4 note
+  in `src/lib/entitlements.ts`), just not previously recognized as present
+  here too. Refactored `PlaybooksPage.tsx` to the same pattern those
+  components use: a single `getUser()` call on mount (no
+  `onAuthStateChange` subscription), with Pro status resolved by querying
+  `subscriptions` directly via `rowIsPro()` once `user` is set, instead of
+  `useEntitlement()`. **Caveat:** despite several repeated attempts —
+  including restoring the original `getSession()`/`useEntitlement()` code
+  verbatim and running the new regression test both in isolation and as
+  part of the full suite — the hang described when this item was filed did
+  not reproduce in this environment (current `@supabase/supabase-js`
+  `^2.56.0`/gotrue-js versions, Chromium via Playwright). It may have been
+  fixed upstream since B-22 was written, or is a rarer timing-dependent race
+  than a handful of local runs can surface. The fix ships anyway since it
+  eliminates a known-hazardous pattern this codebase already treats as a
+  real bug elsewhere, at no cost to behavior. Added the smoke test B-22
+  explicitly called out as blocked (`tests/smoke/designer.spec.ts`,
+  "PlaybooksPage (B-22/B-23)") — passes now, and (per the above) also
+  passed against the pre-fix code in this environment.
 - **2026-07-17 · B-22: Proactive free-tier limit warning** — free users used
   to learn they'd hit the 15-play/2-playbook cap only when the server
   rejected the save (PBP01/PBP02 → upgrade prompt). Added an early nudge:

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
-import { FREE_LIMITS, isNearFreeLimit, useEntitlement } from '../../lib/entitlements';
+import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { UsageWarningBanner } from '../UsageWarningBanner';
 import { getUserPreferences, paperPageSize, teamBrandHTML, type UserPreferences } from '../../lib/userPreferences';
@@ -60,22 +60,39 @@ export function PlaybooksPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
-  const { isPro, loading: entitlementLoading } = useEntitlement();
+  const [isPro, setIsPro] = useState(false);
+  const [entitlementLoading, setEntitlementLoading] = useState(true);
   const [newPlaybookName, setNewPlaybookName] = useState('');
   const [newPlaybookDescription, setNewPlaybookDescription] = useState('');
   const [createPlaybookError, setCreatePlaybookError] = useState<string | null>(null);
 
+  // Single getUser() call on mount (B-23) — this used to be getSession() +
+  // an onAuthStateChange subscription, plus a separate useEntitlement()
+  // call below (its own getUser() + onAuthStateChange). Those concurrent
+  // gotrue-js auth calls could deadlock gotrue's internal session lock —
+  // the same class of bug as the B-4 note in BACKLOG.md, reproduced
+  // consistently under React 18 StrictMode's dev-mode double-invoke. Now
+  // matches PlaysPage.tsx's single-getUser()-call pattern.
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setUser(session?.user ?? null);
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUser(user);
     });
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-    });
-
-    return () => subscription.unsubscribe();
   }, []);
+
+  // Pro status for the free-tier usage nudge (B-22) and export gating,
+  // queried directly off `subscriptions` instead of via useEntitlement() —
+  // see the mount effect's comment above.
+  useEffect(() => {
+    if (!user) { setIsPro(false); setEntitlementLoading(false); return; }
+    let cancelled = false;
+    supabase
+      .from('subscriptions')
+      .select('plan, current_period_end')
+      .eq('user_id', user.id)
+      .maybeSingle()
+      .then(({ data }) => { if (!cancelled) { setIsPro(rowIsPro(data)); setEntitlementLoading(false); } });
+    return () => { cancelled = true; };
+  }, [user]);
 
   // Team identity / export defaults (B-14/B-15), stamped onto playbook PDFs
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -766,10 +766,53 @@ test('PlaysPage (B-22): free user one play from the cap sees a usage nudge', asy
   await expect(page.getByText('14 of 15 free plays used.')).toBeVisible();
 });
 
-// Note: no automated smoke test for PlaybooksPage's usage banner (B-22). It
-// uses the same isNearFreeLimit()/UsageWarningBanner code path already
-// covered above for SavePlayModal and PlaysPage, but PlaybooksPage's
-// getSession() + onAuthStateChange mount pattern hits a pre-existing
-// React 18 StrictMode dev-mode quirk (loadPlaybooks()'s awaited query never
-// settles when driven by a mocked/unreachable Supabase backend) that's
-// unrelated to this change — see BACKLOG.md for the follow-up item.
+test('PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usage nudge', async ({ page }) => {
+  // Regression test for B-23: PlaybooksPage used to resolve its user via
+  // getSession() + onAuthStateChange *and* a separate useEntitlement() call
+  // (its own getUser() + onAuthStateChange) — two concurrent gotrue-js auth
+  // calls that could deadlock gotrue's internal session lock, hanging the
+  // page on "Loading playbooks..." forever. Both call sites now resolve the
+  // user once via a single getUser() call.
+  const userJson = {
+    id: '44444444-4444-4444-4444-444444444444',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'coach@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '2025-09-01T00:00:00Z',
+  };
+
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }),
+  );
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'free' }) }),
+  );
+  await page.route('**/rest/v1/user_preferences**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }),
+  );
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'pb-1', name: 'Home Playbook', description: '', created_at: '2025-09-01T00:00:00Z', user_id: userJson.id, playbook_plays: [] },
+      ]),
+    }),
+  );
+
+  await page.goto('/playbooks');
+  await expect(page.getByText('1 of 2 free playbooks used.')).toBeVisible();
+});


### PR DESCRIPTION
## What changed and why

B-23 asked us to investigate a dev-mode loading hang on `PlaybooksPage` (page stuck on "Loading playbooks..." forever under a mocked/unreachable Supabase backend in Playwright), and determine whether it's dev/test-only or a real risk.

**Root cause finding:** `PlaybooksPage.tsx` resolved its user via its own `getSession()` + `onAuthStateChange` mount effect **and** a separate `useEntitlement()` call (which independently does its own `getUser()` + `onAuthStateChange`). That's two concurrent gotrue-js auth calls firing on mount — the exact same class of client-side session-lock deadlock this codebase already documents and works around elsewhere (see the B-4 note in `src/lib/entitlements.ts`, and how `AccountSettings`/`PlaysPage`/`SavePlayModal` all avoid `useEntitlement()` in favor of a direct `subscriptions` query for exactly this reason). `PlaybooksPage` just hadn't been given the same treatment.

**Fix:** refactored `PlaybooksPage.tsx` to match the established pattern — a single `getUser()` call on mount (no `onAuthStateChange` subscription), with Pro status resolved by querying `subscriptions` directly via `rowIsPro()` once `user` is set, instead of `useEntitlement()`.

**Honest caveat on reproduction:** despite several attempts — including restoring the original `getSession()`/`useEntitlement()` code verbatim and running the new regression test both in isolation and as part of the full smoke suite — I could not reproduce the hang described when B-23 was filed, in this environment (`@supabase/supabase-js ^2.56.0`, Chromium via Playwright). It may have been fixed upstream in a gotrue-js/supabase-js patch since B-22 was written, or it's a rarer timing-dependent race than a handful of local runs can surface. The fix ships anyway since it costs nothing and eliminates a pattern this codebase already treats as a real bug elsewhere.

This also unblocks the smoke coverage B-22 explicitly left out for `PlaybooksPage`'s usage-nudge banner (see the removed comment in `tests/smoke/designer.spec.ts`).

BACKLOG.md: moved B-23 to Done with the finding above.

## Verify output

- `npx tsc --noEmit` — pass, 0 errors
- `npm run lint` — pass, 0 errors (45 pre-existing warnings, all `no-explicit-any`/`exhaustive-deps`, none new)
- `npm run build` — pass
- `npm run smoke` (full suite, 20 tests) — **20/20 passed**, including the new `PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usage nudge` test

Note: this environment has no `.env` / `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` configured, so I created a local-only `.env` from `.env.example`'s placeholder values to run the build/dev server (the smoke suite mocks all Supabase network calls via Playwright route interception, so placeholder values are sufficient). Not committed — `.env` is git-ignored.

## Files changed
- `src/components/playbooks/PlaybooksPage.tsx` — auth/entitlement refactor
- `tests/smoke/designer.spec.ts` — new regression test, removes the stale "no coverage" comment
- `BACKLOG.md` — B-23 moved to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XbAURkbg3pHWya21T8zWjr)_