### PR TITLE
Mix solid and dashed segments within one straight-line route

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -25,7 +25,7 @@ import {
   iconShape,
   iconScaleForCount,
   strokeRoute,
-  strokeStraight,
+  strokeRuns,
   trimEnd,
   drawArrowhead,
   drawBlockCap,
@@ -154,6 +154,14 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // Waypoint mode state (normalized coords)
     const [waypointPoints, setWaypointPoints] = useState<Pt[]>([]);
+    // Per-segment dash style, index i = style of the segment from
+    // waypointPoints[i] to waypointPoints[i+1] — length tracks
+    // waypointPoints.length-1. Tracked unconditionally (cheap either way) but
+    // only acted on for 'straight' mode at commit/render time; every reset,
+    // pop, and append site for waypointPoints has a matching call here, kept
+    // in lockstep by convention — re-grep both on any future change to this
+    // flow, since one site (stampFormation) was missed on the first pass here.
+    const [waypointSegmentDashed, setWaypointSegmentDashed] = useState<boolean[]>([]);
     const [waypointColor, setWaypointColor] = useState('#e05a1e');
     const [waypointIconIndex, setWaypointIconIndex] = useState<number | null>(null);
     const lastTapRef = useRef<number>(0);
@@ -561,10 +569,15 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         const pts = previewPts.map(toPx);
         const isBlock = capStyle === 'block';
         const stroked = pts.length >= 2 && !isBlock ? trimEnd(pts, ARROWHEAD_SIZE * scale * 0.8) : pts;
-        ctx.save();
-        ctx.setLineDash(dashed ? [ROUTE_LINE_WIDTH * scale * 2.5, ROUTE_LINE_WIDTH * scale * 2] : []);
         if (drawMode === 'straight' || drawMode === 'block') {
-          strokeStraight(ctx, stroked, waypointColor, ROUTE_LINE_WIDTH * scale);
+          // Per-segment style, including the live pending segment: it always
+          // previews in the CURRENT toggle value, while already-committed
+          // segments keep whatever was active when each was placed. Same
+          // trimEnd realignment as renderScene's committed-path loop — resolve
+          // against the untrimmed points, then slice to match `stroked`.
+          const fullSegDash = pendingPoint ? [...waypointSegmentDashed, dashed] : waypointSegmentDashed;
+          const segDash = fullSegDash.slice(0, stroked.length - 1);
+          strokeRuns(ctx, stroked, segDash, waypointColor, ROUTE_LINE_WIDTH * scale);
           pts.slice(1).forEach((pt) => {
             ctx.save();
             ctx.fillStyle = waypointColor;
@@ -574,9 +587,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
             ctx.restore();
           });
         } else {
+          ctx.save();
+          ctx.setLineDash(dashed ? [ROUTE_LINE_WIDTH * scale * 2.5, ROUTE_LINE_WIDTH * scale * 2] : []);
           strokeRoute(ctx, stroked, waypointColor, ROUTE_LINE_WIDTH * scale);
+          ctx.restore();
         }
-        ctx.restore();
         if (pts.length >= 2) {
           if (isBlock) drawBlockCap(ctx, pts, waypointColor, ARROWHEAD_SIZE * scale);
           else drawArrowhead(ctx, pts, waypointColor, ARROWHEAD_SIZE * scale);
@@ -639,7 +654,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         ctx.setLineDash([]);
         ctx.restore();
       }
-    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, drawMode, capStyle, dashed, deleteRouteMode, drawingMode, zoneMode, deleteZoneMode, iconHasRoute, iconHasZone]);
+    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, waypointSegmentDashed, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, drawMode, capStyle, dashed, deleteRouteMode, drawingMode, zoneMode, deleteZoneMode, iconHasRoute, iconHasZone]);
 
     // Redraw on state change
     useEffect(() => { draw(); }, [draw]);
