### PR TITLE
Fix Sign Out doing nothing: a deadlocked gotrue session lock

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import type { User } from '@supabase/supabase-js';
 import { UserMenu } from './auth/UserMenu';
 import { supabase } from '../lib/supabase';
+import { signOutSafely } from '../lib/auth';
 
 export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -132,7 +133,7 @@ export function Navbar() {
                   </button>
                   <button
                     onClick={async () => {
-                      await supabase.auth.signOut();
+                      await signOutSafely();
                       setIsMenuOpen(false);
                       navigate('/');
                     }}

--- a/src/components/auth/AccountSettings.tsx
+++ b/src/components/auth/AccountSettings.tsx
@@ -7,6 +7,7 @@ import { ImageCropModal } from './ImageCropModal';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { assertReasonableUpload, downscaleImage } from '../../lib/imageResize';
 import { checkIsAdmin } from '../../lib/admin';
+import { signOutSafely } from '../../lib/auth';
 import { supabase } from '../../lib/supabase';
 import { FREE_LIMITS, rowIsPro, type Plan } from '../../lib/entitlements';
 import {
@@ -311,7 +312,11 @@ export default function AccountSettings() {
     try {
       const { error } = await supabase.rpc('delete_user');
       if (error) throw error;
-      await supabase.auth.signOut();
+      // The account no longer exists, so the server rejects the logout call.
+      // signOutSafely() swallows that and clears the local session anyway —
+      // a bare signOut() here threw, so a *successful* deletion still showed
+      // "Failed to delete account" and never navigated away.
+      await signOutSafely();
       navigate('/');
     } catch (err) {
       setError(getSafeErrorMessage(err, 'Failed to delete account'));

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '../../lib/supabase';
 import { checkIsAdmin } from '../../lib/admin';
+import { signOutSafely } from '../../lib/auth';
 
 interface UserMenuProps {
   user: SupabaseUser;
@@ -84,7 +85,7 @@ export function UserMenu({ user, showName = true }: UserMenuProps) {
   }, [user.id]);
 
   const handleSignOut = async () => {
-    await supabase.auth.signOut();
+    await signOutSafely();
     navigate('/');
   };
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,45 @@
+import { supabase } from './supabase';
+
+/** The key supabase-js persists the session under: `sb-<project-ref>-auth-token`. */
+function sessionStorageKey(): string {
+  const ref = new URL(import.meta.env.VITE_SUPABASE_URL).hostname.split('.')[0];
+  return `sb-${ref}-auth-token`;
+}
+
+/**
+ * Signs the user out and never rejects. Guarantees the session is gone locally
+ * even when the server refuses the logout.
+ *
+ * Two failure modes this exists to absorb, both observed in the browser:
+ *
+ * 1. The three sign-out call sites used to `await supabase.auth.signOut()` bare
+ *    and then navigate. Any rejection meant the navigation never ran and the
+ *    button appeared to do nothing.
+ *
+ * 2. When the session is already gone server-side, `/auth/v1/logout` returns
+ *    403 and gotrue rejects with AuthSessionMissingError — for BOTH
+ *    `scope: 'global'` and `scope: 'local'` — while **leaving the persisted
+ *    token in localStorage**. The app then still looks signed in. So the
+ *    fallback clears the key directly and hard-reloads, because a client-side
+ *    navigate() would leave components holding stale auth state.
+ *
+ * On the happy path this is just `signOut()`; callers navigate afterwards.
+ */
+export async function signOutSafely(): Promise<void> {
+  try {
+    const { error } = await supabase.auth.signOut();
+    if (error) throw error;
+    return;
+  } catch (err) {
+    console.error('Sign out failed; forcing a local sign-out instead:', err);
+  }
+
+  try {
+    localStorage.removeItem(sessionStorageKey());
+  } catch {
+    // Storage blocked — the reload below is still worth attempting.
+  }
+  // Full reload rather than a router navigate: every component that cached the
+  // user must be rebuilt, or the UI keeps showing a signed-in state.
+  window.location.assign('/');
+}

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -51,8 +51,9 @@ export function useEntitlement(): Entitlement {
   useEffect(() => {
     let cancelled = false;
 
-    const resolve = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+    /** Resolves entitlement from an already-known session — never calls an
+     *  auth method itself, so it is safe to run from an auth callback. */
+    const resolveFrom = async (user: { id: string } | null) => {
       if (!user) {
         if (!cancelled) setState({ loading: false, isPro: false, plan: 'free', isFoundingMember: false });
         return;
@@ -74,8 +75,23 @@ export function useEntitlement(): Entitlement {
       });
     };
 
-    resolve();
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(() => resolve());
+    // Initial read. Safe here: we are not inside an auth callback.
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      void resolveFrom(session?.user ?? null);
+    });
+
+    // ⚠ gotrue-js dispatches this callback WHILE HOLDING its session lock.
+    // Calling any Supabase method synchronously from inside it — including
+    // the innocuous-looking `auth.getUser()` this used to do — tries to
+    // re-acquire that same lock and deadlocks it *permanently*: every later
+    // auth call, `signOut()` included, then hangs forever and the Sign Out
+    // button silently does nothing. Use the `session` the callback already
+    // hands us, and defer the follow-up query to a fresh task so the lock is
+    // released first.
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      const user = session?.user ?? null;
+      setTimeout(() => { void resolveFrom(user); }, 0);
+    });
     return () => { cancelled = true; subscription.unsubscribe(); };
   }, []);
 

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2042,3 +2042,96 @@ test('nav "Play Designer" opens in the same tab, not a new one', async ({ page, 
   await expect(page).toHaveURL(/\/designer/);
   expect(context.pages()).toHaveLength(1);
 });
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Sign out. useEntitlement() used to call auth.getUser() from inside an
+ * onAuthStateChange callback; gotrue dispatches those while holding its
+ * session lock, so that re-entrant call deadlocked the lock permanently and
+ * every later auth call — signOut() included — hung forever. The Sign Out
+ * button silently did nothing.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const SIGNED_IN_USER = {
+  id: '77777777-7777-7777-7777-777777777777',
+  aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+  app_metadata: {}, user_metadata: { username: 'Coach' }, created_at: '2025-01-01T00:00:00Z',
+};
+
+/** gotrue decodes the access token, so the fixture must be a structurally
+ *  valid JWT — a placeholder string makes it report "Auth session missing"
+ *  before any network call and the test stops exercising the real path. */
+const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url');
+const FAKE_JWT = `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url({
+  sub: SIGNED_IN_USER.id, aud: 'authenticated', role: 'authenticated',
+  session_id: 'sess-1', email: SIGNED_IN_USER.email,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+})}.sig`;
+
+async function signedInHome(page: Page, logout: (route: never) => unknown) {
+  await page.addInitScript(({ u, k, jwt }) => {
+    localStorage.setItem('pbp-analytics-consent', 'denied');
+    // Seed ONCE. addInitScript re-runs on every navigation, and a failed
+    // sign-out deliberately hard-reloads — re-seeding would silently undo the
+    // very thing under test.
+    if (sessionStorage.getItem('pbp-seeded')) return;
+    sessionStorage.setItem('pbp-seeded', '1');
+    localStorage.setItem(k, JSON.stringify({
+      access_token: jwt, refresh_token: 'ref',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user: u,
+    }));
+  }, { u: SIGNED_IN_USER, k: AUTH_STORAGE_KEY, jwt: FAKE_JWT });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SIGNED_IN_USER) }));
+  await page.route('**/rest/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/auth/v1/logout**', logout as never);
+  await page.goto('/');
+}
+
+test('auth calls do not deadlock the gotrue session lock on the homepage', async ({ page }) => {
+  // The root cause, asserted directly: if the lock is stuck, these never settle.
+  await signedInHome(page, ((route: { fulfill: (o: unknown) => unknown }) =>
+    route.fulfill({ status: 204, body: '' })) as never);
+  await page.waitForTimeout(1200);
+
+  const settled = await page.evaluate(async () => {
+    const mod = await import('/src/lib/supabase.ts');
+    const sb = (mod as { supabase: { auth: { getSession: () => Promise<unknown> } } }).supabase;
+    return Promise.race([
+      sb.auth.getSession().then(() => true),
+      new Promise((res) => setTimeout(() => res(false), 5000)),
+    ]);
+  });
+  expect(settled).toBe(true);
+});
+
+test('Sign Out signs the user out and returns them home', async ({ page }) => {
+  let logoutCalled = false;
+  await signedInHome(page, ((route: { fulfill: (o: unknown) => unknown }) => {
+    logoutCalled = true;
+    return route.fulfill({ status: 204, body: '' });
+  }) as never);
+
+  await page.getByRole('button', { name: 'Coach' }).click();
+  await page.getByRole('button', { name: 'Sign Out' }).click();
+
+  await expect.poll(() => logoutCalled, { timeout: 10000 }).toBe(true);
+  await expect(page.getByRole('button', { name: 'Coach' })).toHaveCount(0);
+  expect(await page.evaluate((k) => localStorage.getItem(k), AUTH_STORAGE_KEY)).toBeNull();
+});
+
+test('Sign Out still works when the server rejects the logout', async ({ page }) => {
+  // Very common: the session is already gone server-side, so /logout 403s. The
+  // user must still end up signed out locally rather than stuck.
+  await signedInHome(page, ((route: { fulfill: (o: unknown) => unknown }) =>
+    route.fulfill({
+      status: 403, contentType: 'application/json',
+      body: JSON.stringify({ code: 403, error_code: 'session_not_found', msg: 'Session not found' }),
+    })) as never);
+
+  await page.getByRole('button', { name: 'Coach' }).click();
+  await page.getByRole('button', { name: 'Sign Out' }).click();
+
+  await expect(page.getByRole('button', { name: 'Coach' })).toHaveCount(0);
+  expect(await page.evaluate((k) => localStorage.getItem(k), AUTH_STORAGE_KEY)).toBeNull();
+});


