### PR TITLE
Restore analytics: fix GA gtag regression + add Cloudflare Web Analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ playbooks, and print/share them. Live at **playbuilderpro.com**.
   cookie consent banner (`ConsentBanner.tsx`); the measurement ID lives in that
   file. Declining means gtag.js never loads (asserted by smoke tests, and
   promised by the live Privacy Policy — don't make GA unconditional).
+  **Cloudflare Web Analytics is the opposite and that's intentional:** a static
+  tag in `index.html`, cookieless, *not* consent-gated, so it measures 100% of
+  visitors (GA only ever sees the share who accept). Don't "fix" it by moving it
+  behind the banner. Its site token is public, like the GA measurement ID.
+  ⚠ **In `analytics.ts`, gtag must push `arguments`, never a rest-param array** —
+  gtag.js only treats `[object Arguments]` entries as commands, so an array
+  silently discards every `config`/`event` and GA records nothing at all. That
+  exact regression zeroed analytics 2026-07-17 → 2026-08-04; the smoke suite now
+  asserts a real `config` command reached `dataLayer`, not just that the script
+  tag exists.
 
 ## Commands
 - `npm run dev` — local dev server

--- a/index.html
+++ b/index.html
@@ -38,5 +38,17 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <!-- Cloudflare Web Analytics — cookieless, so unlike GA it is NOT consent-gated and
+         loads for every visitor (including on /designer, where the banner is hidden).
+         This is deliberately a static tag, not a conditional import like analytics.ts:
+         there is no consent decision to wait for. The token is a public site token,
+         same as the GA measurement ID — not a secret.
+         Requires static.cloudflareinsights.com in script-src and cloudflareinsights.com
+         in connect-src (public/_headers), or it fails silently. -->
+    <script
+      type="module"
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "b57642dff5a44b7c942b23f56663faf5"}'
+    ></script>
   </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -6,7 +6,7 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-site
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://rsms.me; font-src 'self' https://rsms.me; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://rsms.me; font-src 'self' https://rsms.me; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 # Vite content-hashes every filename in /assets (index-<hash>.js), so a cached
 # copy is valid forever — a new deploy always ships new filenames.

--- a/src/components/legal/PrivacyPolicy.tsx
+++ b/src/components/legal/PrivacyPolicy.tsx
@@ -29,7 +29,7 @@ export function PrivacyPolicy() {
             <><strong className="text-chalk">Profile and team content.</strong> Optional profile pictures you upload or icons you select, and optional team settings such as a team name and logo used on your printed playbooks.</>,
             <><strong className="text-chalk">Content you create.</strong> Plays, playbooks, community posts, comments, votes, and feedback you submit. Content you mark public (public plays, community posts) is visible to other users along with your username and avatar.</>,
             <><strong className="text-chalk">Subscription information.</strong> If you upgrade to Pro, payment is processed by Stripe. Your card number never touches our servers. We store your subscription status and Stripe customer/subscription identifiers so we can provide Pro features.</>,
-            <><strong className="text-chalk">Usage data.</strong> We use Google Analytics 4, which sets cookies and collects information such as pages visited, approximate location, and device/browser type. See &ldquo;Cookies and analytics&rdquo; below.</>,
+            <><strong className="text-chalk">Usage data.</strong> We use Cloudflare Web Analytics, which is cookieless and records only aggregate page views, referrer, and general device type — it does not track you across sites or build a profile of you. If you accept our cookie banner, we additionally use Google Analytics 4, which sets cookies and collects information such as pages visited, approximate location, and device/browser type. See &ldquo;Cookies and analytics&rdquo; below.</>,
             <><strong className="text-chalk">Technical data.</strong> A session token stored in your browser&rsquo;s local storage keeps you signed in.</>,
           ]}
         />
