### PR TITLE
Fix Anton/Inter/JetBrains Mono silently failing to load in production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,18 @@ playbooks, and print/share them. Live at **playbuilderpro.com**.
   `public/_redirects`, whose `/* /index.html 200` catch-all must stay **last** —
   the `/sitemap.xml` proxy to the `sitemap` Edge Function sits above it and
   would be swallowed by the catch-all if reordered.
+- **`public/_headers` sets a strict CSP** (no `'unsafe-inline'` in `script-src`).
+  Any new third-party script/stylesheet/font host needs an entry there or it
+  fails **silently** in production — no error banner, just missing behavior.
+  This bit us twice: the Jul 17 "font unblock" commit added an inline
+  `onload="this.media='all'"` to two `<link>` tags to swap them off
+  `media="print"`, which CSP silently blocked, so **every visitor got system
+  fonts instead of Anton/Inter/JetBrains Mono for three weeks** (also missing
+  `fonts.googleapis.com`/`fonts.gstatic.com` from the policy entirely). Fixed
+  by moving the swap into `public/font-loader.js`, loaded via `<script src>`
+  (allowed) instead of an inline handler. When adding a script tag, check the
+  browser console for `Refused to` / `violates the following Content Security
+  Policy` — not just `Refused to`, the exact wording varies by violation type.
 - **Env:** `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_BILLING_ENABLED`
   (must be lowercase `true` to enable Stripe UI — `TRUE` silently fails the
   `=== 'true'` check). Those three are the *only* env vars `src/` reads; see

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="preconnect" href="https://rsms.me" crossorigin />
-    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" media="print" />
     <noscript><link rel="stylesheet" href="https://rsms.me/inter/inter.css" /></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -26,7 +26,6 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Anton&family=JetBrains+Mono:wght@400;600&display=swap"
       media="print"
-      onload="this.media='all'"
     />
     <noscript>
       <link
@@ -34,6 +33,11 @@
         href="https://fonts.googleapis.com/css2?family=Anton&family=JetBrains+Mono:wght@400;600&display=swap"
       />
     </noscript>
+    <!-- Flips the two stylesheets above from media="print" to media="all" once
+         loaded. Must be an external file — CSP's script-src has no
+         'unsafe-inline', so the inline onload="" this replaced was silently
+         blocked and both stylesheets never applied. See font-loader.js. -->
+    <script src="/font-loader.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/_headers
+++ b/public/_headers
@@ -6,7 +6,7 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-site
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://rsms.me; font-src 'self' https://rsms.me; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; font-src 'self' https://rsms.me https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://www.googletagmanager.com https://region1.google-analytics.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 # Vite content-hashes every filename in /assets (index-<hash>.js), so a cached
 # copy is valid forever — a new deploy always ships new filenames.

--- a/public/font-loader.js
+++ b/public/font-loader.js
@@ -1,0 +1,24 @@
+// Flips the preload-style stylesheet links (Inter, Anton/JetBrains Mono) from
+// media="print" — which fetches without blocking first paint — to media="all"
+// once each has actually loaded, so the fonts apply without being render
+// blocking. This must be a separate file, not an inline onload="" attribute:
+// CSP's script-src has no 'unsafe-inline', so an inline handler is silently
+// blocked by the browser. That was the actual bug — both stylesheets stayed
+// stuck at media="print" forever, so every visitor got system fonts instead
+// of Anton/Inter/JetBrains Mono. See CLAUDE.md.
+(function () {
+  function applyStylesheet(link) {
+    if (link.media !== 'all') link.media = 'all';
+  }
+
+  document.querySelectorAll('link[rel="stylesheet"][media="print"]').forEach(function (link) {
+    // A cached stylesheet may have already finished loading (link.sheet is
+    // set) before this script runs, in which case the 'load' event already
+    // fired and a new listener would never see it.
+    if (link.sheet) {
+      applyStylesheet(link);
+    } else {
+      link.addEventListener('load', function () { applyStylesheet(link); }, { once: true });
+    }
+  });
+})();


### PR DESCRIPTION
Every visitor has been on system fonts instead of Anton/Inter/JetBrains Mono since the Jul 17 "font unblock" perf commit — confirmed against the live site while working on the analytics CSP entries. Two independent bugs, same file, same failure mode: silent under CSP, so nothing in the console pointed at it unless you knew to look.

## The two bugs

1. **`fonts.googleapis.com` / `fonts.gstatic.com` were never in the CSP.** `style-src`/`font-src` only allowed `rsms.me`, so the Anton + JetBrains Mono stylesheet was refused outright.

2. **The `media="print"` → `media="all"` swap used an inline `onload=""` handler.** `script-src` has no `'unsafe-inline'`, so that handler was silently blocked — **including on the `rsms.me` Inter link, which `font-src` already allowed**. Both stylesheets stayed stuck at `media="print"` forever, i.e. never applied.

## Fix

- `public/_headers` — add the two Google Fonts hosts to `style-src`/`font-src`.
- `public/font-loader.js` (new) — the swap, loaded via `<script src="/font-loader.js">` instead of an inline handler. Checks `link.sheet` before attaching a `load` listener, since a cached stylesheet may have already fired `load` before the script runs.
- `index.html` — drop the two `onload=""` attributes, add the script tag.
- `CLAUDE.md` — a note on `public/_headers`'s strict CSP: any new script/style/font host needs an entry there or it fails **silently** in production, plus the console-message-wording gotcha (`Refused to` isn't the only phrasing CSP violations use — I've now hit both).

## Verification

Vite's dev server doesn't apply `public/_headers`, so `npm run dev` can't catch this — I built and served `dist/` with the real CSP header applied:

| | before | after |
|---|---|---|
| CSP console violations | 2 | **0** |
| stylesheet `media` | stuck at `print` | `all` |
| `document.fonts` | `[]` (nothing loaded) | `Inter var loaded`, `Anton loaded`, `JetBrains Mono loaded` |

Screenshot confirms the hero headline actually renders in Anton, not a system fallback.

`npm run typecheck` / `npm run smoke` unaffected (**63/63**) — this is markup plus one static asset, no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)