### PR TITLE
[nightly] B-24: formation-template picker in the Play Designer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,26 +55,6 @@ agents skip.
 publish (never fabricate — house rule). Human collects quotes; agent then wires
 them in.
 
-### B-24 · Formation templates (11v11 gap #1 — the retention feature)
-From the 2026-07-17 "11v11 coach" product evaluation: the single biggest gap
-for tackle-football coaches is having to hand-place all 11 icons (including a
-five-man O-line via the custom-icon builder) for **every play**. Ship a
-formation-template picker in the designer toolbar: choose e.g. "I-Formation"
-or "Shotgun Spread" and the icons stamp onto the canvas at the right spots,
-ready to adjust. Scope:
-- Curate starter templates per game format: 11v11 (I-Form, Shotgun, Spread,
-  Wing-T at minimum, squares for linemen), 7v7 and 5v5 flag sets (Trips,
-  Bunch, Twins). Store as normalized 0–1 coordinates matching
-  `canvas_data.playerIcons` — NOT the `formations` table's old Fabric.js
-  `template` JSON.
-- Placing a template = one undo entry (single `pushSnapshot()`).
-- "Save current layout as my formation" for user-defined templates can be a
-  fast follow; system templates first.
-- Note: `FormationSelector.tsx` is **dead code** from the abandoned Fabric.js
-  era (imports `fabric`, nothing imports it) — see B-26; its Shotgun/I-Form
-  layout data is a usable starting reference, but the component itself must
-  be rebuilt against the real `CanvasHandle` API.
-
 ### B-25 · Blocking-assignment notation (11v11 gap #2)
 Routes and defensive zones exist, but 11v11 is run-first and there's no way
 to notate blocking: run-game diagrams need block symbols (line ending in a
@@ -175,6 +155,30 @@ copy update goes through human review.
 
 ## Done
 
+- **2026-07-18 · B-24: Formation templates (11v11 gap #1)** — a "Formation"
+  button in the designer toolbar (offense only) opens a menu of curated
+  starting layouts for the play's game format and stamps the picked one's
+  icons onto the canvas as a single undo entry. New
+  `src/components/designer/formations.ts` holds 10 templates — 11v11
+  (I-Formation, Shotgun, Spread, Wing-T; five-man O-line rendered as black
+  squares) and 7v7/5v5 flag sets (Trips, Bunch, Twins; no O-line — flag has
+  no line of scrimmage blockers, so only a snapping "C") — authored in
+  `canvas_data.playerIcons`-compatible normalized 0–1 coordinates using the
+  same LOS math as `Canvas.tsx` (`yFromYards`/`FIELD_YARDS_ABOVE_LOS`, now
+  exported for reuse rather than duplicated). `Canvas.tsx` gained a new
+  `stampFormation()` method on `CanvasHandle` — `loadState()` replaces the
+  whole scene so it wasn't suitable for adding a formation on top of
+  in-progress work; `stampFormation` does one `pushSnapshot()` + appends
+  icons instead. New `FormationMenu.tsx` component (popover, reuses the
+  `PlayerStyleEditor` panel styling convention); `PlayDesigner.tsx` now
+  threads `currentPlayMetadata.gameType` down to the toolbar so the menu
+  offers the right set. `FormationSelector.tsx` (dead Fabric.js code, see
+  B-26) was left untouched — its Shotgun/I-Form data didn't carry over
+  directly (different coordinate scheme, no LOS concept), so the new
+  templates were authored fresh instead of ported. Not done (fast follow
+  per the original scope): "save current layout as my formation" for
+  user-defined templates. New smoke test stamps I-Formation, asserts 11
+  icons land in-bounds, and confirms one Undo press clears all of them.
 - **2026-07-18 · B-23: Investigate + fix PlaybooksPage dev-mode loading hang**
   — root-cause finding: `PlaybooksPage.tsx` resolved its user via its own
   `getSession()` + `onAuthStateChange` mount effect **and** a separate

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -67,7 +67,7 @@ export type PathItem = {
 
 export type IconShape = 'circle' | 'square' | 'triangle' | 'star';
 
-type PlayerIcon = {
+export type PlayerIcon = {
   x: number; // normalized 0–1
   y: number; // normalized 0–1
   letter: string;
@@ -77,6 +77,11 @@ type PlayerIcon = {
   isSquare?: boolean;
   shape?: IconShape;
 };
+
+// Formation templates (B-24) are authored relative to the line of scrimmage
+// rather than raw 0–1 coordinates, so exporting these lets formations.ts stay
+// in sync with the canvas's own LOS math instead of duplicating constants.
+export { FIELD_YARDS_ABOVE_LOS, FIELD_YARDS_BELOW_LOS, TOTAL_FIELD_YARDS };
 
 /** Resolve an icon's shape, honoring the pre-`shape` isSquare flag. */
 const iconShape = (icon: { shape?: IconShape; isSquare?: boolean }): IconShape =>
@@ -120,6 +125,9 @@ export type CanvasHandle = {
   clearRoutes: () => void;
   removeRouteForIcon: (iconIndex: number) => void;
   loadState: (data: { paths: PathItem[]; playerIcons: PlayerIcon[]; zones?: Zone[] }) => void;
+  /** Adds icons to the existing scene (unlike loadState, which replaces it)
+   *  as a single undo entry — used to stamp a formation template. */
+  stampFormation: (icons: PlayerIcon[]) => void;
   canUndo: () => boolean;
   canRedo: () => boolean;
   getPaths: () => PathItem[];
@@ -1003,6 +1011,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       clearRoutes: () => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex === undefined && p.points.length === 0)); },
       removeRouteForIcon: (iconIndex: number) => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex !== iconIndex)); },
       loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); },