@@ -62,11 +62,18 @@ export function PrivacyPolicy() {
 
       <LegalSection heading="Cookies and analytics">
         <p>
-          We use Google Analytics 4 to understand aggregate site usage, but only after you accept the cookie
-          consent banner shown on your first visit. It sets cookies and may collect your IP-derived approximate
-          location and device information. Declining means Google Analytics never loads and no analytics
-          cookies are set; you can change your mind at any time by clearing your browser&rsquo;s local storage
-          for this site, or opt out with the{' '}
+          <strong className="text-chalk">Cloudflare Web Analytics.</strong> We use Cloudflare Web Analytics on
+          every page to count visits. It is cookieless: it sets no cookies, writes nothing to your browser
+          storage, and does not use fingerprinting or any cross-site identifier. Because it cannot identify or
+          follow you, it runs without a consent prompt and there is nothing to opt out of. It reports only
+          aggregate figures such as page views, referring site, and broad device category.
+        </p>
+        <p>
+          <strong className="text-chalk">Google Analytics 4.</strong> We use GA4 to understand aggregate site
+          usage, but only after you accept the cookie consent banner shown on your first visit. It sets cookies
+          and may collect your IP-derived approximate location and device information. Declining means Google
+          Analytics never loads and no analytics cookies are set; you can change your mind at any time by
+          clearing your browser&rsquo;s local storage for this site, or opt out with the{' '}
           <a className="text-primary hover:underline" href="https://tools.google.com/dlpage/gaoptout" rel="noopener noreferrer" target="_blank">Google Analytics opt-out browser add-on</a>.
           Apart from analytics, we use browser storage only for essential functions such as keeping you signed in.
         </p>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,15 +17,28 @@ const CONSENT_STORAGE_KEY = 'pbp-analytics-consent';
 
 export type ConsentChoice = 'granted' | 'denied';
 
-/** The visitor's stored consent choice, or null if they haven't decided yet. */
+/**
+ * The visitor's stored consent choice, or null if they haven't decided yet.
+ * localStorage access throws outright where storage is blocked (Safari private mode,
+ * embedded contexts) — treat that as "undecided" rather than letting it take out the
+ * ConsentBanner effect that calls this.
+ */
 export function getStoredConsent(): ConsentChoice | null {
-  const value = localStorage.getItem(CONSENT_STORAGE_KEY);
-  return value === 'granted' || value === 'denied' ? value : null;
+  try {
+    const value = localStorage.getItem(CONSENT_STORAGE_KEY);
+    return value === 'granted' || value === 'denied' ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Persists the visitor's choice and loads GA immediately if they granted it. */
 export function storeConsent(choice: ConsentChoice): void {
-  localStorage.setItem(CONSENT_STORAGE_KEY, choice);
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, choice);
+  } catch {
+    // Storage blocked — honor the choice for this page view even if it can't persist.
+  }
   if (choice === 'granted') loadGoogleAnalytics();
 }
 
@@ -42,9 +55,14 @@ export function loadGoogleAnalytics(): void {
   document.head.appendChild(script);
 
   window.dataLayer = window.dataLayer || [];
-  window.gtag = function gtag(...args: unknown[]) {
-    window.dataLayer.push(args);
-  };
+  // Must push the `arguments` object, NOT a rest-param array. gtag.js only treats a
+  // dataLayer entry as a command (js/config/event) when it is [object Arguments]; a real
+  // Array is read as a data push and silently ignored. Using `...args` here meant no
+  // `config` ever registered, so GA recorded nothing at all — even for visitors who
+  // accepted consent. That regression zeroed analytics from 2026-07-17 until it was
+  // caught. Keep this as Google's canonical snippet.
+  // eslint-disable-next-line prefer-rest-params
+  window.gtag = function gtag() { window.dataLayer.push(arguments); };
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID);
 }

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -126,6 +126,27 @@ test('GA consent banner (B-19): accepting loads gtag.js and remembers the choice
   expect(await gaConfigCommandSent(page, 'G-LS75BRZG15')).toBe(true);
 });
 
