### PR TITLE
[nightly] B-25: block-assignment notation for run-game diagrams

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,16 +55,6 @@ agents skip.
 publish (never fabricate — house rule). Human collects quotes; agent then wires
 them in.
 
-### B-25 · Blocking-assignment notation (11v11 gap #2)
-Routes and defensive zones exist, but 11v11 is run-first and there's no way
-to notate blocking: run-game diagrams need block symbols (line ending in a
-perpendicular "T" at contact), pull paths for linemen, and ideally a
-double-team indicator. Scope: a "Block" draw mode alongside Straight/Route —
-same path drawing, different terminal decoration (T-cap instead of
-arrowhead); persists in `canvas_data.paths` via a `mode: 'block'` variant so
-old plays load unchanged; renders in both live canvas and `exportImage()`.
-Extend the smoke suite (draw block → assert path mode → undo).
-
 ### B-26 · Delete dead FormationSelector.tsx (Fabric.js remnant)
 `src/components/designer/FormationSelector.tsx` imports `fabric` /
 `fabric/fabric-impl`, is imported by nothing, and predates the pure-HTML-
@@ -154,6 +144,29 @@ copy + playbook + ordering, respecting the free-tier triggers). Pricing
 copy update goes through human review.
 
 ## Done
+
+- **2026-07-19 · B-25: Blocking-assignment notation (11v11 gap #2)** — a
+  "Block" draw mode alongside Straight/Route in `DesignerToolbar.tsx` (Shield
+  icon), reusing the same click-to-place-points flow as Straight (multi-segment
+  straight lines, so pull paths that bend around the formation work the same
+  way). `Canvas.tsx`'s `DrawMode` gained a third `'block'` value; a new
+  `drawBlockCap()` renders the run-blocking symbol — a short perpendicular bar
+  centered on the path's endpoint (the standard "T-cap") — in place of
+  `drawArrowhead()`, in both the live canvas (`renderScene`, in-progress
+  preview) and `exportImage()`, since both paths through the same
+  `renderScene()` function. Persists as `paths[].mode === 'block'` in
+  `canvas_data`, additive to the existing `'straight' | 'waypoint'` values, so
+  old saved plays load unchanged. Not done (fast follow per the original
+  scope): a double-team indicator — no obvious existing visual language to
+  extend for two blockers on one path, needs its own design pass. New smoke
+  test draws a block assignment, asserts `paths[0].mode === 'block'`, and
+  confirms undo clears it the same way a route does.
+  **Verification:** `npx tsc --noEmit` and `npm run lint` both pass clean (0
+  errors; lint warnings are all pre-existing). `npm run build` succeeds. The
+  Playwright smoke suite (including the new test) **could not run** in this
+  environment — no `.env` file and no `VITE_SUPABASE_URL`/
+  `VITE_SUPABASE_ANON_KEY` in the shell, which `tests/smoke/designer.spec.ts`
+  requires at import time to derive the mocked-session auth storage key.
 
 - **2026-07-18 · B-24: Formation templates (11v11 gap #1)** — a "Formation"
   button in the designer toolbar (offense only) opens a menu of curated

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -57,7 +57,7 @@ export const EXPORT_HEIGHT = 1275;
 // ---------------------------------------------
 // Types
 // ---------------------------------------------
-export type DrawMode = 'straight' | 'waypoint';
+export type DrawMode = 'straight' | 'waypoint' | 'block';
 
 type Pt = { x: number; y: number }; // normalized 0–1
 
@@ -241,6 +241,46 @@ function drawArrowhead(ctx: CanvasRenderingContext2D, pts: Pt[], color: string, 
   ctx.lineTo(tip.x - ux * size + uy * (size * 0.45), tip.y - uy * size - ux * (size * 0.45));
   ctx.closePath();
   ctx.fill();
+  ctx.restore();
+}
+
+/**
+ * Block-notation terminal decoration (B-25): a short perpendicular bar
+ * centered on the path's tip — the standard run-blocking "T-cap" symbol,
+ * in place of an arrowhead. The line is drawn full-length right up to the
+ * tip (see the `useBlockCap` trim skip in renderScene) since the bar sits
+ * on the endpoint rather than tapering to it like an arrowhead does.
+ */
+function drawBlockCap(ctx: CanvasRenderingContext2D, pts: Pt[], color: string, size: number) {
+  if (pts.length < 2) return;
+  const tip = pts[pts.length - 1];
+  let from = pts[pts.length - 2];
+  for (let i = pts.length - 2; i >= Math.max(0, pts.length - 8); i--) {
+    const dx = tip.x - pts[i].x;
+    const dy = tip.y - pts[i].y;
+    if (Math.sqrt(dx * dx + dy * dy) > size * 0.4) {
+      from = pts[i];
+      break;
+    }
+  }
+  const dx = tip.x - from.x;
+  const dy = tip.y - from.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 0.5) return;
+  const ux = dx / len;
+  const uy = dy / len;
+  // Perpendicular unit vector
+  const px = -uy;
+  const py = ux;
+  const halfWidth = size * 0.6;
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = size * 0.28;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  ctx.moveTo(tip.x + px * halfWidth, tip.y + py * halfWidth);
+  ctx.lineTo(tip.x - px * halfWidth, tip.y - py * halfWidth);
+  ctx.stroke();
   ctx.restore();
 }
 
@@ -461,14 +501,20 @@ function renderScene(
   paths.forEach((p, i) => {
     const pts = p.points.map(toPx);
     const isLast = p.startIconIndex !== undefined ? lastByIcon.get(p.startIconIndex) === i : true;
-    // Stop the stroked line short of the tip so it tucks behind the arrowhead
-    const stroked = isLast ? trimEnd(pts, arrowSize * 0.8) : pts;
-    if (p.mode === 'straight') {
-      strokeStraight(ctx, stroked, p.color, lineWidth);
-    } else {
+    const useBlockCap = p.mode === 'block';
+    // Stop the stroked line short of the tip so it tucks behind the
+    // arrowhead. Skipped for the block cap, which sits on the endpoint
+    // rather than tapering to it.
+    const stroked = isLast && !useBlockCap ? trimEnd(pts, arrowSize * 0.8) : pts;
+    if (p.mode === 'waypoint') {
       strokeRoute(ctx, stroked, p.color, lineWidth);
+    } else {
+      strokeStraight(ctx, stroked, p.color, lineWidth);
     }
-    if (isLast) drawArrowhead(ctx, pts, p.color, arrowSize);
+    if (isLast) {
+      if (useBlockCap) drawBlockCap(ctx, pts, p.color, arrowSize);
+      else drawArrowhead(ctx, pts, p.color, arrowSize);
+    }
   });
 
   // Player icons
@@ -818,8 +864,9 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       // In-progress route preview
       if (waypointPoints.length >= 1) {
         const pts = waypointPoints.map(toPx);
-        const stroked = pts.length >= 2 ? trimEnd(pts, ARROWHEAD_SIZE * scale * 0.8) : pts;
-        if (drawMode === 'straight') {
+        const isBlock = drawMode === 'block';
+        const stroked = pts.length >= 2 && !isBlock ? trimEnd(pts, ARROWHEAD_SIZE * scale * 0.8) : pts;
+        if (drawMode === 'straight' || isBlock) {
           strokeStraight(ctx, stroked, waypointColor, ROUTE_LINE_WIDTH * scale);
           pts.slice(1).forEach((pt) => {
             ctx.save();
@@ -832,7 +879,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         } else {
           strokeRoute(ctx, stroked, waypointColor, ROUTE_LINE_WIDTH * scale);
         }
-        if (pts.length >= 2) drawArrowhead(ctx, pts, waypointColor, ARROWHEAD_SIZE * scale);
+        if (pts.length >= 2) {
+          if (isBlock) drawBlockCap(ctx, pts, waypointColor, ARROWHEAD_SIZE * scale);
+          else drawArrowhead(ctx, pts, waypointColor, ARROWHEAD_SIZE * scale);
+        }
       }
 
       const ringRadius = (PLAYER_SIZE * scale) / 2;
@@ -1158,7 +1208,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       }
 
       // Straight + Waypoint modes — click-to-add-segments flow
-      if (drawingMode && (drawMode === 'waypoint' || drawMode === 'straight')) {
+      if (drawingMode && (drawMode === 'waypoint' || drawMode === 'straight' || drawMode === 'block')) {
         const now = Date.now();
         const isDoubleTap = now - lastTapRef.current < 350;
         lastTapRef.current = now;
@@ -1497,7 +1547,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         )}
 
         {/* ── Action bar (bottom of canvas): Finish + Cancel ── */}
-        {drawingMode && (drawMode === 'waypoint' || drawMode === 'straight') && waypointPoints.length >= 1 && (
+        {drawingMode && (drawMode === 'waypoint' || drawMode === 'straight' || drawMode === 'block') && waypointPoints.length >= 1 && (
           <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10">
             {waypointPoints.length >= 2 && (
               <button

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet } from 'lucide-react';
+import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet, Shield } from 'lucide-react';
 import { PlayerToolbar, players, defensivePlayers } from './PlayerToolbar';
 import { FormationMenu } from './FormationMenu';
 import type { DrawMode, IconShape, PlayerIcon } from './Canvas';
@@ -177,6 +177,17 @@ export function DesignerToolbar({
           <span className={label}>Route</span>
         </button>
 
+        {/* Block (B-25): same click-to-place-points flow as Straight, but
+            ends in a perpendicular T-cap instead of an arrowhead. */}
+        <button
+          onClick={() => pickDraw('block')}
+          title="Block Assignment (tap points, double-tap to finish)"
+          className={`${tool} ${activeDraw === 'block' ? active : inactive}`}
+        >
+          <Shield className="h-4 w-4" />
+          <span className={label}>Block</span>
+        </button>
+
         {/* Remove Route for a player */}
         <button
           onClick={toggleDeleteRouteMode}
@@ -287,6 +298,7 @@ export function DesignerToolbar({
             {zoneMode && 'Zone mode'}
             {!deleteRouteMode && !deleteZoneMode && !zoneMode && activeDraw === 'straight' && 'Straight line mode'}
             {!deleteRouteMode && !deleteZoneMode && !zoneMode && activeDraw === 'waypoint' && 'Curved route mode'}
+            {!deleteRouteMode && !deleteZoneMode && !zoneMode && activeDraw === 'block' && 'Block assignment mode'}
           </span>
           <span>· See field for instructions</span>
         </p>

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -210,7 +210,7 @@ test('offense: draw a block assignment (B-25), path mode is "block", undo clears
   expect(state.playerIcons).toHaveLength(1);
 
   // Block mode uses the same click-to-place-points flow as Straight
-  await btn(page, 'Block Assignment').click();
+  await btn(page, 'Block Assignment (tap points, double-tap to finish)').click();
   const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
   await page.mouse.click(icon.x, icon.y);
   await page.waitForTimeout(TAP_GAP);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -199,6 +199,42 @@ test('offense: place a player, draw a straight route, undo both', async ({ page 
   expect(state.playerIcons).toHaveLength(0);
 });
 
+test('offense: draw a block assignment (B-25), path mode is "block", undo clears it', async ({ page }) => {
+  await openDesigner(page);
+
+  // Place a lineman
+  await btn(page, 'Player C').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(1);
+
+  // Block mode uses the same click-to-place-points flow as Straight
+  await btn(page, 'Block Assignment').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.3);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].mode).toBe('block');
+  expect(state.paths[0].startIconIndex).toBe(0);
+
+  // Undo removes the block path first, then the icon — same history
+  // behavior as a regular route.
+  await btn(page, 'Undo').click();
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(0);
+  expect(state.playerIcons).toHaveLength(1);
+
+  await btn(page, 'Undo').click();
+  state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(0);
+});
+
 test('formation templates (B-24): stamping I-Formation places 11 icons as one undo entry', async ({ page }) => {
   await openDesigner(page);
 


### PR DESCRIPTION
## What changed and why

BACKLOG item B-25: 11v11 is run-first, and there was no way to notate blocking assignments on run-game diagrams — routes and defensive zones existed, but nothing for "who blocks whom."

- Added a **Block** draw mode alongside Straight/Route in `DesignerToolbar.tsx` (Shield icon). It reuses the exact click-to-place-points flow as Straight (multi-segment straight-line drawing), so pull paths that bend around the formation work the same way a regular route does.
- `Canvas.tsx`'s `DrawMode` gained a third `'block'` value alongside the existing `'straight' | 'waypoint'`.
- New `drawBlockCap()` renders the standard run-blocking symbol — a short perpendicular bar centered on the path's endpoint (a "T-cap") — in place of `drawArrowhead()`. Wired into both the live canvas (`renderScene()`, plus the in-progress draw preview) and `exportImage()`, since both render through the same `renderScene()` function, so on-screen and printed/exported plays stay identical.
- Persists as `paths[].mode === 'block'` in `canvas_data` — purely additive to the existing mode values, so previously saved plays load unchanged.
- **Not done** (flagged as a fast-follow in the original backlog scope): a double-team indicator. There's no obvious existing visual language in this canvas to extend for "two blockers, one assignment" — it needs its own design pass rather than a bolt-on.

No schema changes — `canvas_data` is opaque JSON, so no `supabase/*.sql` file or `SCHEMA.md` update needed.

## Verification

- ✅ `npx tsc --noEmit` — passes clean (0 errors).
- ✅ `npm run lint` — passes clean (0 errors, 47 warnings, all pre-existing — none new).
- ✅ `npm run build` — succeeds.
- ⚠️ **Playwright smoke suite could not run in this environment.** There is no `.env` file and no `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` in the shell environment. `tests/smoke/designer.spec.ts` reads `.env` directly at import time to derive the mocked-session auth storage key, so the whole suite fails to even load tests (`ENOENT: no such file or directory, open '.env'`). Separately, the app's own `src/lib/supabase.ts` throws at runtime when those env vars are missing (`Missing Supabase environment variables`), which also blocks any manual browser verification of the Designer — confirmed via a standalone Playwright script against a local dev server, which hit the same runtime error.
- A new smoke test **was added** (`offense: draw a block assignment (B-25), path mode is "block", undo clears it`) mirroring the existing Straight-route test — it draws a block path, asserts `paths[0].mode === 'block'`, and confirms undo clears the path first and then the icon. It just hasn't been able to run in this session.

Opening as a **draft** per the verification gap above — the smoke suite (existing + new test) needs to run with real Supabase credentials before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSsUBXwLA5ExFJthkg713t

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSsUBXwLA5ExFJthkg713t)_