### PR TITLE
⚠ requires SQL run — manage user entitlements from the Admin Dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,13 @@ take the topmost unblocked item there.
   `subscriptions.sql`, `security_hardening.sql`, `community_authors.sql`,
   `free_tier_limits.sql`, `user_preferences.sql`, `play_votes.sql`,
   `custom_formations.sql`, `blog_seo.sql`, `football_avatars.sql`,
-  `founding_member_backfill.sql`. When schema changes are needed, add a new
-  idempotent `.sql` file and tell the user to run it.
+  `founding_member_backfill.sql`, `admin_entitlements.sql`. When schema changes
+  are needed, add a new idempotent `.sql` file and tell the user to run it.
+- **Granting Pro / Founding Member is a UI action, not a SQL file.** Use the
+  Users tab of `/admin` (`admin_set_user_plan`, `admin_entitlements.sql`). Don't
+  write another one-off grant migration. Only `free`/`founding` are settable by
+  hand — `pro` belongs to the Stripe webhook, and rows with a
+  `stripe_subscription_id` are refused outright (`PBP06`).
 - **Admin** is tracked via the `admin_users` table + `is_admin()` function (NOT a
   column on auth.users). Add yourself with an INSERT into `admin_users`.
 - **Pro entitlement** is the `subscriptions` table + `is_pro()` function, same