@@ -668,6 +683,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // Clear in-progress segments when switching draw modes
     useEffect(() => {
       setWaypointPoints([]);
+      setWaypointSegmentDashed([]);
       setWaypointIconIndex(null);
       setHoveredIconIndex(null);
     }, [drawMode]);
@@ -677,6 +693,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     useEffect(() => {
       if (!drawingMode) {
         setWaypointPoints([]);
+        setWaypointSegmentDashed([]);
         setWaypointIconIndex(null);
         setHoveredIconIndex(null);
       }
@@ -734,10 +751,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
           if (waypointPoints.length === 1) {
             // Only the locked origin remains — cancel the route entirely.
             setWaypointPoints([]);
+            setWaypointSegmentDashed([]);
             setWaypointIconIndex(null);
             setHoveredIconIndex(null);
           } else {
             setWaypointPoints((prev) => prev.slice(0, -1));
+            setWaypointSegmentDashed((prev) => prev.slice(0, -1));
           }
           return;
         }
@@ -778,7 +797,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setEditingIconIndex(null);
         setEditingTextIndex(null);
       },
-      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
+      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointSegmentDashed([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
       clearRoutes: () => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex === undefined && p.points.length === 0)); },
       removeRouteForIcon: (iconIndex: number) => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex !== iconIndex)); },
       loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setTextBoxes(data.textBoxes || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingTextIndex(null); },
@@ -797,6 +816,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setZoneDraft(null);
         setEditingIconIndex(null);
         setWaypointPoints([]);
+        setWaypointSegmentDashed([]);
         setWaypointIconIndex(null);
         setHoveredIconIndex(null);
       },
@@ -832,9 +852,15 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // ------------------------------------------
     // Finish route helper
     // ------------------------------------------