### PR DESCRIPTION
## Root cause

`useEntitlement()` registered `onAuthStateChange(() => resolve())`, and `resolve()` called `supabase.auth.getUser()`.

**gotrue-js dispatches those callbacks while holding its session lock.** That re-entrant auth call waited on a lock its own caller already owned and deadlocked it *permanently*. From then on every auth call hung forever — `signOut()` was just the most visible victim: the promise never settled, so the `navigate('/')` after it never ran, **no `/auth/v1/logout` request was ever sent**, and the button appeared to do nothing.

`<Pricing />` is rendered on the homepage (`App.tsx:54`) and calls `useEntitlement()`, so the lock was already wedged on first load for every signed-in visitor. `FormationMenu` and `ExportModal` do the same in the designer.

This is the same class of bug as the B-4 note in `CLAUDE.md` — *"two concurrent gotrue calls can deadlock its session lock"* — which had already been worked around in `PlaysPage`/`PlaybooksPage` but was still live inside the hook itself.

## Measured in the browser

On the homepage, signed in:

| | before | after |
|---|---|---|
| `getSession()` | **HUNG (4001ms)** | settled (1ms) |
| `getUser()` | **HUNG (4001ms)** | settled (4ms) |
| `signOut()` | **never settles** | resolves |
| `navigator.locks` held | `["lock:sb-<ref>-auth-token"]` | `[]` |
| logout request | **never sent** | `POST logout?scope=global` |
| result | still signed in | session cleared, signed out |

