### PR TITLE
Add Cloudflare Web Analytics: cookieless, no consent gate, 100% coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ playbooks, and print/share them. Live at **playbuilderpro.com**.
   cookie consent banner (`ConsentBanner.tsx`); the measurement ID lives in that
   file. Declining means gtag.js never loads (asserted by smoke tests, and
   promised by the live Privacy Policy — don't make GA unconditional).
+  **Cloudflare Web Analytics is the opposite and that's intentional:** a static
+  tag in `index.html`, cookieless, *not* consent-gated, so it measures 100% of
+  visitors (GA only ever sees the share who accept). Don't "fix" it by moving it
+  behind the banner. Its site token is public, like the GA measurement ID.
+  ⚠ **In `analytics.ts`, gtag must push `arguments`, never a rest-param array** —
+  gtag.js only treats `[object Arguments]` entries as commands, so an array
+  silently discards every `config`/`event` and GA records nothing at all. That
+  exact regression zeroed analytics 2026-07-17 → 2026-08-04; the smoke suite now
+  asserts a real `config` command reached `dataLayer`, not just that the script
+  tag exists.
 
 ## Commands
 - `npm run dev` — local dev server

--- a/index.html
+++ b/index.html
@@ -38,5 +38,17 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <!-- Cloudflare Web Analytics — cookieless, so unlike GA it is NOT consent-gated and
+         loads for every visitor (including on /designer, where the banner is hidden).
+         This is deliberately a static tag, not a conditional import like analytics.ts:
+         there is no consent decision to wait for. The token is a public site token,
+         same as the GA measurement ID — not a secret.
+         Requires static.cloudflareinsights.com in script-src and cloudflareinsights.com
+         in connect-src (public/_headers), or it fails silently. -->
+    <script
+      type="module"
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "b57642dff5a44b7c942b23f56663faf5"}'
+    ></script>
   </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -6,7 +6,7 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-site
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://rsms.me; font-src 'self' https://rsms.me; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://rsms.me; font-src 'self' https://rsms.me; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 # Vite content-hashes every filename in /assets (index-<hash>.js), so a cached
 # copy is valid forever — a new deploy always ships new filenames.

--- a/src/components/legal/PrivacyPolicy.tsx
+++ b/src/components/legal/PrivacyPolicy.tsx
@@ -29,7 +29,7 @@ export function PrivacyPolicy() {
             <><strong className="text-chalk">Profile and team content.</strong> Optional profile pictures you upload or icons you select, and optional team settings such as a team name and logo used on your printed playbooks.</>,
             <><strong className="text-chalk">Content you create.</strong> Plays, playbooks, community posts, comments, votes, and feedback you submit. Content you mark public (public plays, community posts) is visible to other users along with your username and avatar.</>,
             <><strong className="text-chalk">Subscription information.</strong> If you upgrade to Pro, payment is processed by Stripe. Your card number never touches our servers. We store your subscription status and Stripe customer/subscription identifiers so we can provide Pro features.</>,
-            <><strong className="text-chalk">Usage data.</strong> We use Google Analytics 4, which sets cookies and collects information such as pages visited, approximate location, and device/browser type. See &ldquo;Cookies and analytics&rdquo; below.</>,
+            <><strong className="text-chalk">Usage data.</strong> We use Cloudflare Web Analytics, which is cookieless and records only aggregate page views, referrer, and general device type — it does not track you across sites or build a profile of you. If you accept our cookie banner, we additionally use Google Analytics 4, which sets cookies and collects information such as pages visited, approximate location, and device/browser type. See &ldquo;Cookies and analytics&rdquo; below.</>,
             <><strong className="text-chalk">Technical data.</strong> A session token stored in your browser&rsquo;s local storage keeps you signed in.</>,
           ]}
         />
@@ -62,11 +62,18 @@ export function PrivacyPolicy() {
 
       <LegalSection heading="Cookies and analytics">
         <p>
-          We use Google Analytics 4 to understand aggregate site usage, but only after you accept the cookie
-          consent banner shown on your first visit. It sets cookies and may collect your IP-derived approximate
-          location and device information. Declining means Google Analytics never loads and no analytics
-          cookies are set; you can change your mind at any time by clearing your browser&rsquo;s local storage
-          for this site, or opt out with the{' '}
+          <strong className="text-chalk">Cloudflare Web Analytics.</strong> We use Cloudflare Web Analytics on
+          every page to count visits. It is cookieless: it sets no cookies, writes nothing to your browser
+          storage, and does not use fingerprinting or any cross-site identifier. Because it cannot identify or
+          follow you, it runs without a consent prompt and there is nothing to opt out of. It reports only
+          aggregate figures such as page views, referring site, and broad device category.
+        </p>
+        <p>
+          <strong className="text-chalk">Google Analytics 4.</strong> We use GA4 to understand aggregate site
+          usage, but only after you accept the cookie consent banner shown on your first visit. It sets cookies
+          and may collect your IP-derived approximate location and device information. Declining means Google
+          Analytics never loads and no analytics cookies are set; you can change your mind at any time by
+          clearing your browser&rsquo;s local storage for this site, or opt out with the{' '}
           <a className="text-primary hover:underline" href="https://tools.google.com/dlpage/gaoptout" rel="noopener noreferrer" target="_blank">Google Analytics opt-out browser add-on</a>.
           Apart from analytics, we use browser storage only for essential functions such as keeping you signed in.
         </p>

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -126,6 +126,27 @@ test('GA consent banner (B-19): accepting loads gtag.js and remembers the choice
   expect(await gaConfigCommandSent(page, 'G-LS75BRZG15')).toBe(true);
 });
 
