### PR TITLE
Fix avatar overlapping the hero headline on mobile

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { Link } from 'react-router-dom';
-import { UserMenu } from './auth/UserMenu';
 import { HeroPlayCard } from './HeroPlayCard';
 import { supabase } from '../lib/supabase';
 
@@ -66,11 +65,6 @@ export function Hero() {
 
       <div className="max-w-7xl mx-auto">
         <div className="relative z-10 pb-8 bg-transparent sm:pb-16 md:pb-20 lg:pb-24 xl:pb-28">
-          <div className="absolute right-0 top-4 sm:hidden">
-            {user ? (
-              <UserMenu user={user} />
-            ) : null}
-          </div>
           <main className="mt-10 mx-auto max-w-7xl px-4 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-24">
             <div className="lg:grid lg:grid-cols-2 lg:gap-12 lg:items-center">
               <div className="text-center lg:text-left max-w-3xl mx-auto lg:mx-0 lg:max-w-none">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -42,6 +42,10 @@ export function Navbar() {
     { path: '/blog', label: 'Blog' }
   ];
 
+  // Deliberately no `position`/`z-index` here: the nav must stay a plain in-flow box so it
+  // doesn't form a stacking context. That lets UserMenu's `z-50` dropdown compete in the root
+  // context and paint above the Hero's `relative z-10`. Adding `relative z-50` here instead
+  // floats the whole bar over page content and swallows clicks on the designer toolbar.
   return (
     <nav className="bg-board-light border-b border-chalk/10">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -80,7 +84,8 @@ export function Navbar() {
               </button>
             )}
           </div>
-          <div className="flex items-center sm:hidden">
+          <div className="flex items-center gap-1 sm:hidden">
+            {user && <UserMenu user={user} showName={false} />}
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="inline-flex items-center justify-center p-2 rounded-md text-chalk/70 hover:text-chalk hover:bg-board-light focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
@@ -116,7 +121,7 @@ export function Navbar() {
                 <>
                   <div className="px-4 py-2 text-sm text-chalk/70">
                     Signed in as<br />
-                    <span className="font-medium text-chalk">{user.email}</span>
+                    <span className="font-medium text-chalk break-all">{user.email}</span>
                   </div>
                   <button
                     onClick={() => {

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -7,9 +7,11 @@ import { checkIsAdmin } from '../../lib/admin';
 
 interface UserMenuProps {
   user: SupabaseUser;
+  /** Hide the username label — used in the cramped mobile navbar row. */
+  showName?: boolean;
 }
 
-export function UserMenu({ user }: UserMenuProps) {
+export function UserMenu({ user, showName = true }: UserMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -147,6 +149,7 @@ export function UserMenu({ user }: UserMenuProps) {
     >
       <button
         onClick={() => isMobile && setIsOpen(!isOpen)}
+        aria-label={showName ? undefined : displayName}
         className="flex items-center gap-2 px-3 py-2 rounded-md text-chalk hover:bg-board transition-colors"
       >
         <div className="h-8 w-8 rounded-full bg-primary/20 flex items-center justify-center overflow-hidden">
@@ -160,14 +163,16 @@ export function UserMenu({ user }: UserMenuProps) {
             <User className="h-5 w-5 text-primary" />
           )}
         </div>
-        <span className="text-sm font-medium">
-          {displayName}
-          {isAdmin && (
-            <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/20 text-primary">
-              Admin
-            </span>
-          )}
-        </span>
+        {showName && (
+          <span className="text-sm font-medium">
+            {displayName}
+            {isAdmin && (
+              <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/20 text-primary">
+                Admin
+              </span>
+            )}
+          </span>
+        )}
       </button>
 
       {isOpen && (
@@ -178,7 +183,8 @@ export function UserMenu({ user }: UserMenuProps) {
         >
           <div className="px-4 py-2 text-sm text-chalk/70 border-b border-chalk/10">
             Signed in as<br />
-            <span className="font-medium text-chalk">{user.email}</span>
+            {/* break-all: long addresses otherwise spill past the w-48 panel */}
+            <span className="font-medium text-chalk break-all">{user.email}</span>
           </div>
           
           {isAdmin && (


### PR DESCRIPTION
## Problem

On small screens the signed-in user's avatar sat directly on top of the homepage headline "Draw the play. / Run the play. / Win the day."

The Navbar was not the cause — it's a normal in-flow element. The culprit was a **second, mobile-only `UserMenu` rendered inside the Hero**:

```jsx
<div className="absolute right-0 top-4 sm:hidden">
  {user ? <UserMenu user={user} /> : null}
</div>
```

Absolutely positioned inside a wrapper with no top padding, so it occupied roughly y=16–64px while `<main>` starts at `mt-10` (40px). The centered, full-width `<h1>` ran straight under it, and a longer username widened the button leftward and made it worse.

Two related defects in the same block: no right gutter (`right-0` vs. the headline's `px-4`), and `UserMenu`'s `text-chalk` label — built for the dark navbar — was nearly invisible on the Hero's light `bg-chalk`.

## Fix

That block only existed to compensate for the Navbar hiding the avatar below `sm:`. Moved the avatar into the Navbar's mobile row instead, which fixes the overlap **site-wide** rather than just on the homepage and restores correct contrast.

- **`UserMenu.tsx`** — new `showName?: boolean` (default `true`) so the username label can be dropped in the cramped `h-16` mobile row, rather than duplicating the avatar fetch / realtime-subscription logic. Added an `aria-label` fallback so the icon-only button keeps an accessible name.
- **`Navbar.tsx`** — renders `<UserMenu showName={false} />` before the hamburger. Signed-out mobile is unchanged.
- **`Hero.tsx`** — removed the absolute block and the now-unused import. `user` is still used to branch the CTA buttons.
- **Both menus** — `break-all` on the "Signed in as" email, which previously spilled past the `w-48` dropdown panel (pre-existing, visible on desktop too).

### Note on z-index

An earlier pass added `relative z-50` to `<nav>` so the dropdown would beat the Hero's `relative z-10`. That was wrong and broke 7 smoke tests — it floated the whole navbar over page content and swallowed clicks on the designer toolbar. Since `<nav>` is `static` it forms no stacking context, so the dropdown's own `z-50` already competes in the root context and wins. The nav is now intentionally left position-less, with a comment recording why.

## Verification

- `npm run typecheck` — no errors in the touched files
- `npx eslint` on all three — 0 errors, 1 pre-existing `exhaustive-deps` warning
- `npm run build` ✅
- `npm run smoke` — **46/46 passed**
- Drove the real app in Playwright at 375px with a mocked session:
  - avatar box `y 8–56` (inside the navbar), `<h1>` starts at `y 105` — no overlap
  - `elementFromPoint` confirms the open dropdown is genuinely topmost over the hero
  - long email now wraps 20.5px **inside** the panel instead of past it
  - desktop 1280px unchanged, exactly one avatar, username still shown
  - signed-out mobile: no avatar, hamburger still shows Sign In

🤖 Generated with [Claude Code](https://claude.com/claude-code)