### PR TITLE
⚠ requires SQL run — Founding Member grant for 2026-08-05 signups

### DIFF
--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -27,6 +27,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `football_avatars.sql` | **pending — needs SQL run** | Replaces the seeded Dicebear "bottts" robot avatar icons with 8 self-contained football-themed SVG data URIs (football, helmet, flag, whistle, goalpost, cleat, playbook, trophy). Repoints any user on an old icon to the new default first. |
 | `playbook_packs.sql` | applied (2026-08-03) | B-33 starter playbook packs: adds `playbooks.is_public`; public-read policies for public playbooks, their `playbook_plays` rows, and the plays inside them; `clone_playbook_pack(pack_playbook_id)` (Pro-gated, `SECURITY DEFINER`) clones a public playbook + its plays into the caller's own account. |
 | `feedback_triage.sql` | **pending — needs SQL run** | B-35 automated feedback triage: additive `triage_class`/`triage_state`/`triage_ref`/`triage_notes`/`triaged_at` columns on `feedback` + a partial index on untriaged rows. No RLS or existing-column changes. |
+| `founding_members_2026_08_05.sql` | **pending — needs SQL run** | One-off data grant: Founding Member (`plan='founding'`, `current_period_end=NULL`) for everyone who signed up on 2026-08-05, windowed in **America/New_York** not UTC. Step 1 is a dry-run SELECT to confirm the list before Step 2 writes. Upgrades only `free` rows; never touches an existing `pro`/`founding` row. No schema change. |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.

--- a/supabase/founding_members_2026_08_05.sql
+++ b/supabase/founding_members_2026_08_05.sql
@@ -1,0 +1,75 @@
+-- Grant Founding Member status (free Pro for life) to everyone who signed up
+-- on 2026-08-05.
+--
+-- Run manually in the Supabase SQL Editor. RUN STEP 1 FIRST and read the list —
+-- it is the only chance to catch a wrong date window before the grant.
+--
+-- Why this is enough: is_pro() (subscriptions.sql) returns true for
+--   plan IN ('founding','pro') AND (current_period_end IS NULL OR > now())
+-- It does NOT look at `status`. So a 'founding' row with a NULL
+-- current_period_end is exactly "full access, never expires". The Stripe
+-- webhook is also written to never downgrade a 'founding' row, so this
+-- survives the eventual live-billing switch (B-18).
+--
+-- TIMEZONE: "today" is interpreted as America/New_York, not UTC. This matters —
+-- a plain DATE '2026-08-05' comparison means UTC midnight, which would sweep in
+-- anyone who signed up after 8pm Eastern on 8/4. If you want UTC instead,
+-- replace 'America/New_York' with 'UTC' in all three steps below.
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- STEP 1 — DRY RUN. Run this alone first and confirm the list looks right.
+-- Changes nothing.
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+  u.id,
+  u.email,
+  u.created_at AT TIME ZONE 'America/New_York' AS signed_up_eastern,
+  u.created_at                                  AS signed_up_utc,
+  COALESCE(s.plan, '(no row — will be granted)') AS current_plan,
+  CASE
+    WHEN s.user_id IS NULL   THEN 'INSERT founding'
+    WHEN s.plan = 'free'     THEN 'UPGRADE free -> founding'
+    ELSE                          'SKIP — already ' || s.plan
+  END AS action
+FROM auth.users u
+LEFT JOIN subscriptions s ON s.user_id = u.id
+WHERE u.created_at >= TIMESTAMPTZ '2026-08-05 00:00:00 America/New_York'
+  AND u.created_at <  TIMESTAMPTZ '2026-08-06 00:00:00 America/New_York'
+ORDER BY u.created_at;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- STEP 2 — THE GRANT. Only run once Step 1 shows the users you expect.
+--
+-- Idempotent, and safe to re-run: it inserts a 'founding' row for today's
+-- signups that have none, and upgrades a row only when it is currently 'free'.
+-- An existing 'pro' or 'founding' row is left completely untouched — we must
+-- never convert a paying Stripe subscriber to 'founding', which would keep
+-- billing them while the webhook refuses to ever downgrade the row.
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO subscriptions (user_id, plan, current_period_end)
+SELECT u.id, 'founding', NULL
+FROM auth.users u
+WHERE u.created_at >= TIMESTAMPTZ '2026-08-05 00:00:00 America/New_York'
+  AND u.created_at <  TIMESTAMPTZ '2026-08-06 00:00:00 America/New_York'
+ON CONFLICT (user_id) DO UPDATE
+  SET plan               = 'founding',
+      current_period_end = NULL
+  WHERE subscriptions.plan = 'free';
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- STEP 3 — VERIFY. Every row should read founding / true.
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+  u.email,
+  u.created_at AT TIME ZONE 'America/New_York' AS signed_up_eastern,
+  s.plan,
+  s.current_period_end,
+  is_pro(u.id) AS has_full_access
+FROM auth.users u
+JOIN subscriptions s ON s.user_id = u.id
+WHERE u.created_at >= TIMESTAMPTZ '2026-08-05 00:00:00 America/New_York'
+  AND u.created_at <  TIMESTAMPTZ '2026-08-06 00:00:00 America/New_York'
+ORDER BY u.created_at;


