### PR TITLE
[nightly] B-24 fix: Formation menu popover invisibly clipped by toolbar scroll row

### DIFF
--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Layout } from 'lucide-react';
 import { formationsFor } from './formations';
 import type { PlayerIcon } from './Canvas';
@@ -11,7 +12,34 @@ interface FormationMenuProps {
 
 export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
   const [open, setOpen] = useState(false);
+  // Position is computed from the trigger button's real screen location and
+  // the popover is portaled to <body> as position:fixed — the toolbar row it
+  // lives in scrolls horizontally (`overflow-x-auto`), which per the CSS
+  // overflow spec forces overflow-y to `auto` too, so an `absolute`-positioned
+  // popover nested inside that row gets silently clipped out of view instead
+  // of showing (still clickable via automation, just invisible to a real
+  // user — see B-24 follow-up).
+  const [coords, setCoords] = useState<{ left: number; top: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const templates = formationsFor(gameType);
+
+  useEffect(() => {
+    if (!open) return;
+    const updatePosition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setCoords({ left: rect.left, top: rect.bottom + 4 });
+    };
+    updatePosition();
+    // The toolbar can scroll/resize (horizontal scroll row, mobile rotation);
+    // close instead of leaving the popover pinned to a stale position.
+    const close = () => setOpen(false);
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', close, true);
+    return () => {
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [open]);
 
   const btnBase = 'flex items-center justify-center rounded-lg transition-colors shrink-0';
   const inactive = 'text-chalk/60 hover:text-chalk hover:bg-white/10';
@@ -20,6 +48,7 @@ export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
   return (
     <div className="relative shrink-0">
       <button
+        ref={triggerRef}
         onClick={() => setOpen((o) => !o)}
         title="Formation templates"
         className={`${btnBase} px-2.5 py-2 gap-1.5 text-xs font-medium ${open ? active : inactive}`}
@@ -28,12 +57,13 @@ export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
         <span className="hidden sm:inline whitespace-nowrap">Formation</span>
       </button>
 
-      {open && (
+      {open && coords && createPortal(
         <>
           {/* Click-outside catcher */}
           <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
           <div
-            className="absolute left-0 top-full mt-1 z-40 bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56"
+            className="fixed z-40 bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56"
+            style={{ left: coords.left, top: coords.top }}
             onPointerDown={(e) => e.stopPropagation()}
           >
             <p className="text-[10px] uppercase tracking-wide text-chalk/40 px-1.5 pb-1">
@@ -58,7 +88,8 @@ export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
               </div>
             )}
           </div>
-        </>
+        </>,
+        document.body,
       )}
     </div>
   );

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -140,7 +140,15 @@ test('formation templates (B-24): stamping I-Formation places 11 icons as one un
   // New play defaults to 11v11 (PlayDesigner.tsx currentPlayMetadata), so the
   // Formation menu should offer the 11v11 templates.
   await btn(page, 'Formation templates').click();
-  await page.getByRole('button', { name: 'I-Formation' }).click();
+  const menuItem = page.getByRole('button', { name: 'I-Formation' });
+  // A real click on the coordinates the item actually renders at, not
+  // Locator.click() — that auto-scrolls a clipped/off-screen target into
+  // view first, which would silently pass even if the popover were clipped
+  // out of sight by a scrollable toolbar ancestor (the exact bug this
+  // formation menu shipped with — see the FormationMenu.tsx portal comment).
+  const box = await menuItem.boundingBox();
+  expect(box, 'formation menu item should have a real, unclipped position').not.toBeNull();
+  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
 
   const state = await canvasState(page);
   expect(state.playerIcons).toHaveLength(11);


### PR DESCRIPTION
## Context

PR #16 (B-24 formation-template picker) was merged with a bug: clicking **Formation** in the Play Designer toolbar appeared to do nothing in production. This is a production regression fix for that — the buggy version is currently live on playbuilderpro.com.

## Root cause

The Formation popover was `position: absolute` inside the toolbar's `overflow-x-auto` row. Per the CSS overflow spec, setting `overflow-x` to anything other than `visible` forces `overflow-y` to compute as `auto` too — so the row was silently clipping the popover below its own (button-height) box. It was still in the DOM and technically clickable via automation (Playwright's `Locator.click()` auto-scrolls a target into view before clicking, which is why the original smoke test passed), but invisible and unreachable for a real user.

## Fix

- `FormationMenu.tsx`: the popover now portals to `document.body` via `createPortal`, positioned `position: fixed` from the trigger button's real `getBoundingClientRect()` — it can no longer be clipped by any toolbar ancestor. Closes on window resize/scroll so it can't get pinned to a stale position.
- `tests/smoke/designer.spec.ts`: hardened the B-24 smoke test to click the menu item's actual rendered screen coordinates via `page.mouse.click()` instead of `Locator.click()` — the latter's auto-scroll is exactly what let this bug ship undetected.

## Verify

- `npx tsc --noEmit` — pass.
- `npm run build` — pass.
- `npm run lint` — pass, 0 errors (47 pre-existing warnings, none new).
- `npm run smoke` — 21/21 passed.
- Manually reproduced and confirmed the fix in a real (non-Playwright-assisted) browser session: started the dev server, drove it with a raw script, confirmed the popover rendered outside the clipped toolbar row and that a synthetic mouse click at its exact on-screen coordinates (bypassing any auto-scroll assist) successfully stamped the formation. Screenshot taken during that session showed the menu rendering correctly.
- Same sandbox caveats as PR #16: no real Supabase credentials available here, so a placeholder `.env` (from `.env.example`) was used locally to boot the dev server for the smoke run (not committed), and Playwright's browser download was blocked by network policy so the sandbox's pre-installed Chromium was used via a local-only, reverted `playwright.config.ts` edit.

No SQL/migrations, no Stripe/billing/auth code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWQSLoKSTmAqR6jMER9NjK)_