+const cfBeaconPresent = (page: Page) =>
+  page.evaluate(() =>
+    Boolean(document.querySelector('script[src*="static.cloudflareinsights.com/beacon"]')));
+
+test('Cloudflare Web Analytics is cookieless, so it loads without consent', async ({ page }) => {
+  // The whole point of the CF beacon is that it is NOT consent-gated: it measures 100% of
+  // visitors, where GA only ever sees the share who accept. If someone moves it behind the
+  // banner "for consistency", this fails.
+  await page.goto('/');
+  expect(await cfBeaconPresent(page)).toBe(true);
+  expect(await gaScriptPresent(page)).toBe(false); // GA still waits for consent
+
+  await page.getByRole('button', { name: 'Decline' }).click();
+  expect(await cfBeaconPresent(page)).toBe(true);
+  expect(await gaScriptPresent(page)).toBe(false);
+
+  // ...and it must set no cookies, which is what exempts it from the consent prompt.
+  const cookies = await page.context().cookies();
+  expect(cookies.filter((c) => /cf|cloudflare/i.test(c.name))).toEqual([]);
+});
+
 test('GA consent banner is hidden on the full-screen Play Designer', async ({ page }) => {
   await openDesigner(page);
   await expect(page.getByText('We use Google Analytics', { exact: false })).toHaveCount(0);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -77,6 +77,25 @@ test('home page renders without uncaught errors', async ({ page }) => {
 const gaScriptPresent = (page: Page) =>
   page.evaluate(() => Boolean(document.querySelector('script[src*="googletagmanager.com/gtag/js"]')));
 
+/**
+ * Whether a usable GA `config` command actually reached dataLayer.
+ *
+ * The script tag existing is NOT enough: gtag.js only recognizes an entry as a command
+ * when it's an `arguments` object. A regression that pushed a plain Array instead left
+ * the tag loading normally while GA recorded nothing for three weeks, and the old
+ * script-tag-only assertion passed the whole time. Assert the shape, not the tag.
+ */
+const gaConfigCommandSent = (page: Page, measurementId: string) =>
+  page.evaluate((id) => {
+    const entries: unknown[] = (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? [];
+    return entries.some(
+      (e) =>
+        Object.prototype.toString.call(e) === '[object Arguments]' &&
+        (e as IArguments)[0] === 'config' &&
+        (e as IArguments)[1] === id,
+    );
+  }, measurementId);
+
 test('GA consent banner (B-19): declining hides it and blocks the GA script', async ({ page }) => {
   await page.goto('/');
   const banner = page.getByText('We use Google Analytics', { exact: false });
@@ -91,6 +110,7 @@ test('GA consent banner (B-19): declining hides it and blocks the GA script', as
   await page.reload();
   await expect(banner).not.toBeVisible();
   expect(await gaScriptPresent(page)).toBe(false);
+  expect(await gaConfigCommandSent(page, 'G-LS75BRZG15')).toBe(false);
 });
 
 test('GA consent banner (B-19): accepting loads gtag.js and remembers the choice', async ({ page }) => {
@@ -99,9 +119,11 @@ test('GA consent banner (B-19): accepting loads gtag.js and remembers the choice
   await expect(page.getByText('We use Google Analytics', { exact: false })).not.toBeVisible();
   expect(await page.evaluate(() => localStorage.getItem('pbp-analytics-consent'))).toBe('granted');
   expect(await gaScriptPresent(page)).toBe(true);
+  expect(await gaConfigCommandSent(page, 'G-LS75BRZG15')).toBe(true);
 
   await page.reload();
   expect(await gaScriptPresent(page)).toBe(true);
+  expect(await gaConfigCommandSent(page, 'G-LS75BRZG15')).toBe(true);
 });
 
 test('GA consent banner is hidden on the full-screen Play Designer', async ({ page }) => {


### PR DESCRIPTION
> **Now contains #26 as well.** #26 was merged into this branch rather than `main`, so this single PR carries both changes. Merging it deploys both.

## 1. GA has recorded nothing since 2026-07-17 (the outage)

Not low consent acceptance — visitors who clicked **Accept** also sent nothing.

`src/lib/analytics.ts` initialized gtag with a TypeScript rest parameter:

```ts
window.gtag = function gtag(...args: unknown[]) {
  window.dataLayer.push(args);      // a real Array
};
```

Google's snippet pushes the **`arguments` object**. gtag.js only treats a `dataLayer` entry as a *command* (`js` / `config` / `event`) when it is `[object Arguments]`; a genuine `Array` is read as a data push and ignored. With no `config`, GA never starts a session — no page_view, no events — even though gtag.js loads fine and the cookie is set.

Introduced in `544df5d` (Jul 16, *"B-19: add Google Analytics consent banner"*), which deleted `public/gtag-init.js` containing the correct `function gtag(){dataLayer.push(arguments);}`. Deployed Jul 16 → data flatlines Jul 17.

**Evidence** — two identical pages differing only in the shim, against live GA with the real ID:

| Shim | dataLayer entry types | `/g/collect` hits |
|---|---|---|
| before (`...args` array) | `[object Array]` | **0** |
| after (`arguments`) | `[object Arguments]` | **2** |

Also guards `localStorage` in `getStoredConsent()` / `storeConsent()`, which throws where storage access is blocked and would take out the `ConsentBanner` effect.

## 2. Cloudflare Web Analytics (cookieless, no consent gate)

GA can only ever measure the share who accept the banner. Cloudflare is cookieless — no cookies, no browser storage, no cross-site identifier — so it needs no consent prompt and runs for **every** visitor, including on `/designer` where the banner is hidden. It becomes the reliable traffic number; GA stays for the richer consented subset. Together they finally reveal your actual accept rate.

Static tag in `index.html` per Cloudflare's instructions — no consent decision to wait on, and it loads earlier than a React-side import. CSP updated in the same change (`script-src` += `static.cloudflareinsights.com`, `connect-src` += `cloudflareinsights.com`); without it the beacon fails silently, exactly how the GA bug hid for three weeks.

## 3. Guardrails

- **`tests/smoke/designer.spec.ts`** — the suite passed all three weeks because it only asserted the `<script>` tag existed. New `gaConfigCommandSent()` asserts an `[object Arguments]` `config` command for the real measurement ID actually reached `dataLayer`, and asserts its absence after Decline. New CF test asserts the beacon loads before any consent choice and still after Decline, that GA does not, and that no CF cookie is set.
- **`CLAUDE.md`** — records why the two analytics tools load differently (so the static tag isn't "fixed" behind the banner later) and the arguments-vs-array constraint.

## ⚠️ Needs review before merge

`src/components/legal/PrivacyPolicy.tsx` is **legal copy** — it now discloses both tools and explains why one is consent-gated and the other isn't. The old text was GA-only and would be factually wrong once Cloudflare ships. Per CLAUDE.md this needs human review, and **B-21 (attorney review) is still open**. Treat it as a draft.

## Verification

- `npm run typecheck` clean on touched files; `npx eslint` 0 errors
- `npm run build` ✅ — bundle emits `window.gtag=function(){window.dataLayer.push(arguments)}`; beacon + both CSP entries confirmed in `dist/`
- `npm run smoke` — **47/47** on the combined merged state
- **Regression test proven to bite:** restoring the old shim makes the new assertion fail; the fix makes it pass
- **Real-hit proof:** driving the built app, Accept → **1 request to `google-analytics.com/g/collect`**. Before: 0.
- CF beacon loads for real (`200 beacon.min.js`) and fires its `/cdn-cgi/rum` POST; sets zero cookies

**Post-deploy checks:** GA4 → Realtime should show users for the first time since Jul 17; Cloudflare dashboard within ~15 min; zero `Refused to load/connect` console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)