@@ -83,8 +88,11 @@ take the topmost unblocked item there.
   custom errcode, not RLS `WITH CHECK` (a bare RLS failure surfaces as a generic
   42501 the client can't turn into a useful upgrade prompt). `PBP01` = play cap,
   `PBP02` = playbook cap (`free_tier_limits.sql`), `PBP03` = custom formations
-  are Pro-only (`custom_formations.sql`). `src/lib/errors.ts` passes these
-  through as user-safe messages; mirror that pattern for any new gate.
+  are Pro-only (`custom_formations.sql`), `PBP04`/`PBP05` = playbook pack clone
+  (`playbook_packs.sql`), `PBP06` = admin plan change rejected
+  (`admin_entitlements.sql`). `src/lib/errors.ts` passes these through as
+  user-safe messages; mirror that pattern for any new gate. **`PBP07` is the
+  next free code.**
 - All tables use **Row Level Security**. Mirror existing policy patterns.
 - **Edge Functions** live in `supabase/functions/` (`create-checkout-session`,
   `create-portal-session`, `stripe-webhook`, `sitemap`, `feedback-triage`) and

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -5,6 +5,7 @@ import { BlogManagement } from './BlogManagement';
 import { FeedbackManagement } from './FeedbackManagement';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { usePageMeta } from '../../lib/seo';
+import type { Plan } from '../../lib/entitlements';
 
 interface AdminUserRow {
   id: string;
@@ -12,7 +13,30 @@ interface AdminUserRow {
   username: string | null;
   created_at: string;
   is_admin_user: boolean;
+  plan: Plan;
+  current_period_end: string | null;
+  is_stripe_backed: boolean;
 }
+
+/** Plans an admin may set by hand. 'pro' is owned by the Stripe webhook and is
+ *  deliberately absent — `admin_set_user_plan` rejects it (PBP06). Comping
+ *  someone is what 'founding' is for. */
+const ASSIGNABLE_PLANS: { value: Plan; label: string }[] = [
+  { value: 'free', label: 'Free' },
+  { value: 'founding', label: 'Founding' },
+];
+
+const PLAN_BADGE: Record<Plan, string> = {
+  free: 'bg-chalk/10 text-chalk/70',
+  founding: 'bg-primary/15 text-primary',
+  pro: 'bg-primary/15 text-primary',
+};
+
+const PLAN_LABEL: Record<Plan, string> = {
+  free: 'Free',
+  founding: 'Founding',
+  pro: 'Pro (Stripe)',
+};
 
 export function AdminDashboard() {
   usePageMeta({ title: 'Admin', path: '/admin' });
@@ -20,6 +44,8 @@ export function AdminDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'users' | 'blog' | 'feedback' | 'moderation'>('users');
+  const [search, setSearch] = useState('');
+  const [savingPlanFor, setSavingPlanFor] = useState<string | null>(null);
 
   useEffect(() => {
     if (activeTab === 'users') {
@@ -57,6 +83,51 @@ export function AdminDashboard() {
       setError(getSafeErrorMessage(err, 'Failed to delete user'));
     }
   };
+
+  const handleSetPlan = async (user: AdminUserRow, newPlan: Plan) => {
+    if (newPlan === user.plan) return;
+
+    // Only confirm on the destructive direction; granting access is cheap to undo.
+    if (
+      newPlan === 'free' &&
+      !confirm(`Remove Pro access from ${user.email}? They'll be dropped to the free plan limits.`)
+    ) {
+      return;
+    }
+
+    // Optimistic, with a snapshot to roll back to — same pattern as
+    // FeedbackManagement.updateStatus(), plus a pending flag so the select
+    // can't be driven again mid-write.
+    const previous = users;
+    setError(null);
+    setSavingPlanFor(user.id);
+    setUsers(prev =>
+      prev.map(u =>
+        u.id === user.id ? { ...u, plan: newPlan, current_period_end: null } : u,
+      ),
+    );
+
+    try {
+      const { error: rpcError } = await supabase.rpc('admin_set_user_plan', {
+        target_user_id: user.id,
+        new_plan: newPlan,
+      });
+      if (rpcError) throw rpcError;
+    } catch (err) {
+      setUsers(previous);
+      setError(getSafeErrorMessage(err, 'Failed to update plan'));
+    } finally {
+      setSavingPlanFor(null);
+    }
+  };
+
+  const visibleUsers = users.filter(u => {
+    const q = search.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      u.email?.toLowerCase().includes(q) || (u.username?.toLowerCase().includes(q) ?? false)
+    );
+  });
 
   return (
     <div className="min-h-screen bg-board py-8">
@@ -125,6 +196,19 @@ export function AdminDashboard() {
 
             {activeTab === 'users' && (
               <div className="overflow-x-auto">
+                <div className="mb-4 flex items-center gap-3">
+                  <input
+                    type="search"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search by email or username…"
+                    aria-label="Search users"
+                    className="w-72 max-w-full px-3 py-1.5 bg-board border border-chalk/20 rounded-lg text-sm text-chalk placeholder:text-chalk/40 focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                  <span className="ml-auto text-sm text-chalk/50">
+                    {visibleUsers.length} of {users.length} user{users.length === 1 ? '' : 's'}
+                  </span>
+                </div>
                 {loading ? (
                   <div className="space-y-4">
                     {[1, 2, 3].map((i) => (
@@ -137,12 +221,13 @@ export function AdminDashboard() {
                       <tr className="border-b border-chalk/10">
                         <th className="px-4 py-2 text-left text-chalk">User</th>
                         <th className="px-4 py-2 text-left text-chalk">Email</th>
+                        <th className="px-4 py-2 text-left text-chalk">Plan</th>
                         <th className="px-4 py-2 text-left text-chalk">Joined</th>
                         <th className="px-4 py-2 text-right text-chalk">Actions</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {users.map((user) => (
+                      {visibleUsers.map((user) => (
                         <tr key={user.id} className="border-b border-chalk/10">
                           <td className="px-4 py-2 text-chalk">
                             {user.username || 'Anonymous'}
@@ -153,6 +238,30 @@ export function AdminDashboard() {
                             )}
                           </td>
                           <td className="px-4 py-2 text-chalk">{user.email}</td>
+                          <td className="px-4 py-2">
+                            {user.is_stripe_backed ? (
+                              // Paying subscriber — the server refuses to change these
+                              // (PBP06), so don't offer a control that can only fail.
+                              <span
+                                className={`px-2 py-0.5 rounded-full text-xs font-medium ${PLAN_BADGE[user.plan]}`}
+                                title="Managed by Stripe — cancel the subscription in Stripe to change this"
+                              >
+                                {PLAN_LABEL[user.plan]}
+                              </span>
+                            ) : (
+                              <select
+                                aria-label={`Plan for ${user.email}`}
+                                value={user.plan}
+                                disabled={savingPlanFor === user.id}
+                                onChange={(e) => handleSetPlan(user, e.target.value as Plan)}
+                                className={`px-2 py-1 rounded-lg border border-chalk/20 bg-board text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 ${PLAN_BADGE[user.plan]}`}
+                              >
+                                {ASSIGNABLE_PLANS.map(({ value, label }) => (
+                                  <option key={value} value={value}>{label}</option>
+                                ))}
+                              </select>
+                            )}
+                          </td>
                           <td className="px-4 py-2 text-chalk">
                             {new Date(user.created_at).toLocaleDateString()}
                           </td>
@@ -171,6 +280,13 @@ export function AdminDashboard() {
                       ))}
                     </tbody>
                   </table>
+                )}
+                {!loading && visibleUsers.length === 0 && (
+                  <p className="py-8 text-center text-sm text-chalk/50">
+                    {users.length === 0
+                      ? 'No users yet.'
+                      : `No users match “${search}”.`}
+                  </p>
                 )}
               </div>
             )}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -28,10 +28,14 @@ export function getSafeErrorMessage(
     if (code === '23505') return 'That already exists.';
     if (code === '23503') return 'That item could not be found or no longer exists.';
     // Free-tier limit triggers (see supabase/free_tier_limits.sql), the
-    // custom-formations Pro gate (supabase/custom_formations.sql), and the
-    // playbook pack clone function (supabase/playbook_packs.sql) raise these
-    // custom codes with an already user-safe, upgrade-prompt message.
-    if (code === 'PBP01' || code === 'PBP02' || code === 'PBP03' || code === 'PBP04' || code === 'PBP05') return String(message);
+    // custom-formations Pro gate (supabase/custom_formations.sql), the
+    // playbook pack clone function (supabase/playbook_packs.sql), and the
+    // admin entitlement RPC (supabase/admin_entitlements.sql) raise these
+    // custom codes with an already user-safe message.
+    if (
+      code === 'PBP01' || code === 'PBP02' || code === 'PBP03' ||
+      code === 'PBP04' || code === 'PBP05' || code === 'PBP06'
+    ) return String(message);
     if (code === '42501' || (typeof message === 'string' && /row-level security/i.test(message))) {
       return "You don't have permission to do that.";
     }

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -27,6 +27,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `football_avatars.sql` | **pending — needs SQL run** | Replaces the seeded Dicebear "bottts" robot avatar icons with 8 self-contained football-themed SVG data URIs (football, helmet, flag, whistle, goalpost, cleat, playbook, trophy). Repoints any user on an old icon to the new default first. |
 | `playbook_packs.sql` | applied (2026-08-03) | B-33 starter playbook packs: adds `playbooks.is_public`; public-read policies for public playbooks, their `playbook_plays` rows, and the plays inside them; `clone_playbook_pack(pack_playbook_id)` (Pro-gated, `SECURITY DEFINER`) clones a public playbook + its plays into the caller's own account. |
 | `feedback_triage.sql` | **pending — needs SQL run** | B-35 automated feedback triage: additive `triage_class`/`triage_state`/`triage_ref`/`triage_notes`/`triaged_at` columns on `feedback` + a partial index on untriaged rows. No RLS or existing-column changes. |
+| `admin_entitlements.sql` | **pending — needs SQL run** | Admin Dashboard entitlement management, replacing one-off grant SQL. Re-creates `admin_list_users()` with `plan`/`current_period_end`/`is_stripe_backed` (DROP first — return type changed); adds `admin_set_user_plan(uuid, text)`. No schema/RLS change. |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.
@@ -83,9 +84,10 @@ idempotent `.sql` file and update this doc in the same change.
 |---|---|
 | `is_admin() → bool` | True if caller is in `admin_users`. `SECURITY DEFINER`, `search_path` pinned. Use in RLS. |
 | `is_pro(uid uuid = auth.uid()) → bool` | True if caller has an active `founding`/`pro` subscription. `SECURITY DEFINER`, pinned. |
-| `admin_list_users()` | Admin-gated; all users w/ email, username, created_at, is_admin flag. |
+| `admin_list_users()` | Admin-gated; all users w/ email, username, created_at, is_admin flag, plus entitlement columns `plan` (`COALESCE(s.plan,'free')` — no row = free), `current_period_end`, `is_stripe_backed` (`admin_entitlements.sql`). |
 | `admin_list_feedback()` | Admin-gated; feedback rows joined to submitter email. |
 | `delete_user(target_user_id uuid)` | Admin-gated; deletes the auth account (cascades). Blocks self-deletion. |
+| `admin_set_user_plan(target_user_id uuid, new_plan text)` | Admin-gated; sets a user's entitlement from the Admin Dashboard (upsert, `current_period_end` NULL). Only `'free'`/`'founding'` are settable — `'pro'` belongs to the Stripe webhook. Refuses any row with a `stripe_subscription_id`. All rejections raise `PBP06` (`admin_entitlements.sql`). |
 | `get_community_authors(target_ids uuid[])` | Returns `id, username, avatar_url` for a batch of authors (Community page; avoids embedding a nonexistent `profiles` table). Granted to anon+authenticated. |
 | `enforce_plays_free_limit()` / `enforce_playbooks_free_limit()` | Trigger fns: raise `PBP01`/`PBP02` (custom SQLSTATE, user-safe message) when a non-`is_pro()` user's insert would exceed `FREE_LIMITS.plays`/`FREE_LIMITS.playbooks`. Client maps these codes to an upgrade prompt in `src/lib/errors.ts`. |
 | `clone_playbook_pack(pack_playbook_id uuid) → uuid` | `SECURITY DEFINER`, pinned `search_path`. B-33: clones a public playbook + its plays (private copies, preserving order) into the caller's own account, returning the new playbook id. Raises `PBP04` if the caller isn't `is_pro()`, `PBP05` if `pack_playbook_id` isn't a public playbook. Granted to `authenticated`. |

--- a/supabase/admin_entitlements.sql
+++ b/supabase/admin_entitlements.sql
@@ -1,0 +1,114 @@
+-- Admin entitlement management: set a user's plan from the Admin Dashboard
+-- instead of hand-writing a one-off SQL file for every grant.
+--
+-- Run once in the Supabase SQL Editor. Idempotent — safe to re-run.
+--
+-- `subscriptions` RLS is SELECT-own-only (subscriptions.sql): "writes happen
+-- only via the Stripe webhook (service role) or admin SQL — never directly
+-- from the client." So the dashboard cannot UPDATE the table directly; it has
+-- to go through a SECURITY DEFINER function that gates itself on is_admin().
+-- Same shape as delete_user() in feedback_admin.sql.
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- admin_list_users() — replaced to include entitlement columns.
+--
+-- DROP first: Postgres refuses CREATE OR REPLACE when the RETURNS TABLE
+-- signature changes. The only caller is AdminDashboard.tsx.
+-- ─────────────────────────────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS admin_list_users();
+
+CREATE OR REPLACE FUNCTION admin_list_users()
+RETURNS TABLE (
+  id uuid,
+  email text,
+  username text,
+  created_at timestamptz,
+  is_admin_user boolean,
+  plan text,
+  current_period_end timestamptz,
+  is_stripe_backed boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'Not authorized';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email::text,
+    (u.raw_user_meta_data->>'username')::text,
+    u.created_at,
+    EXISTS (SELECT 1 FROM admin_users a WHERE a.user_id = u.id),
+    -- No subscriptions row at all = free (that is how signup leaves users).
+    COALESCE(s.plan, 'free')::text,
+    s.current_period_end,
+    (s.stripe_subscription_id IS NOT NULL)
+  FROM auth.users u
+  LEFT JOIN subscriptions s ON s.user_id = u.id
+  ORDER BY u.created_at DESC;
+END;
+$$;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- admin_set_user_plan(target_user_id, new_plan)
+--
+-- Comping someone is what 'founding' is for: is_pro() returns true for
+--   plan IN ('founding','pro') AND (current_period_end IS NULL OR > now())
+-- and ignores `status`, so 'founding' + NULL current_period_end is exactly
+-- "full access, never expires". The Stripe webhook also refuses to downgrade
+-- a 'founding' row, so a comp survives the live-billing switch (B-18).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION admin_set_user_plan(target_user_id uuid, new_plan text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  existing subscriptions%ROWTYPE;
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'Only admins can change a user''s plan';
+  END IF;
+
+  -- 'pro' is deliberately NOT settable here. That value is owned by the Stripe
+  -- webhook; hand-setting it invents an entitlement Stripe knows nothing about
+  -- and will later contradict.
+  IF new_plan NOT IN ('free', 'founding') THEN
+    RAISE EXCEPTION 'Plan must be free or founding. Paid Pro is managed by Stripe.'
+      USING ERRCODE = 'PBP06';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = target_user_id) THEN
+    RAISE EXCEPTION 'That user no longer exists.'
+      USING ERRCODE = 'PBP06';
+  END IF;
+
+  SELECT * INTO existing FROM subscriptions WHERE user_id = target_user_id;
+
+  -- Never touch a live Stripe subscription. Converting a paying subscriber to
+  -- 'founding' would keep Stripe billing them while the webhook refuses to ever
+  -- downgrade the row; flipping them to 'free' would strip access they are
+  -- still paying for. Cancel in Stripe first, then change the plan here.
+  IF existing.stripe_subscription_id IS NOT NULL THEN
+    RAISE EXCEPTION 'This user has an active Stripe subscription. Cancel it in Stripe before changing their plan.'
+      USING ERRCODE = 'PBP06';
+  END IF;
+
+  INSERT INTO subscriptions (user_id, plan, current_period_end)
+  VALUES (target_user_id, new_plan, NULL)
+  ON CONFLICT (user_id) DO UPDATE
+    SET plan               = EXCLUDED.plan,
+        current_period_end = NULL;
+END;
+$$;
+
+-- The function gates itself on is_admin(); the grant only makes it callable.
+GRANT EXECUTE ON FUNCTION admin_set_user_plan(uuid, text) TO authenticated;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -1910,3 +1910,116 @@ test('PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usag
   await page.goto('/playbooks');
   await expect(page.getByText('1 of 2 free playbooks used.')).toBeVisible();
 });
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Admin Dashboard — entitlement management.
+ *
+ * These are the first tests to touch /admin. The route has no client-side
+ * guard by design: gating is server-side (every RPC raises for non-admins), so
+ * these stub the RPCs directly rather than trying to simulate real admin auth.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const ADMIN_USER = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  aud: 'authenticated', role: 'authenticated', email: 'admin@example.com',
+  app_metadata: {}, user_metadata: { username: 'TheAdmin' }, created_at: '2025-01-01T00:00:00Z',
+};
+
+/** Signs in as an admin and stubs admin_list_users() with the given rows. */
+async function mockAdmin(page: Page, rows: Record<string, unknown>[]) {
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem('pbp-analytics-consent', 'denied');
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: ADMIN_USER, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ADMIN_USER) }));
+  await page.route('**/rest/v1/admin_users**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ user_id: ADMIN_USER.id }) }));
+  await page.route('**/rest/v1/rpc/admin_list_users**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(rows) }));
+}
+
+const freeRow = {
+  id: '11111111-1111-1111-1111-111111111111', email: 'freecoach@example.com',
+  username: 'FreeCoach', created_at: '2026-08-05T12:00:00Z', is_admin_user: false,
+  plan: 'free', current_period_end: null, is_stripe_backed: false,
+};
+const stripeRow = {
+  id: '22222222-2222-2222-2222-222222222222', email: 'payingcoach@example.com',
+  username: 'PayingCoach', created_at: '2026-08-05T13:00:00Z', is_admin_user: false,
+  plan: 'pro', current_period_end: '2027-08-05T00:00:00Z', is_stripe_backed: true,
+};
+
+test('admin users tab: a user with no subscription row shows as Free', async ({ page }) => {
+  await mockAdmin(page, [freeRow]);
+  await page.goto('/admin');
+
+  await expect(page.getByRole('cell', { name: 'freecoach@example.com' })).toBeVisible();
+  await expect(page.getByLabel('Plan for freecoach@example.com')).toHaveValue('free');
+});
+
+test('admin users tab: changing the dropdown calls admin_set_user_plan', async ({ page }) => {
+  await mockAdmin(page, [freeRow]);
+
+  let body: Record<string, unknown> | null = null;
+  await page.route('**/rest/v1/rpc/admin_set_user_plan**', (route) => {
+    body = route.request().postDataJSON();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: 'null' });
+  });
+
+  await page.goto('/admin');
+  await page.getByLabel('Plan for freecoach@example.com').selectOption('founding');
+
+  await expect.poll(() => body).not.toBeNull();
+  expect(body).toEqual({ target_user_id: freeRow.id, new_plan: 'founding' });
+  // Optimistic update sticks when the call succeeds.
+  await expect(page.getByLabel('Plan for freecoach@example.com')).toHaveValue('founding');
+});
+
+test('admin users tab: a Stripe-backed subscriber is read-only, not a dropdown', async ({ page }) => {
+  // The server refuses these (PBP06), so the UI must not offer a control that
+  // can only fail.
+  await mockAdmin(page, [stripeRow]);
+  await page.goto('/admin');
+
+  await expect(page.getByRole('cell', { name: 'payingcoach@example.com' })).toBeVisible();
+  await expect(page.getByText('Pro (Stripe)')).toBeVisible();
+  await expect(page.getByLabel('Plan for payingcoach@example.com')).toHaveCount(0);
+});
+
+test('admin users tab: a PBP06 rejection shows its real message and rolls back', async ({ page }) => {
+  await mockAdmin(page, [freeRow]);
+  await page.route('**/rest/v1/rpc/admin_set_user_plan**', (route) =>
+    route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 'PBP06',
+        message: 'This user has an active Stripe subscription. Cancel it in Stripe before changing their plan.',
+        details: null, hint: null,
+      }),
+    }));
+
+  await page.goto('/admin');
+  await page.getByLabel('Plan for freecoach@example.com').selectOption('founding');
+
+  // errors.ts must pass PBP06 through verbatim rather than the generic fallback.
+  await expect(page.getByText('This user has an active Stripe subscription.', { exact: false })).toBeVisible();
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  // Failed write must roll the optimistic change back.
+  await expect(page.getByLabel('Plan for freecoach@example.com')).toHaveValue('free');
+});
+
+test('admin users tab: search filters the list', async ({ page }) => {
+  await mockAdmin(page, [freeRow, stripeRow]);
+  await page.goto('/admin');
+  await expect(page.getByText('2 of 2 users')).toBeVisible();
+
+  await page.getByLabel('Search users').fill('paying');
+  await expect(page.getByText('1 of 2 users')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'freecoach@example.com' })).toHaveCount(0);
+});


### PR DESCRIPTION
Replaces hand-written one-off grant SQL with a Plan column, per-row dropdown, and email search on the Users tab of `/admin`. Supersedes #27 (closed).

> **One manual SQL run required — and it's the last one.** `supabase/admin_entitlements.sql` installs the RPCs; after that, plan changes are a UI action forever.

## Why it needs an RPC

`subscriptions` RLS is **SELECT-own-only** — *"writes happen only via the Stripe webhook (service role) or admin SQL — never directly from the client."* A `.from('subscriptions').update()` in the dashboard is denied (42501). So the write goes through a `SECURITY DEFINER` function gated on `is_admin()`, mirroring `delete_user()` in `feedback_admin.sql`.

## `supabase/admin_entitlements.sql`

- **`admin_list_users()` re-created** with `plan` / `current_period_end` / `is_stripe_backed`. `DROP` first — Postgres refuses `CREATE OR REPLACE` when the `RETURNS TABLE` signature changes. No subscriptions row = `free`.
- **`admin_set_user_plan(uuid, text)`** — new. Only `'free'`/`'founding'` are settable. `'pro'` belongs to the Stripe webhook; hand-setting it invents an entitlement Stripe knows nothing about. Refuses any row carrying a `stripe_subscription_id` outright: converting a paying subscriber to `founding` would keep Stripe billing them while the webhook refuses to ever downgrade the row, and flipping them to `free` would strip access they're still paying for. All rejections raise `PBP06`.

## SQL verification

Ran against a **throwaway PostgreSQL 17 instance** (isolated cluster, torn down after) with fixtures for admin and non-admin callers and for no-row / free-row / founding-row / Stripe-backed users:

| Case | Result |
|---|---|
| Non-admin calls either function | refused ✅ |
| Grant to user with no subscriptions row | `founding`, `period_end=NULL`, `is_pro()` true ✅ |
| Upgrade existing `free` row | `founding`, `is_pro()` true ✅ |
| Downgrade `founding` → `free` | `is_pro()` false ✅ |
| Stripe-backed row, **both** directions | `PBP06`, row byte-identical ✅ |
| `'pro'` set by hand | `PBP06` ✅ |
| Nonexistent user | `PBP06` ✅ |
| Re-run file / repeat grant | no-op ✅ |

## Client

- `PBP06` added to the `errors.ts` allowlist so admins see the real reason, not the generic fallback.
- **Stripe-backed rows render a read-only badge, not a dropdown** — the UI never offers an action the server will reject.
- Optimistic update with snapshot rollback, plus a per-row pending flag so the select can't be driven mid-write.
- Confirm prompt only on downgrade; upgrades apply immediately.
- ⚠️ Deliberately **no** `useEntitlement()`/`checkIsAdmin()` in `AdminDashboard` — it makes no auth calls today, and a second concurrent `auth.getUser()` is the documented B-4 gotrue deadlock that hung PlaybooksPage. Plans come from the RPC payload.

## Tests

First tests to cover `/admin` at all — 5 cases: Free renders for a user with no row; the dropdown POSTs the right `target_user_id`/`new_plan`; a Stripe row has no dropdown; **a `PBP06` rejection surfaces its real message and rolls the row back**; search filters. The `PBP06` test was confirmed to *fail* when `PBP06` is removed from the allowlist — a regression test that doesn't bite isn't worth having.

`npm run typecheck` clean on touched files, `npx eslint` 0 errors, `npm run build` ✅, **`npm run smoke` 52/52** (was 47). Rendered UI checked in a browser.

## Not in scope

- **No audit trail** — nothing records which admin changed whose plan. `subscriptions.updated_at` shows *that* it changed, not *who*. Worth adding for money-adjacent actions; would be a small `entitlement_audit` table written inside the same RPC.
- Bulk/date-range grants; admin-role management still needs a manual `INSERT INTO admin_users`.

## After you run the SQL

Load `/admin` → Users, confirm the Plan column populates, and flip yesterday's 8/5 signups to Founding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)