+      stampFormation: (icons) => { pushSnapshot(); setPlayerIcons((prev) => [...prev, ...icons]); },
       canUndo: () => undoStack.length > 0 || waypointPoints.length > 0,
       canRedo: () => redoStack.length > 0 && waypointPoints.length === 0,
       getPaths: () => paths,

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet } from 'lucide-react';
 import { PlayerToolbar, players, defensivePlayers } from './PlayerToolbar';
-import type { DrawMode, IconShape } from './Canvas';
+import { FormationMenu } from './FormationMenu';
+import type { DrawMode, IconShape, PlayerIcon } from './Canvas';
+import type { PlayMetadata } from '../../types/play';
 
 export type PlayType = 'offense' | 'defense';
 
@@ -9,6 +11,8 @@ interface DesignerToolbarProps {
   playType: PlayType;
   onSetPlayType: (type: PlayType) => void;
   playTypeLocked: boolean;
+  gameType: PlayMetadata['gameType'];
+  onStampFormation: (icons: PlayerIcon[]) => void;
   drawingMode: boolean;
   setDrawingMode: (mode: boolean) => void;
   drawMode: DrawMode;
@@ -35,6 +39,8 @@ export function DesignerToolbar({
   playType,
   onSetPlayType,
   playTypeLocked,
+  gameType,
+  onStampFormation,
   drawingMode,
   setDrawingMode,
   drawMode,
@@ -166,6 +172,13 @@ export function DesignerToolbar({
           <RouteOff className="h-4 w-4" />
           <span className="hidden sm:inline whitespace-nowrap">Remove Route</span>
         </button>
+
+        {!isDefense && (
+          <>
+            <div className="w-px h-5 bg-chalk/15 shrink-0 mx-0.5" />
+            <FormationMenu gameType={gameType} onStamp={onStampFormation} />
+          </>
+        )}
 
         {isDefense && (
           <>

--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Layout } from 'lucide-react';
+import { formationsFor } from './formations';
+import type { PlayerIcon } from './Canvas';
+import type { PlayMetadata } from '../../types/play';
+
+interface FormationMenuProps {
+  gameType: PlayMetadata['gameType'];
+  onStamp: (icons: PlayerIcon[]) => void;
+}
+
+export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
+  const [open, setOpen] = useState(false);
+  const templates = formationsFor(gameType);
+
+  const btnBase = 'flex items-center justify-center rounded-lg transition-colors shrink-0';
+  const inactive = 'text-chalk/60 hover:text-chalk hover:bg-white/10';
+  const active = 'bg-primary/20 text-primary';
+
+  return (
+    <div className="relative shrink-0">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="Formation templates"
+        className={`${btnBase} px-2.5 py-2 gap-1.5 text-xs font-medium ${open ? active : inactive}`}
+      >
+        <Layout className="h-4 w-4" />
+        <span className="hidden sm:inline whitespace-nowrap">Formation</span>
+      </button>
+
+      {open && (
+        <>
+          {/* Click-outside catcher */}
+          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          <div
+            className="absolute left-0 top-full mt-1 z-40 bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56"
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <p className="text-[10px] uppercase tracking-wide text-chalk/40 px-1.5 pb-1">
+              {gameType} formations
+            </p>
+            {templates.length === 0 ? (
+              <p className="text-xs text-chalk/50 px-1.5 py-1">No templates yet for this format.</p>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                {templates.map((t) => (
+                  <button
+                    key={t.id}
+                    onClick={() => {
+                      onStamp(t.icons);
+                      setOpen(false);
+                    }}
+                    className="text-left px-2 py-1.5 rounded-lg text-sm text-chalk hover:bg-primary/20 hover:text-primary transition-colors"
+                  >
+                    {t.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -7,7 +7,7 @@ import type { PlayType } from './DesignerToolbar';
 import { ExportModal } from './ExportModal';
 import { SavePlayModal } from './SavePlayModal';
 import { Canvas } from './Canvas';
-import type { DrawMode, IconShape } from './Canvas';
+import type { CanvasHandle, DrawMode, IconShape, PlayerIcon } from './Canvas';
 import { supabase } from '../../lib/supabase';
 import { PlayMetadata } from '../../types/play';
 import { getSafeErrorMessage } from '../../lib/errors';
@@ -19,7 +19,7 @@ export function PlayDesigner() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const canvasContainerRef = useRef<HTMLDivElement>(null);
-  const canvasRef = useRef<any>(null);
+  const canvasRef = useRef<CanvasHandle>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 600, height: 480 });
 
   const [drawingMode, setDrawingMode] = useState(false);
@@ -173,6 +173,10 @@ export function PlayDesigner() {
       }),
     };
     return () => { delete (window as any).__PBP_TEST__; };
+  }, []);
+
+  const handleStampFormation = useCallback((icons: PlayerIcon[]) => {
+    canvasRef.current?.stampFormation(icons);
   }, []);
 
   const handleNewPlay = useCallback(() => {
@@ -369,6 +373,8 @@ export function PlayDesigner() {
           playType={playType}
           onSetPlayType={setPlayType}
           playTypeLocked={playTypeLocked}
+          gameType={currentPlayMetadata.gameType}
+          onStampFormation={handleStampFormation}
           drawingMode={drawingMode}
           setDrawingMode={setDrawingMode}
           drawMode={drawMode}
@@ -425,6 +431,8 @@ export function PlayDesigner() {
           playType={playType}
           onSetPlayType={setPlayType}
           playTypeLocked={playTypeLocked}
+          gameType={currentPlayMetadata.gameType}
+          onStampFormation={handleStampFormation}
           drawingMode={drawingMode}
           setDrawingMode={setDrawingMode}
           drawMode={drawMode}

--- a/src/components/designer/formations.ts
+++ b/src/components/designer/formations.ts
@@ -1,0 +1,165 @@
+import type { PlayerIcon } from './Canvas';
+import { FIELD_YARDS_ABOVE_LOS, TOTAL_FIELD_YARDS } from './Canvas';
+import type { PlayMetadata } from '../../types/play';
+
+// Formation templates (B-24): curated starting positions coaches can stamp
+// onto the canvas instead of hand-placing every icon. Coordinates are
+// authored relative to the line of scrimmage using the same math Canvas.tsx
+// uses to render it (yFromYards), so a template lines up on the LOS exactly
+// like a hand-placed icon would.
+const yBehindLOS = (yardsBehindLOS: number) =>
+  (FIELD_YARDS_ABOVE_LOS + yardsBehindLOS) / TOTAL_FIELD_YARDS;
+
+const LOS = yBehindLOS(0);
+
+// Colors reuse the app's existing player-icon palette (PlayerToolbar.tsx /
+// PlayerStyleEditor.tsx's SWATCH_COLORS) so stamped icons look like ones a
+// coach placed by hand, not a separate visual language.
+const C = { QB: '#3B82F6', RB: '#10B981', FB: '#F59E0B', WR: '#8B5CF6', TE: '#EC4899', OL: '#000000', SLOT: '#6366F1' };
+
+const ol = (x: number, letter: string): PlayerIcon => ({ x, y: LOS, letter, color: C.OL, shape: 'square' });
+const wr = (x: number, letter: string, y = LOS, color = C.WR): PlayerIcon => ({ x, y, letter, color, shape: 'circle' });
+
+export type FormationTemplate = {
+  id: string;
+  name: string;
+  gameType: PlayMetadata['gameType'];
+  /** All curated templates are offensive alignments — see B-24 scope. */
+  playType: 'offense';
+  icons: PlayerIcon[];
+};
+
+// ---------------------------------------------
+// 11v11 (five-man line + six skill/backfield players)
+// ---------------------------------------------
+const line11 = [ol(0.30, 'LT'), ol(0.40, 'LG'), ol(0.50, 'C'), ol(0.60, 'RG'), ol(0.70, 'RT')];
+
+const FORMATIONS_11V11: FormationTemplate[] = [
+  {
+    id: '11v11-i-formation',
+    name: 'I-Formation',
+    gameType: '11v11',
+    playType: 'offense',
+    icons: [
+      ...line11,
+      wr(0.80, 'TE', LOS, C.TE),
+      wr(0.10, 'WR'),
+      wr(0.90, 'WR'),
+      { x: 0.50, y: yBehindLOS(1.5), letter: 'QB', color: C.QB, shape: 'circle' },
+      { x: 0.50, y: yBehindLOS(4), letter: 'FB', color: C.FB, shape: 'circle' },
+      { x: 0.50, y: yBehindLOS(7), letter: 'RB', color: C.RB, shape: 'circle' },
+    ],
+  },
+  {
+    id: '11v11-shotgun',
+    name: 'Shotgun',
+    gameType: '11v11',
+    playType: 'offense',
+    icons: [
+      ...line11,
+      wr(0.80, 'TE', LOS, C.TE),
+      wr(0.06, 'WR'),
+      wr(0.18, 'WR'),
+      wr(0.94, 'WR'),
+      { x: 0.50, y: yBehindLOS(5), letter: 'QB', color: C.QB, shape: 'circle' },
+      { x: 0.40, y: yBehindLOS(5), letter: 'RB', color: C.RB, shape: 'circle' },
+    ],
+  },
+  {
+    id: '11v11-spread',
+    name: 'Spread',
+    gameType: '11v11',
+    playType: 'offense',
+    icons: [
+      ...line11,
+      wr(0.06, 'WR'),
+      wr(0.20, 'WR'),
+      wr(0.80, 'WR'),
+      wr(0.94, 'WR'),
+      { x: 0.50, y: yBehindLOS(5), letter: 'QB', color: C.QB, shape: 'circle' },
+      { x: 0.40, y: yBehindLOS(5), letter: 'RB', color: C.RB, shape: 'circle' },
+    ],
+  },
+  {
+    id: '11v11-wing-t',
+    name: 'Wing-T',
+    gameType: '11v11',
+    playType: 'offense',
+    icons: [
+      ...line11,
+      wr(0.80, 'TE', LOS, C.TE),
+      { x: 0.86, y: yBehindLOS(1), letter: 'WR', color: C.SLOT, shape: 'circle' }, // wingback, tight off the LOS
+      wr(0.10, 'WR'),
+      { x: 0.50, y: yBehindLOS(1.5), letter: 'QB', color: C.QB, shape: 'circle' },
+      { x: 0.50, y: yBehindLOS(4), letter: 'FB', color: C.FB, shape: 'circle' },
+      { x: 0.42, y: yBehindLOS(4), letter: 'RB', color: C.RB, shape: 'circle' },
+    ],
+  },
+];
+
+// ---------------------------------------------
+// Flag formations (7v7 / 5v5): no offensive line — every player is
+// eligible, so a snapping "C" is the only square, and the rest are WRs.
+// ---------------------------------------------
+function flagFormation(
+  id: string,
+  name: string,
+  gameType: '5v5' | '7v7',
+  receivers: PlayerIcon[],
+  extras: PlayerIcon[] = [],
+): FormationTemplate {
+  return {
+    id,
+    name,
+    gameType,
+    playType: 'offense',
+    icons: [
+      ol(0.50, 'C'),
+      { x: 0.50, y: yBehindLOS(4), letter: 'QB', color: C.QB, shape: 'circle' },
+      ...receivers,
+      ...extras,
+    ],
+  };
+}
+
+const FORMATIONS_7V7: FormationTemplate[] = [
+  flagFormation('7v7-trips', 'Trips', '7v7', [
+    wr(0.10, 'WR1'), wr(0.25, 'WR2'),
+    wr(0.65, 'WR3'), wr(0.78, 'WR4'), wr(0.90, 'WR5'),
+  ]),
+  flagFormation('7v7-bunch', 'Bunch', '7v7', [
+    wr(0.15, 'WR1'),
+    wr(0.70, 'WR2'), { x: 0.75, y: yBehindLOS(0.5), letter: 'WR3', color: C.WR, shape: 'circle' }, wr(0.80, 'WR4'),
+  ], [
+    { x: 0.40, y: yBehindLOS(4), letter: 'RB', color: C.RB, shape: 'circle' },
+  ]),
+  flagFormation('7v7-twins', 'Twins', '7v7', [
+    wr(0.15, 'WR1'), wr(0.30, 'WR2'),
+    wr(0.70, 'WR3'), wr(0.85, 'WR4'),
+  ], [
+    { x: 0.50, y: yBehindLOS(6), letter: 'RB', color: C.RB, shape: 'circle' },
+  ]),
+];
+
+const FORMATIONS_5V5: FormationTemplate[] = [
+  flagFormation('5v5-trips', 'Trips', '5v5', [
+    wr(0.65, 'WR1'), wr(0.78, 'WR2'), wr(0.90, 'WR3'),
+  ]),
+  flagFormation('5v5-bunch', 'Bunch', '5v5', [
+    wr(0.68, 'WR1'), { x: 0.74, y: yBehindLOS(0.5), letter: 'WR2', color: C.WR, shape: 'circle' }, wr(0.80, 'WR3'),
+  ]),
+  flagFormation('5v5-twins', 'Twins', '5v5', [
+    wr(0.15, 'WR1'),
+    wr(0.75, 'WR2'), wr(0.88, 'WR3'),
+  ]),
+];
+
+export const FORMATION_TEMPLATES: FormationTemplate[] = [
+  ...FORMATIONS_11V11,
+  ...FORMATIONS_7V7,
+  ...FORMATIONS_5V5,
+];
+
+export function formationsFor(gameType: PlayMetadata['gameType']): FormationTemplate[] {
+  return FORMATION_TEMPLATES.filter((f) => f.gameType === gameType);
+}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -134,6 +134,30 @@ test('offense: place a player, draw a straight route, undo both', async ({ page 
   expect(state.playerIcons).toHaveLength(0);
 });
 
+test('formation templates (B-24): stamping I-Formation places 11 icons as one undo entry', async ({ page }) => {
+  await openDesigner(page);
+
+  // New play defaults to 11v11 (PlayDesigner.tsx currentPlayMetadata), so the
+  // Formation menu should offer the 11v11 templates.
+  await btn(page, 'Formation templates').click();
+  await page.getByRole('button', { name: 'I-Formation' }).click();
+
+  const state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(11);
+  expect(state.playerIcons.map((i) => i.letter)).toContain('QB');
+  // Stamped icons land within the field, not off-canvas.
+  for (const icon of state.playerIcons) {
+    expect(icon.x).toBeGreaterThan(0);
+    expect(icon.x).toBeLessThan(1);
+    expect(icon.y).toBeGreaterThan(0);
+    expect(icon.y).toBeLessThan(1);
+  }
+
+  // Stamping is a single undo entry, however many icons it added.
+  await btn(page, 'Undo').click();
+  expect((await canvasState(page)).playerIcons).toHaveLength(0);
+});
+
 test('defense: place a safety and drag a zone of responsibility', async ({ page }) => {
   await openDesigner(page);
 


### PR DESCRIPTION
## What changed

Adds a "Formation" menu to the Play Designer toolbar (offense only) that stamps a curated starting layout onto the canvas instead of the coach hand-placing every icon (including a five-man O-line via the custom-icon builder) for every play — the #1 gap identified in the 2026-07-17 11v11 coach product evaluation.

- **`src/components/designer/formations.ts`** (new): 10 curated templates — 11v11 (I-Formation, Shotgun, Spread, Wing-T; five-man O-line rendered as black squares) and 7v7/5v5 flag sets (Trips, Bunch, Twins; no O-line — flag has no line of scrimmage blockers, just a snapping "C"). Positions are authored in `canvas_data.playerIcons`-compatible normalized 0–1 coordinates, using the same LOS math as `Canvas.tsx` (`yFromYards`/`FIELD_YARDS_ABOVE_LOS`, now exported from `Canvas.tsx` instead of being duplicated) so a stamped icon lines up exactly like a hand-placed one.
- **`Canvas.tsx`**: new `CanvasHandle.stampFormation(icons)` method — adds icons to the *existing* scene as a single `pushSnapshot()`/undo entry. The existing `loadState()` wasn't suitable since it replaces the whole scene rather than adding to it.
- **`FormationMenu.tsx`** (new): toolbar popover listing templates for the play's current game format, reusing the app's existing anchored-popover styling convention (`bg-board-light`/`border-chalk/20`/`rounded-xl` from `PlayerStyleEditor.tsx`). Only rendered for offense — all curated templates are offensive alignments.
- **`DesignerToolbar.tsx` / `PlayDesigner.tsx`**: thread `currentPlayMetadata.gameType` down to the toolbar so the Formation menu offers the right template set, and wire the stamp action through `canvasRef`. `canvasRef` is now typed as `CanvasHandle` instead of `any`.

**Not in scope** (per the backlog item's own scope note, fast follow): "save current layout as my formation" for user-defined templates — system templates only, this round.

**Note on `FormationSelector.tsx`** (the dead Fabric.js-era component, see B-26): its salvageable Shotgun/I-Form layout data used a different coordinate scheme with no LOS concept, so it didn't port over directly — the new templates were authored fresh against the real `Canvas.tsx` coordinate system instead. That file is untouched by this PR; B-26 (delete it) is still open.

## Verify

- `npx tsc --noEmit` — pass, no errors.
- `npm run build` — pass.
- `npm run lint` — pass, 0 errors (47 pre-existing warnings, none new).
- `npm run smoke` (Playwright) — **21/21 passed**, including a new test ("formation templates (B-24): stamping I-Formation places 11 icons as one undo entry") that stamps the 11v11 I-Formation template, asserts all 11 icons land in-bounds and include a `QB`, and confirms a single Undo press clears all of them.
- ⚠ This sandbox has no `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` and no `.env`. I used a placeholder `.env` (`https://your-project.supabase.co` + a dummy anon key, from the repo's own `.env.example`) purely to boot the dev server for the smoke run — no real Supabase project was involved, and nothing here touches auth or DB calls, so this doesn't affect confidence in the result. `.env` was not committed. Similarly, `npx playwright install` couldn't reach the Playwright CDN in this sandbox (network policy), so the run used this environment's pre-installed Chromium at `/opt/pw-browsers/chromium` via a temporary local-only `playwright.config.ts` edit that was reverted before committing — the committed `playwright.config.ts` is unchanged.

No SQL/migrations, no Stripe/billing/auth code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWQSLoKSTmAqR6jMER9NjK)_