### PR TITLE
Open the Play Designer in the same tab, not a new one

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,7 +35,7 @@ export function Navbar() {
 
   const navItems = [
     { path: '/', label: 'Home' },
-    { path: '/designer', label: 'Play Designer', newTab: true },
+    { path: '/designer', label: 'Play Designer' },
     { path: '/plays', label: 'Plays' },
     { path: '/playbooks', label: 'Playbooks' },
     { path: '/community', label: 'Community' },
@@ -56,11 +56,10 @@ export function Navbar() {
               <span className="ml-2"><Wordmark /></span>
             </Link>
             <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
-              {navItems.map(({ path, label, newTab }) => (
+              {navItems.map(({ path, label }) => (
                 <Link
                   key={path}
                   to={path}
-                  {...(newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
                   className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
                     isActive(path)
                       ? 'border-primary text-chalk'
@@ -99,11 +98,10 @@ export function Navbar() {
       {isMenuOpen && (
         <div className="sm:hidden bg-board-light">
           <div className="pt-2 pb-3 space-y-1">
-            {navItems.map(({ path, label, newTab }) => (
+            {navItems.map(({ path, label }) => (
               <Link
                 key={path}
                 to={path}
-                {...(newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
                 className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                   isActive(path)
                     ? 'bg-board text-primary border-primary'

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2023,3 +2023,22 @@ test('admin users tab: search filters the list', async ({ page }) => {
   await expect(page.getByText('1 of 2 users')).toBeVisible();
   await expect(page.getByRole('cell', { name: 'freecoach@example.com' })).toHaveCount(0);
 });
+
+test('nav "Play Designer" opens in the same tab, not a new one', async ({ page, context }) => {
+  // The nav item used to carry newTab:true (target="_blank"), which orphaned
+  // tabs and broke SPA navigation. Guard the desktop nav and the mobile menu.
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Play Designer' }).click();
+
+  await expect(page).toHaveURL(/\/designer/);
+  expect(context.pages()).toHaveLength(1);
+
+  // Mobile menu path.
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto('/');
+  await page.locator('nav button').last().click();
+  await page.getByRole('link', { name: 'Play Designer' }).click();
+
+  await expect(page).toHaveURL(/\/designer/);
+  expect(context.pages()).toHaveLength(1);
+});


### PR DESCRIPTION
The **Play Designer** nav item carried `newTab: true`, so clicking it from any page opened a second tab via `target="_blank"` — orphaning tabs and losing SPA navigation state. It now navigates in place like every other nav item.

## Changes

`src/components/Navbar.tsx` — `/designer` was the **only** item that ever set `newTab`, so the flag and the conditional `target`/`rel` spread are removed from both the desktop nav and the mobile menu rather than left as dead code.

## Scope check

Every other link to `/designer` already navigated in-tab — `Hero.tsx`, `PlaysPage.tsx` (including `?play=` and `?template=`), `PlaybooksPage.tsx` — so this was the only place that needed changing.

The remaining `target="_blank"` uses in `src/` are genuinely external and left alone:
- the wristband product page (`PlaybooksPage.tsx`, `ExportModal.tsx`)
- the Google Analytics opt-out link (`PrivacyPolicy.tsx`)

Also confirmed no test depended on the popup — the smoke suite reaches the designer via `page.goto('/designer')`, and nothing used `waitForEvent('popup')`.

## Verification

- `npm run typecheck` clean on touched files; `npx eslint` 0 errors
- `npm run build` ✅
- **`npm run smoke` 53/53** (was 52)
- New test covers **both** the desktop nav and the mobile menu, asserting the URL changes *and* that no second page is opened. **Confirmed to fail when `newTab: true` is restored** — the page stays on `/` — so it actually guards the regression rather than just passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)