-    const finishRoute = useCallback((pts: Pt[], color: string, iconIdx: number | null, mode: DrawMode) => {
+    const finishRoute = useCallback((pts: Pt[], color: string, iconIdx: number | null, mode: DrawMode, segDash: boolean[]) => {
       if (pts.length < 2) return;
       pushSnapshot();
+      // Only 'straight' mode gets per-segment styling (see the PathItem
+      // comment on segmentDashed for why curved routes don't), and only when
+      // it's not just a uniform value the plain `dashed` field already covers
+      // — keeps a route that was never toggled mid-draw exactly as small as
+      // it was before this feature existed.
+      const mixed = mode === 'straight' && segDash.length > 0 && segDash.some((d) => d !== segDash[0]);
       const newPath: PathItem = {
         points: pts,
         color,
@@ -842,6 +868,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         mode,
         capStyle,
         dashed,
+        segmentDashed: mixed ? segDash : undefined,
       };
       setPaths((prev) => [...prev, newPath]);
       if (onDrawingComplete) onDrawingComplete(pts);
@@ -853,16 +880,17 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     const finishWaypoint = useCallback(() => {
       if (waypointPoints.length >= 2) {
         // Use the active drawMode so straight segments are stored as 'straight'
-        finishRoute(waypointPoints, waypointColor, waypointIconIndex, drawMode);
+        finishRoute(waypointPoints, waypointColor, waypointIconIndex, drawMode, waypointSegmentDashed);
         // Flash "Route saved!" confirmation — setSavedFlash is stable, safe to call here
         if (savedFlashTimerRef.current) clearTimeout(savedFlashTimerRef.current);
         setSavedFlash(true);
         savedFlashTimerRef.current = setTimeout(() => setSavedFlash(false), 1500);
       }
       setWaypointPoints([]);
+      setWaypointSegmentDashed([]);
       setWaypointIconIndex(null);
       setHoveredIconIndex(null);
-    }, [waypointPoints, waypointColor, waypointIconIndex, drawMode, finishRoute]);
+    }, [waypointPoints, waypointColor, waypointIconIndex, drawMode, waypointSegmentDashed, finishRoute]);
 
     // ------------------------------------------
     // Pointer events
@@ -999,6 +1027,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
             setWaypointColor(icon.color);
             setWaypointIconIndex(clicked);
             setWaypointPoints([{ x: icon.x, y: icon.y }]);
+            setWaypointSegmentDashed([]);
             setHoveredIconIndex(null);
             routeDragRef.current = true;
             setPendingPoint({ x: icon.x, y: icon.y });
@@ -1010,6 +1039,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
           if (clicked >= 0 && clicked === waypointIconIndex) {
             // Tapped the SAME origin icon → cancel the in-progress route and deselect
             setWaypointPoints([]);
+            setWaypointSegmentDashed([]);
             setWaypointIconIndex(null);
             setHoveredIconIndex(null);
           } else if (clicked >= 0) {
@@ -1242,6 +1272,9 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
             : 0;
           if (traveled >= DRAG_THRESHOLD_PX) {
             setWaypointPoints((prev) => [...prev, pendingPoint]);
+            // Whatever the toggle reads right now is this segment's style —
+            // already-committed segments before it are untouched.
+            setWaypointSegmentDashed((prev) => [...prev, dashed]);
           }
         }
         setPendingPoint(null);
@@ -1477,6 +1510,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
               onPointerDown={(e) => {
                 e.stopPropagation();
                 setWaypointPoints([]);
+                setWaypointSegmentDashed([]);
                 setWaypointIconIndex(null);
                 setHoveredIconIndex(null);
               }}

--- a/src/lib/renderPlayScene.ts
+++ b/src/lib/renderPlayScene.ts
@@ -81,7 +81,30 @@ export type PathItem = {
   capStyle?: CapStyle;
   /** Dashed vs solid stroke. Omitted/undefined means solid. */
   dashed?: boolean;
+  /** Per-segment dash override for a 'straight' mode path — index i is the
+   *  style of the segment from points[i] to points[i+1], so length must equal
+   *  points.length-1 when present. Omitted means every segment uses `dashed`
+   *  above, which covers every pre-existing saved play and any route that was
+   *  never toggled mid-draw — no migration, no version bump, same pattern as
+   *  `dashed`/`capStyle` themselves. Never set for 'waypoint' mode: splitting
+   *  a curved route's quadratic-smoothed stroke at an interior point changes
+   *  the curve's shape, not just its dash pattern (the curve is drawn through
+   *  the midpoints between points, never touching an interior point itself —
+   *  forcing a split to land exactly on one distorts the silhouette). See
+   *  resolveSegmentDash(). */
+  segmentDashed?: boolean[];
 };
+
+/** The per-segment dash style to actually render/edit, honoring the
+ *  whole-path `dashed` fallback. Falls back even if `segmentDashed` is
+ *  present but the wrong length (e.g. a hand-edited or corrupted save),
+ *  rather than let a misaligned array silently attach the wrong style to the
+ *  wrong segment. */
+export function resolveSegmentDash(path: Pick<PathItem, 'points' | 'dashed' | 'segmentDashed'>): boolean[] {
+  const segmentCount = Math.max(0, path.points.length - 1);
+  if (path.segmentDashed && path.segmentDashed.length === segmentCount) return path.segmentDashed;
+  return new Array(segmentCount).fill(!!path.dashed);
+}
 
 export type IconShape = 'circle' | 'square' | 'triangle' | 'star';
 
@@ -174,6 +197,41 @@ export function strokeStraight(ctx: CanvasRenderingContext2D, pts: Pt[], color: 
   for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
   ctx.stroke();
   ctx.restore();
+}
+
+/**
+ * Strokes contiguous same-style runs of a polyline separately, so a route can
+ * mix solid and dashed segments. `segDash[i]` is the style of the segment
+ * from `pts[i]` to `pts[i+1]`, so `segDash.length === pts.length - 1`.
+ *
+ * Only used for 'straight' mode (plain `lineTo` between points), where
+ * splitting is exact — each run is a literal sub-polyline of the original,
+ * so this is pixel-identical to a single stroke() call when every entry in
+ * `segDash` is the same (the common case: nobody toggled mid-route). Do NOT
+ * use this for the quadratic-smoothed 'waypoint' mode — see the PathItem
+ * comment on `segmentDashed`.
+ */
+export function strokeRuns(
+  ctx: CanvasRenderingContext2D,
+  pts: Pt[],
+  segDash: boolean[],
+  color: string,
+  lw: number,
+) {
+  if (pts.length < 2 || segDash.length !== pts.length - 1) {
+    strokeStraight(ctx, pts, color, lw);
+    return;
+  }
+  let runStart = 0;
+  for (let i = 0; i <= segDash.length; i++) {
+    if (i === segDash.length || segDash[i] !== segDash[runStart]) {
+      ctx.save();
+      ctx.setLineDash(segDash[runStart] ? [lw * 2.5, lw * 2] : []);
+      strokeStraight(ctx, pts.slice(runStart, i + 1), color, lw);
+      ctx.restore();
+      runStart = i;
+    }
+  }
 }
 
 /**
@@ -584,14 +642,24 @@ export function renderScene(
     // arrowhead. Skipped for the block cap, which sits on the endpoint
     // rather than tapering to it.
     const stroked = isLast && !useBlockCap ? trimEnd(pts, arrowSize * 0.8) : pts;
-    ctx.save();
-    ctx.setLineDash(p.dashed ? [lineWidth * 2.5, lineWidth * 2] : []);
     if (p.mode === 'waypoint') {
+      ctx.save();
+      ctx.setLineDash(p.dashed ? [lineWidth * 2.5, lineWidth * 2] : []);
       strokeRoute(ctx, stroked, p.color, lineWidth);
+      ctx.restore();
+    } else if (p.segmentDashed) {
+      // trimEnd only ever removes/rewrites points from the tail, so the
+      // first `stroked.length - 1` entries of the original per-segment
+      // array still line up with the segments still visually present —
+      // resolve against the untrimmed points, then slice to match.
+      const segDash = resolveSegmentDash(p).slice(0, stroked.length - 1);
+      strokeRuns(ctx, stroked, segDash, p.color, lineWidth);
     } else {
+      ctx.save();
+      ctx.setLineDash(p.dashed ? [lineWidth * 2.5, lineWidth * 2] : []);
       strokeStraight(ctx, stroked, p.color, lineWidth);
+      ctx.restore();
     }
-    ctx.restore();
     if (isLast) {
       if (useBlockCap) drawBlockCap(ctx, pts, p.color, arrowSize);
       else drawArrowhead(ctx, pts, p.color, arrowSize);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -22,7 +22,7 @@ const AUTH_STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split('.')[0]}-aut
 const TAP_GAP = 450;
 
 type CanvasState = {
-  paths: Array<{ points: { x: number; y: number }[]; color: string; startIconIndex?: number; mode: string; capStyle?: string; dashed?: boolean }>;
+  paths: Array<{ points: { x: number; y: number }[]; color: string; startIconIndex?: number; mode: string; capStyle?: string; dashed?: boolean; segmentDashed?: boolean[] }>;
   playerIcons: Array<{ x: number; y: number; letter: string; color: string; shape?: string }>;
   zones: Array<{ iconIndex: number; cx: number; cy: number; rx: number; ry: number; color: string }>;
   textBoxes: Array<{ x: number; y: number; text: string; color: string; fontSize: number }>;
@@ -465,6 +465,188 @@ test('offense: curved route with block ending and dotted line — new combinatio
   expect(state.paths[0].mode).toBe('waypoint');
   expect(state.paths[0].capStyle).toBe('block');
   expect(state.paths[0].dashed).toBe(true);
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Mixed solid/dashed segments within one straight-line route (feedback: a
+ * coach draws a solid hitch, then breaks into a dashed in/out cut, as one
+ * continuous route). Deliberately straight-mode only — see the segmentDashed
+ * comment in renderPlayScene.ts for why curved routes don't get this.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+test('straight route: toggling dash mid-draw produces mixed segments', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Segment 1 (solid hitch): commit it BEFORE toggling.
+  const mid = await canvasPoint(page, 0.4, 0.45);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Toggle to dashed, then commit segment 2 (the in/out cut).
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const end = await canvasPoint(page, 0.55, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].mode).toBe('straight');
+  expect(state.paths[0].points).toHaveLength(3);
+  expect(state.paths[0].segmentDashed).toEqual([false, true]);
+});
+
+test('straight route: toggling dash but ending up uniform omits segmentDashed', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Toggle to dashed BEFORE placing anything, so every segment is dashed —
+  // net uniform, even though the button was clicked mid-route-session.
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const mid = await canvasPoint(page, 0.4, 0.45);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.55, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].dashed).toBe(true);
+  expect(state.paths[0].segmentDashed).toBeUndefined();
+});
+
+test('straight route: undo mid-route after toggling pops the right segment style', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Segment 1: dashed.
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const p1 = await canvasPoint(page, 0.4, 0.45);
+  await page.mouse.click(p1.x, p1.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Segment 2: solid — then place a THIRD point we're about to undo away.
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const p2 = await canvasPoint(page, 0.5, 0.35);
+  await page.mouse.click(p2.x, p2.y);
+  await page.waitForTimeout(TAP_GAP);
+  const p3 = await canvasPoint(page, 0.6, 0.25);
+  await page.mouse.click(p3.x, p3.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  // Undo pops the last committed point (p3) and its segment style, leaving
+  // origin -> p1 (dashed) -> p2 (solid) in progress.
+  await btn(page, 'Undo').click();
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].points).toHaveLength(3);
+  expect(state.paths[0].segmentDashed).toEqual([true, false]);
+});
+
+test('straight route: canceling mid-route leaves no stale segment styles for the next route', async ({ page }) => {
+  await openDesigner(page);
+
+  // First icon: start a route, toggle to dashed, then cancel via the Cancel button.
+  await btn(page, 'Player Q').click();
+  const spotQ = await canvasPoint(page, 0.3, 0.65);
+  await page.mouse.click(spotQ.x, spotQ.y);
+  await btn(page, 'Player R').click();
+  const spotR = await canvasPoint(page, 0.6, 0.65);
+  await page.mouse.click(spotR.x, spotR.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const iconQ = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(iconQ.x, iconQ.y);
+  await page.waitForTimeout(TAP_GAP);
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const midQ = await canvasPoint(page, 0.35, 0.45);
+  await page.mouse.click(midQ.x, midQ.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  // Second icon: a fresh, never-toggled route must come out fully solid —
+  // no leftover per-segment state from the canceled route.
+  const iconR = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+  await page.mouse.click(iconR.x, iconR.y);
+  await page.waitForTimeout(TAP_GAP);
+  const midR = await canvasPoint(page, 0.65, 0.45);
+  await page.mouse.click(midR.x, midR.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  // The global dash toggle is deliberately sticky across routes (unrelated
+  // to this feature — unchanged pre-existing behavior), so the second route
+  // legitimately inherits "dashed" from the first toggle click. What must
+  // NOT happen is a leaked per-segment array from the canceled route.
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].points).toHaveLength(2);
+  expect(state.paths[0].segmentDashed).toBeUndefined();
+});
+
+test('curved route: toggling dash mid-draw never sets segmentDashed (straight-only feature)', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Multi-Segment Route (drag or tap to place points, double-tap to finish)').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+
+  const mid = await canvasPoint(page, 0.4, 0.45);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+  await btn(page, 'Line style: Solid / Dotted').click();
+  const end = await canvasPoint(page, 0.55, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].mode).toBe('waypoint');
+  // Whole-path `dashed` still reflects the toggle at commit time (unchanged
+  // legacy behavior for curved routes) — it's the per-segment field that
+  // must never appear here.
+  expect(state.paths[0].dashed).toBe(true);
+  expect(state.paths[0].segmentDashed).toBeUndefined();
 });
 
 test('custom formations: signed-out/free user sees a locked upsell instead of the save flow', async ({ page }) => {


### PR DESCRIPTION
## Feedback this addresses

> "It seems like the routes are either solid or dashed. It would be nice if [they] could be both. For example, I use a goalie play where 2 WR line up on same side and run hitches (solid lines) then, if the pass doesn't happen, I have them cross with in/out routes (dashes). This can also be very useful in RPO plays."

Today `PathItem.dashed` is one boolean for the whole route — the dash toggle is global sticky state baked into the entire path at "Finish Route". No way to mix styles within one continuous route.

## Scoped to Straight only, not curved Multi-Segment Route

Not just a simplification — there's a real geometric reason. `strokeRoute`'s quadratic smoothing draws through the **midpoints** between consecutive points, using each point only as a curve control point, so a curved route never actually touches an interior waypoint. Splitting the stroke at a waypoint would force the curve to bend and touch that point directly — **distorting the route's silhouette, not just its dash pattern**. `strokeStraight` is literal `lineTo` between points, so splitting it into per-style runs is pixel-identical to today's rendering whenever nobody actually toggles mid-draw.

## Changes

**`renderPlayScene.ts`** — new `PathItem.segmentDashed?: boolean[]` (index `i` = style of the segment from `points[i]` to `points[i+1]`). Omitted = falls back to the whole-path `dashed` flag — no migration, no version bump, same "omitted means X" pattern as `dashed`/`capStyle` themselves. New `strokeRuns()` strokes contiguous same-style runs separately instead of the whole polyline in one call.

`trimEnd()` can **drop trailing points**, not just move the last one — segment styles are resolved against the original untrimmed points, then sliced to match the trimmed array. Verified by hand-tracing a 5-point example where a trailing point gets dropped.

**`Canvas.tsx`** — new `waypointSegmentDashed` state, appended to at the same `pointerUp` commit that appends a point, mirrored across every place `waypointPoints` resets or pops.

That's **11 call sites, not the 10** first enumerated during design review — a design-review pass with a subagent caught most of the risk here but still missed one (`stampFormation`) on a careful first count. I verified by direct grep rather than trusting the enumeration by eye, which is also the takeaway: re-grep-and-diff both arrays next time this flow changes, don't just eyeball it.

`finishRoute()` only stores `segmentDashed` when mode is `'straight'` **and** the styles aren't uniform — a route nobody toggled mid-draw keeps the exact same minimal shape it has today. The preview block gets the same run-splitting treatment: already-committed segments keep whatever style was active when placed, only the live pending segment follows the toggle — **the curved-route preview is completely untouched**.

## Tests

Six new smoke tests: mixed segments come out as recorded; a toggle that nets out uniform omits `segmentDashed` entirely; undo mid-route pops the right segment style; canceling mid-route doesn't leak state into the next route; a curved route never gets `segmentDashed` even when toggled mid-draw. The mixed-segment test was confirmed to **fail** when the commit-time append is removed — a regression test that doesn't bite isn't worth having.

`npm run typecheck` clean; `npx eslint` — 0 new errors, identical warning count to `main` (verified by diffing against a stash). `npm run build` ✅. **`npm run smoke` 68/68** (was 63).

Manual pass at 1280px and 375px confirms the arrowhead lands correctly on the dashed segment and earlier segments don't flicker when toggling later in the route — screenshots match the coach's exact scenario (solid leg up, dashed break).

## Out of scope

Curved/waypoint per-segment dashing (geometry reason above); editing an already-committed route's dash after the fact; per-segment cap style (a block cap is inherently terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)