+const cfBeaconPresent = (page: Page) =>
+  page.evaluate(() =>
+    Boolean(document.querySelector('script[src*="static.cloudflareinsights.com/beacon"]')));
+
+test('Cloudflare Web Analytics is cookieless, so it loads without consent', async ({ page }) => {
+  // The whole point of the CF beacon is that it is NOT consent-gated: it measures 100% of
+  // visitors, where GA only ever sees the share who accept. If someone moves it behind the
+  // banner "for consistency", this fails.
+  await page.goto('/');
+  expect(await cfBeaconPresent(page)).toBe(true);
+  expect(await gaScriptPresent(page)).toBe(false); // GA still waits for consent
+
+  await page.getByRole('button', { name: 'Decline' }).click();
+  expect(await cfBeaconPresent(page)).toBe(true);
+  expect(await gaScriptPresent(page)).toBe(false);
+
+  // ...and it must set no cookies, which is what exempts it from the consent prompt.
+  const cookies = await page.context().cookies();
+  expect(cookies.filter((c) => /cf|cloudflare/i.test(c.name))).toEqual([]);
+});
+
 test('GA consent banner is hidden on the full-screen Play Designer', async ({ page }) => {
   await openDesigner(page);
   await expect(page.getByText('We use Google Analytics', { exact: false })).toHaveCount(0);


### PR DESCRIPTION
> **Stacked on #25** — base is `fix/ga-dataLayer-arguments-regression`. Merge #25 first; GitHub will retarget this to `main` automatically.

## Why

GA can only ever measure the share of visitors who accept the cookie banner. Cloudflare Web Analytics is **cookieless** — no cookies, no browser storage, no fingerprinting or cross-site identifier — so it needs no consent prompt and runs for **every** visitor, including on `/designer` where the banner is deliberately hidden.

Cloudflare becomes the reliable traffic number. GA stays for the richer, consented subset. Together they also tell you your actual accept rate for the first time.

## Changes

- **`index.html`** — the beacon, before `</body>` per Cloudflare's instructions. Deliberately a static tag rather than a conditional import like `analytics.ts`: there's no consent decision to wait for, and loading early covers sessions that never reach React. The site token is public, same class of value as the GA measurement ID.
- **`public/_headers`** — CSP: `script-src` += `static.cloudflareinsights.com`, `connect-src` += `cloudflareinsights.com`. **Without this the beacon fails silently** — precisely how the GA regression in #25 hid for three weeks.
- **`src/components/legal/PrivacyPolicy.tsx`** — discloses both tools and explains why one is consent-gated and the other isn't. The old copy was GA-only and would have been factually wrong once this shipped.
- **`CLAUDE.md`** — records why the two analytics tools load differently, so the static tag doesn't get "fixed" behind the banner later; also the arguments-vs-array gtag constraint.
- **`tests/smoke/designer.spec.ts`** — asserts the beacon loads before any consent choice and still after **Decline**, that GA does *not*, and that no CF cookie is set.

## ⚠️ Needs your review before merge

The Privacy Policy edit is **legal copy**. Per CLAUDE.md it needs human review, and **B-21 (attorney review) is still open**. I've drafted it to be accurate, but treat it as a draft for you and the attorney — not as done.

## Verification

- `npm run typecheck` clean on touched files; `npx eslint` 0 errors
- `npm run build` ✅ — beacon and both CSP entries confirmed present in `dist/`
- `npm run smoke` — **47/47** (46 + the new beacon test)
- Beacon loads for real from the running app: `200 static.cloudflareinsights.com/beacon.min.js`, and it fires its `/cdn-cgi/rum` POST
- Zero cookies set by it, which is what exempts it from the consent prompt

**Honest limit:** the RUM POST is CORS-rejected from `localhost:4517` because Cloudflare only accepts beacons from the registered origin. End-to-end delivery can only be confirmed after deploy — check the Cloudflare Web Analytics dashboard ~15 min later, and confirm zero `Refused to load/connect` errors in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)