## The fix

Use the `session` the callback is already handed instead of asking for it again, and defer the follow-up query with `setTimeout(…, 0)` so the lock is released before any Supabase call runs.

## Also: sign-out had no error handling anywhere

All three call sites `await supabase.auth.signOut()` bare, then navigate — any rejection skipped the navigation. New `signOutSafely()` never rejects, and covers a **second failure observed in the browser**: when the session is already gone server-side, `/auth/v1/logout` returns 403 and gotrue rejects for **both** `scope: 'global'` *and* `scope: 'local'` while leaving the persisted token in `localStorage`, so the app still looks signed in. The fallback removes the key directly and hard-reloads — a router `navigate()` would leave components holding stale auth state.

**That same 403 broke account deletion.** After `delete_user()` succeeds the account no longer exists, so the bare `signOut()` threw — meaning a *successful* deletion reported "Failed to delete account" and never navigated away.

## Tests

Three regression tests, **all confirmed to fail when the re-entrant call is put back**: auth calls settle on the homepage; Sign Out clears the session and returns home; Sign Out still works when the server 403s.

Two fixture details worth knowing, both found the hard way:
- the session needs a **structurally valid JWT** — a placeholder token makes gotrue report "Auth session missing" before any network call, so the test silently stops exercising the real path;
- it must **seed only once**, because a failed sign-out deliberately hard-reloads and `addInitScript` re-runs on every navigation, which was quietly undoing the thing under test.

`npm run typecheck` clean; `npx eslint` adds no new problems (the two reported are pre-existing on `main` — verified by stashing); `npm run build` ✅; **`npm run smoke` 56/56** (was 53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)