### PR TITLE
[nightly] B-24 fix: 5v5/7v7 formats reachable, re-stamp replaces instead of layering

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -125,8 +125,9 @@ export type CanvasHandle = {
   clearRoutes: () => void;
   removeRouteForIcon: (iconIndex: number) => void;
   loadState: (data: { paths: PathItem[]; playerIcons: PlayerIcon[]; zones?: Zone[] }) => void;
-  /** Adds icons to the existing scene (unlike loadState, which replaces it)
-   *  as a single undo entry — used to stamp a formation template. */
+  /** Replaces the whole scene with a formation template's icons (paths and
+   *  zones are cleared too, since they'd otherwise reference stale icon
+   *  indices) as a single undo entry — used to stamp a formation template. */
   stampFormation: (icons: PlayerIcon[]) => void;
   canUndo: () => boolean;
   canRedo: () => boolean;
@@ -1011,7 +1012,22 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       clearRoutes: () => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex === undefined && p.points.length === 0)); },
       removeRouteForIcon: (iconIndex: number) => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex !== iconIndex)); },
       loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); },
-      stampFormation: (icons) => { pushSnapshot(); setPlayerIcons((prev) => [...prev, ...icons]); },
+      // Replaces the whole scene with the template (routes/zones would
+      // otherwise reference icon indices that no longer line up once a
+      // different formation is stamped over the old one) — same shape as
+      // clear(), just landing on the new icons instead of an empty canvas.
+      stampFormation: (icons) => {
+        pushSnapshot();
+        setPaths([]);
+        setPlayerIcons(icons);
+        setZones([]);
+        setSelectedZoneIndex(null);
+        setZoneDraft(null);
+        setEditingIconIndex(null);
+        setWaypointPoints([]);
+        setWaypointIconIndex(null);
+        setHoveredIconIndex(null);
+      },
       canUndo: () => undoStack.length > 0 || waypointPoints.length > 0,
       canRedo: () => redoStack.length > 0 && waypointPoints.length === 0,
       getPaths: () => paths,

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -12,6 +12,7 @@ interface DesignerToolbarProps {
   onSetPlayType: (type: PlayType) => void;
   playTypeLocked: boolean;
   gameType: PlayMetadata['gameType'];
+  onSetGameType: (gameType: PlayMetadata['gameType']) => void;
   onStampFormation: (icons: PlayerIcon[]) => void;
   drawingMode: boolean;
   setDrawingMode: (mode: boolean) => void;
@@ -40,6 +41,7 @@ export function DesignerToolbar({
   onSetPlayType,
   playTypeLocked,
   gameType,
+  onSetGameType,
   onStampFormation,
   drawingMode,
   setDrawingMode,
@@ -176,7 +178,7 @@ export function DesignerToolbar({
         {!isDefense && (
           <>
             <div className="w-px h-5 bg-chalk/15 shrink-0 mx-0.5" />
-            <FormationMenu gameType={gameType} onStamp={onStampFormation} />
+            <FormationMenu gameType={gameType} onSetGameType={onSetGameType} onStamp={onStampFormation} />
           </>
         )}
 

--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -5,12 +5,15 @@ import { formationsFor } from './formations';
 import type { PlayerIcon } from './Canvas';
 import type { PlayMetadata } from '../../types/play';
 
+const GAME_TYPES: PlayMetadata['gameType'][] = ['5v5', '7v7', '11v11'];
+
 interface FormationMenuProps {
   gameType: PlayMetadata['gameType'];
+  onSetGameType: (gameType: PlayMetadata['gameType']) => void;
   onStamp: (icons: PlayerIcon[]) => void;
 }
 
-export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
+export function FormationMenu({ gameType, onSetGameType, onStamp }: FormationMenuProps) {
   const [open, setOpen] = useState(false);
   // Position is computed from the trigger button's real screen location and
   // the popover is portaled to <body> as position:fixed — the toolbar row it
@@ -66,6 +69,22 @@ export function FormationMenu({ gameType, onStamp }: FormationMenuProps) {
             style={{ left: coords.left, top: coords.top }}
             onPointerDown={(e) => e.stopPropagation()}
           >
+            <p className="text-[10px] uppercase tracking-wide text-chalk/40 px-1.5 pb-1">
+              Game format
+            </p>
+            <div className="flex items-center rounded-md border border-chalk/15 overflow-hidden mb-2">
+              {GAME_TYPES.map((g) => (
+                <button
+                  key={g}
+                  onClick={() => onSetGameType(g)}
+                  className={`flex-1 px-2 py-1 text-[11px] font-medium transition-colors ${
+                    gameType === g ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
+                  }`}
+                >
+                  {g}
+                </button>
+              ))}
+            </div>
             <p className="text-[10px] uppercase tracking-wide text-chalk/40 px-1.5 pb-1">
               {gameType} formations
             </p>

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -179,6 +179,10 @@ export function PlayDesigner() {
     canvasRef.current?.stampFormation(icons);
   }, []);
 
+  const handleSetGameType = useCallback((gameType: PlayMetadata['gameType']) => {
+    setCurrentPlayMetadata((prev) => ({ ...prev, gameType }));
+  }, []);
+
   const handleNewPlay = useCallback(() => {
     canvasRef.current?.clear();
     setCurrentPlayMetadata((p) => ({ ...p, playName: 'New Play', formation: '', tags: [], description: '', situation: '', yardage: '' }));
@@ -374,6 +378,7 @@ export function PlayDesigner() {
           onSetPlayType={setPlayType}
           playTypeLocked={playTypeLocked}
           gameType={currentPlayMetadata.gameType}
+          onSetGameType={handleSetGameType}
           onStampFormation={handleStampFormation}
           drawingMode={drawingMode}
           setDrawingMode={setDrawingMode}
@@ -432,6 +437,7 @@ export function PlayDesigner() {
           onSetPlayType={setPlayType}
           playTypeLocked={playTypeLocked}
           gameType={currentPlayMetadata.gameType}
+          onSetGameType={handleSetGameType}
           onStampFormation={handleStampFormation}
           drawingMode={drawingMode}
           setDrawingMode={setDrawingMode}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -50,6 +50,20 @@ async function canvasPoint(page: Page, fx: number, fy: number) {
 // the one that exists at the test viewport size.
 const btn = (page: Page, title: string) => page.locator(`button[title="${title}"]:visible`);
 
+/**
+ * Clicks a locator at its actual on-screen coordinates, bypassing
+ * Locator.click()'s auto-scroll-into-view. Playwright's normal .click() will
+ * happily scroll a clipped/off-screen element into the viewport before
+ * clicking it — which would silently pass even if a real user could never
+ * see or reach that element (the exact bug the formation menu shipped with;
+ * see the FormationMenu.tsx portal comment).
+ */
+async function realClick(page: Page, locator: ReturnType<Page['getByRole']>) {
+  const box = await locator.boundingBox();
+  expect(box, 'element should have a real, unclipped position').not.toBeNull();
+  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+}
+
 test('home page renders without uncaught errors', async ({ page }) => {
   const errors: Error[] = [];
   page.on('pageerror', (err) => errors.push(err));
@@ -140,15 +154,7 @@ test('formation templates (B-24): stamping I-Formation places 11 icons as one un
   // New play defaults to 11v11 (PlayDesigner.tsx currentPlayMetadata), so the
   // Formation menu should offer the 11v11 templates.
   await btn(page, 'Formation templates').click();
-  const menuItem = page.getByRole('button', { name: 'I-Formation' });
-  // A real click on the coordinates the item actually renders at, not
-  // Locator.click() — that auto-scrolls a clipped/off-screen target into
-  // view first, which would silently pass even if the popover were clipped
-  // out of sight by a scrollable toolbar ancestor (the exact bug this
-  // formation menu shipped with — see the FormationMenu.tsx portal comment).
-  const box = await menuItem.boundingBox();
-  expect(box, 'formation menu item should have a real, unclipped position').not.toBeNull();
-  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await realClick(page, page.getByRole('button', { name: 'I-Formation' }));
 
   const state = await canvasState(page);
   expect(state.playerIcons).toHaveLength(11);
@@ -164,6 +170,66 @@ test('formation templates (B-24): stamping I-Formation places 11 icons as one un
   // Stamping is a single undo entry, however many icons it added.
   await btn(page, 'Undo').click();
   expect((await canvasState(page)).playerIcons).toHaveLength(0);
+});
+
+test('formation templates: game-format picker in the menu offers 5v5/7v7/11v11 sets', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Formation templates').click();
+  // Defaults to 11v11's four templates.
+  await expect(page.getByRole('button', { name: 'I-Formation' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Wing-T' })).toBeVisible();
+
+  await realClick(page, page.getByRole('button', { name: '7v7', exact: true }));
+  await expect(page.getByRole('button', { name: 'I-Formation' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Trips' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Bunch' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Twins' })).toBeVisible();
+
+  await realClick(page, page.getByRole('button', { name: '5v5', exact: true }));
+  await expect(page.getByRole('button', { name: 'Trips' })).toBeVisible();
+
+  await realClick(page, page.getByRole('button', { name: 'Trips' }));
+  const state = await canvasState(page);
+  // 5v5 Trips: snapper + QB + 3 receivers.
+  expect(state.playerIcons).toHaveLength(5);
+});
+
+test('formation templates: picking a second formation replaces the first instead of layering', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Formation templates').click();
+  await realClick(page, page.getByRole('button', { name: 'Shotgun' }));
+  expect((await canvasState(page)).playerIcons).toHaveLength(11);
+
+  // Draw a route off one of the Shotgun icons, so there's a path referencing
+  // an icon index too — it should be gone after the re-stamp, not left
+  // pointing at a different formation's icon.
+  const shotgunState = await canvasState(page);
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, shotgunState.playerIcons[0].x, shotgunState.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.3);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+  expect((await canvasState(page)).paths).toHaveLength(1);
+
+  await btn(page, 'Formation templates').click();
+  await realClick(page, page.getByRole('button', { name: 'Wing-T' }));
+
+  const state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(11);
+  expect(state.playerIcons.map((i) => i.letter)).toContain('QB');
+  // The old formation's route is gone, not layered under/over the new one.
+  expect(state.paths).toHaveLength(0);
+
+  // Still a single undo entry — one press returns all the way to the first
+  // formation plus its route, not a partial step through the re-stamp.
+  await btn(page, 'Undo').click();
+  const undone = await canvasState(page);
+  expect(undone.playerIcons).toHaveLength(11);
+  expect(undone.paths).toHaveLength(1);
 });
 
 test('defense: place a safety and drag a zone of responsibility', async ({ page }) => {


### PR DESCRIPTION
## Context

PR #17 (the Formation-menu clipping fix) was merged before this second commit reached the branch, so it never made it to `main`/production — same race as #16 → #17. This PR carries just that one commit, rebased onto current `main`.

## What changed

Two more issues reported against the Formation menu (on top of the clipping fix already live):

**1. 5v5/7v7 formations were unreachable.** They existed in `formations.ts` but the designer canvas had no live way to change game format while picking a formation — it was only settable from `SavePlayModal`'s metadata form, after finishing a play. Added a game-format segmented control (5v5 / 7v7 / 11v11) at the top of the Formation menu itself (`FormationMenu.tsx`), wired through `DesignerToolbar`/`PlayDesigner` to update `currentPlayMetadata.gameType` directly, so switching format and picking a template happens in one place.

**2. Picking a second formation layered its icons on top of whatever was already on the canvas instead of replacing it.** `CanvasHandle.stampFormation` (`Canvas.tsx`) now clears paths/icons/zones before placing the new template's icons — same shape as the existing `clear()` — still as a single `pushSnapshot()`, so one Undo press returns to exactly what was on the canvas before the re-stamp. Clearing paths/zones too (not just icons) avoids leaving routes pointing at stale icon indices from the discarded formation.

New smoke coverage: switching game format changes the offered templates and stamps the right roster size (5v5 Trips = 5 icons: snapper + QB + 3 receivers), and re-stamping a second formation over a first (with a route drawn off one of its icons) fully replaces rather than layers, with the whole thing still one undo step.

## Verify

- `npx tsc --noEmit` — pass.
- `npm run build` — pass.
- `npm run lint` — pass, 0 errors (47 pre-existing warnings, none new).
- `npm run smoke` — 23/23 passed (21 previous + 2 new for this change).
- Same sandbox caveats as prior PRs in this chain: no real Supabase credentials here, so a placeholder `.env` was used locally to boot the dev server for the smoke run (not committed), and the sandbox's pre-installed Chromium was used via a local-only, reverted `playwright.config.ts` edit (Playwright's browser download is blocked by network policy here).

No SQL/migrations, no Stripe/billing/auth code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWQSLoKSTmAqR6jMER9NjK)_