### PR DESCRIPTION
Grants **free Pro for life** to everyone who signed up on **2026-08-05**.

**I have not run this.** Per the agent rules in `BACKLOG.md` migrations and data grants are executed manually in the Supabase SQL Editor, and this is entitlement/money-adjacent, so it wants your eyes first.

## Why one insert covers both halves of the ask

`is_pro()` checks `plan IN ('founding','pro') AND (current_period_end IS NULL OR > now())` — it ignores `status`. So a `founding` row with a NULL `current_period_end` *is* "full access, never expires". The Stripe webhook already refuses to downgrade a `founding` row, so this survives the live-billing switch (B-18).

## How to run it

Three steps in `supabase/founding_members_2026_08_05.sql`:

1. **Dry run** — a SELECT listing exactly who is in the window and what would happen to each (`INSERT founding` / `UPGRADE free -> founding` / `SKIP — already pro`). Changes nothing. **Read this before step 2** — it's the only chance to catch a wrong date window.
2. **The grant.**
3. **Verify** — shows `plan` and `is_pro()` per affected user.

## The timezone detail worth knowing about

The window uses explicit `TIMESTAMPTZ '... America/New_York'` literals rather than `DATE '2026-08-05'`. That's not cosmetic: a bare `DATE` is resolved against the **session** timezone, and the Supabase SQL Editor runs sessions in **UTC**.

Verified against a throwaway PostgreSQL 17 instance with fixtures on both boundaries. Under a UTC session:

| user (Eastern) | explicit tz | naive `DATE` |
|---|---|---|
| 2026-08-04 22:00 | not granted ✅ | **granted ❌** |
| 2026-08-05 00:05 | granted ✅ | granted ✅ |
| 2026-08-05 23:55 | granted ✅ | **missed ❌** |
| 2026-08-06 00:30 | not granted ✅ | not granted ✅ |

The naive form gets 2 of 7 wrong. The explicit form is correct under either session timezone.

**If you'd rather define "today" as UTC**, swap `America/New_York` → `UTC` in all three steps.

## Safety

- **Idempotent** — verified re-running the whole file is a no-op.
- **Never touches a paying subscriber.** Conflict handling upgrades a row only when it is currently `free`; an existing `pro`/`founding` row is skipped. Converting a paying Stripe subscriber to `founding` would keep billing them while the webhook refuses to ever downgrade the row. Verified: a seeded paying-pro user is skipped with `stripe_subscription_id` intact.
- **No schema change** — data only. `SCHEMA.md` updated to list it as pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)