### PR TITLE
Route color independent of player-icon color

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import { PlayerStyleEditor } from './PlayerStyleEditor';
+import { RouteColorEditor } from './RouteColorEditor';
 import { TextBoxEditor } from './TextBoxEditor';
 import {
   renderScene,
@@ -92,7 +93,12 @@ type CanvasProps = {
   capStyle: CapStyle;
   /** Solid vs dashed stroke for the next route finished — sticky until changed. */
   dashed: boolean;
+  /** Color for the next route finished — 'auto' matches the origin player;
+   *  a hex value draws every new route in that fixed color instead. */
+  routeColorMode: 'auto' | string;
   deleteRouteMode: boolean;
+  /** Tap a player's icon to recolor just their route. */
+  recolorRouteMode: boolean;
   zoneMode: boolean;
   deleteZoneMode: boolean;
   textMode: boolean;
@@ -141,7 +147,7 @@ export type CanvasHandle = {
 // Component
 // ---------------------------------------------
 export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
-  ({ width, height, drawingMode, drawMode, capStyle, dashed, deleteRouteMode, zoneMode, deleteZoneMode, textMode, snapEnabled, selectedPlayer, setSelectedPlayer, onDrawingComplete, onHistoryChange, onPan, onPinch, id }, ref) => {
+  ({ width, height, drawingMode, drawMode, capStyle, dashed, routeColorMode, deleteRouteMode, recolorRouteMode, zoneMode, deleteZoneMode, textMode, snapEnabled, selectedPlayer, setSelectedPlayer, onDrawingComplete, onHistoryChange, onPan, onPinch, id }, ref) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
     const [paths, setPaths] = useState<PathItem[]>([]);
@@ -221,6 +227,8 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // Icon being edited via the tap-to-customize popover (Select mode only).
     const [editingIconIndex, setEditingIconIndex] = useState<number | null>(null);
+    // Icon whose route is being recolored via the Recolor Route popover.
+    const [editingRouteColorIconIndex, setEditingRouteColorIconIndex] = useState<number | null>(null);
     // Text box being edited via its popover (Select mode, or immediately
     // after placing a new one in Text mode).
     const [editingTextIndex, setEditingTextIndex] = useState<number | null>(null);
@@ -277,9 +285,27 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     const applyIconStyle = useCallback((idx: number, letter: string, color: string, shape: IconShape) => {
       pushSnapshot();
       setPlayerIcons((prev) => { const c = [...prev]; c[idx] = { ...c[idx], letter, color, shape, isSquare: shape === 'square' }; return c; });
-      setPaths((prev) => prev.map((p) => (p.startIconIndex === idx ? { ...p, color } : p)));
+      // A route whose color was explicitly set (independentColor) must not
+      // snap back to the icon's new color — that's the whole point of the
+      // Recolor Route / non-Auto route-color feature. Zones have no such
+      // override, so they keep following the icon unconditionally.
+      setPaths((prev) => prev.map((p) => (p.startIconIndex === idx && !p.independentColor ? { ...p, color } : p)));
       setZones((prev) => prev.map((z) => (z.iconIndex === idx ? { ...z, color } : z)));
     }, [pushSnapshot]);
+
+    /** Recolor every path belonging to one icon's route (mirrors delete
+     *  route's own `startIconIndex === idx` filter, so a route made of
+     *  multiple legs — not reachable via the current UI, but the data model
+     *  allows it — recolors as one unit rather than partially). Picking
+     *  "Auto" reverts to the icon's current color and clears the override,
+     *  which is what lets applyIconStyle resume following it. */
+    const applyRouteColor = useCallback((idx: number, color: string, auto: boolean) => {
+      pushSnapshot();
+      const resolvedColor = auto ? playerIcons[idx]?.color ?? color : color;
+      setPaths((prev) => prev.map((p) => (p.startIconIndex === idx
+        ? { ...p, color: resolvedColor, independentColor: auto ? undefined : true }
+        : p)));
+    }, [pushSnapshot, playerIcons]);
 
     /** Update a text box's content/color/size, or remove it if left blank —
      *  an empty annotation is never worth persisting as clutter. Snapshotting
@@ -711,11 +737,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // its own popover right after placement, so it's excluded from closing
     // itself here — see the textMode branch in handlePointerDown).
     useEffect(() => {
-      if (drawingMode || zoneMode || deleteRouteMode || deleteZoneMode || selectedPlayer) {
+      if (drawingMode || zoneMode || deleteRouteMode || recolorRouteMode || deleteZoneMode || selectedPlayer) {
         setEditingIconIndex(null);
         setEditingTextIndex(null);
       }
-    }, [drawingMode, zoneMode, deleteRouteMode, deleteZoneMode, selectedPlayer]);
+    }, [drawingMode, zoneMode, deleteRouteMode, recolorRouteMode, deleteZoneMode, selectedPlayer]);
 
     // Switching into text mode dismisses the icon popover (they're mutually
     // exclusive tools); leaving text mode dismisses the text popover.
@@ -723,6 +749,14 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       if (textMode) setEditingIconIndex(null);
       else setEditingTextIndex(null);
     }, [textMode]);
+
+    // The Recolor Route popover only makes sense while that mode is active —
+    // toggling it off directly, or switching to any other exclusive mode
+    // (which already resets recolorRouteMode false via DesignerToolbar's
+    // toggle handlers), must close it.
+    useEffect(() => {
+      if (!recolorRouteMode) setEditingRouteColorIconIndex(null);
+    }, [recolorRouteMode]);
 
     // ------------------------------------------
     // Imperative handle
@@ -776,6 +810,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setTextBoxes(prevState.textBoxes);
         setSelectedZoneIndex(null);
         setEditingIconIndex(null);
+        setEditingRouteColorIconIndex(null);
         setEditingTextIndex(null);
       },
       redo: () => {
@@ -795,12 +830,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setTextBoxes(nextState.textBoxes);
         setSelectedZoneIndex(null);
         setEditingIconIndex(null);
+        setEditingRouteColorIconIndex(null);
         setEditingTextIndex(null);
       },
-      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointSegmentDashed([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
+      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorIconIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointSegmentDashed([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
       clearRoutes: () => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex === undefined && p.points.length === 0)); },
       removeRouteForIcon: (iconIndex: number) => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex !== iconIndex)); },
-      loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setTextBoxes(data.textBoxes || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingTextIndex(null); },
+      loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setTextBoxes(data.textBoxes || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorIconIndex(null); setEditingTextIndex(null); },
       // Replaces the whole scene with the template (routes/zones would
       // otherwise reference icon indices that no longer line up once a
       // different formation is stamped over the old one) — same shape as
@@ -815,6 +851,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setSelectedZoneIndex(null);
         setZoneDraft(null);
         setEditingIconIndex(null);
+        setEditingRouteColorIconIndex(null);
         setWaypointPoints([]);
         setWaypointSegmentDashed([]);
         setWaypointIconIndex(null);
@@ -869,10 +906,14 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         capStyle,
         dashed,
         segmentDashed: mixed ? segDash : undefined,
+        // A non-Auto sticky route color was an explicit choice, not just
+        // "whatever the icon happened to be" — it must survive that icon
+        // being recolored later (see applyIconStyle).
+        independentColor: routeColorMode !== 'auto' ? true : undefined,
       };
       setPaths((prev) => [...prev, newPath]);
       if (onDrawingComplete) onDrawingComplete(pts);
-    }, [pushSnapshot, onDrawingComplete, capStyle, dashed]);
+    }, [pushSnapshot, onDrawingComplete, capStyle, dashed, routeColorMode]);
 
     // ------------------------------------------
     // Waypoint: finish
@@ -973,6 +1014,16 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         return;
       }
 
+      // Recolor-route mode — tap any icon with a route to open its
+      // color popover (mirrors delete-route mode above exactly).
+      if (recolorRouteMode) {
+        if (clicked >= 0) {
+          if (iconHasRoute(clicked)) setEditingRouteColorIconIndex(clicked);
+          setHoveredIconIndex(null);
+        }
+        return;
+      }
+
       // Delete-zone mode — tap a zone (or its player) to remove it
       if (deleteZoneMode) {
         let zoneIdx = clicked >= 0 ? findZoneByIcon(clicked) : -1;
@@ -1024,7 +1075,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
             // and dragging out draws the first segment in one motion. A
             // plain tap discards the zero-length pending point on release.
             const icon = playerIcons[clicked];
-            setWaypointColor(icon.color);
+            setWaypointColor(routeColorMode === 'auto' ? icon.color : routeColorMode);
             setWaypointIconIndex(clicked);
             setWaypointPoints([{ x: icon.x, y: icon.y }]);
             setWaypointSegmentDashed([]);
@@ -1352,6 +1403,22 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       }
     }
 
+    // ── Route-color popover placement ─────────────────────────────
+    // Same clamp/flip mechanism as the icon editor above, anchored to the
+    // icon whose route is being recolored.
+    const editingRouteColorIcon = editingRouteColorIconIndex !== null ? playerIcons[editingRouteColorIconIndex] : null;
+    let routeColorEditorLeft = 0;
+    let routeColorEditorTop = 0;
+    if (editingRouteColorIcon) {
+      const POPOVER_W = 230;
+      const POPOVER_H = 190;
+      routeColorEditorLeft = Math.min(Math.max(editingRouteColorIcon.x * width - POPOVER_W / 2, 8), Math.max(8, width - POPOVER_W - 8));
+      routeColorEditorTop = editingRouteColorIcon.y * height + iconRadiusPx + 10;
+      if (routeColorEditorTop + POPOVER_H > height - 8) {
+        routeColorEditorTop = Math.max(8, editingRouteColorIcon.y * height - iconRadiusPx - POPOVER_H - 10);
+      }
+    }
+
     // ── Text-box popover placement ────────────────────────────────
     // Anchored under the text box's bounding box, same clamp/flip logic as
     // the icon editor above.
@@ -1473,6 +1540,23 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
                 setEditingIconIndex(null);
               }}
               onCancel={() => setEditingIconIndex(null)}
+            />
+          </div>
+        )}
+
+        {/* ── Recolor Route popover (tap an icon in Recolor Route mode) ── */}
+        {editingRouteColorIcon && editingRouteColorIconIndex !== null && (
+          <div className="absolute z-20" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
+            <RouteColorEditor
+              key={editingRouteColorIconIndex}
+              initialColor={paths.find((p) => p.startIconIndex === editingRouteColorIconIndex)?.color ?? editingRouteColorIcon.color}
+              initialAuto={!paths.find((p) => p.startIconIndex === editingRouteColorIconIndex)?.independentColor}
+              applyLabel="Apply"
+              onApply={(color, auto) => {
+                applyRouteColor(editingRouteColorIconIndex, color, auto);
+                setEditingRouteColorIconIndex(null);
+              }}
+              onCancel={() => setEditingRouteColorIconIndex(null)}
             />
           </div>
         )}

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet, Shield, Type, ArrowUpRight } from 'lucide-react';
+import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet, Shield, Type, ArrowUpRight, Palette } from 'lucide-react';
 import { PlayerToolbar } from './PlayerToolbar';
 import { resolveRoster, type CustomRoster } from './rosters';
 import { FormationMenu } from './FormationMenu';
+import { RouteColorButton } from './RouteColorButton';
 import type { DrawMode, CapStyle, IconShape, PlayerIcon } from './Canvas';
 import type { PlayMetadata } from '../../types/play';
 
@@ -27,8 +28,17 @@ interface DesignerToolbarProps {
   /** Solid vs dashed stroke for the next route finished — sticky until changed. */
   dashed: boolean;
   setDashed: (dashed: boolean) => void;
+  /** Color for the next route finished — 'auto' matches the origin player
+   *  (today's only behavior); a hex value draws every new route in that
+   *  fixed color instead, independent of player color. Sticky until changed. */
+  routeColorMode: 'auto' | string;
+  setRouteColorMode: (mode: 'auto' | string) => void;
   deleteRouteMode: boolean;
   setDeleteRouteMode: (mode: boolean) => void;
+  /** Tap a player's icon to recolor just their route, independent of the
+   *  sticky default above and any other route. */
+  recolorRouteMode: boolean;
+  setRecolorRouteMode: (mode: boolean) => void;
   zoneMode: boolean;
   setZoneMode: (mode: boolean) => void;
   deleteZoneMode: boolean;
@@ -71,8 +81,12 @@ export function DesignerToolbar({
   setCapStyle,
   dashed,
   setDashed,
+  routeColorMode,
+  setRouteColorMode,
   deleteRouteMode,
   setDeleteRouteMode,
+  recolorRouteMode,
+  setRecolorRouteMode,
   zoneMode,
   setZoneMode,
   deleteZoneMode,
@@ -105,6 +119,7 @@ export function DesignerToolbar({
   const selectMode = () => {
     setDrawingMode(false);
     setDeleteRouteMode(false);
+    setRecolorRouteMode(false);
     setZoneMode(false);
     setDeleteZoneMode(false);
     setTextMode(false);
@@ -114,6 +129,7 @@ export function DesignerToolbar({
   const pickDraw = (mode: DrawMode) => {
     setDrawingMode(true);
     setDeleteRouteMode(false);
+    setRecolorRouteMode(false);
     setZoneMode(false);
     setDeleteZoneMode(false);
     setTextMode(false);
@@ -124,31 +140,38 @@ export function DesignerToolbar({
   const toggleDeleteRouteMode = () => {
     const next = !deleteRouteMode;
     setDeleteRouteMode(next);
-    if (next) { setDrawingMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setRecolorRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+  };
+
+  const toggleRecolorRouteMode = () => {
+    const next = !recolorRouteMode;
+    setRecolorRouteMode(next);
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleZoneMode = () => {
     const next = !zoneMode;
     setZoneMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleDeleteZoneMode = () => {
     const next = !deleteZoneMode;
     setDeleteZoneMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleTextMode = () => {
     const next = !textMode;
     setTextMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); onSelectPlayer(null); }
   };
 
   const handlePlayerSelect = (player: { letter: string; color: string; isSquare?: boolean; shape?: IconShape } | null) => {
     if (player) {
       setDrawingMode(false);
       setDeleteRouteMode(false);
+      setRecolorRouteMode(false);
       setZoneMode(false);
       setDeleteZoneMode(false);
       setTextMode(false);
@@ -255,6 +278,11 @@ export function DesignerToolbar({
           <span className={label}>{dashed ? 'Dotted' : 'Solid'}</span>
         </button>
 
+        {/* Route color: Auto (match player, today's only past behavior) or a
+            fixed color for every new route — e.g. black routes with
+            color-coded positions. Sticky until changed, like capStyle/dashed. */}
+        <RouteColorButton value={routeColorMode} onChange={setRouteColorMode} fullWidth={vertical} />
+
         {/* Remove Route for a player */}
         <button
           onClick={toggleDeleteRouteMode}
@@ -263,6 +291,19 @@ export function DesignerToolbar({
         >
           <RouteOff className="h-4 w-4" />
           <span className={label}>Remove Route</span>
+        </button>
+
+        {/* Recolor Route for a player: tap their icon to set just that route's
+            color, independent of the sticky default above. Not destructive,
+            so it uses the standard active (primary) styling, not Remove
+            Route's amber warning color. */}
+        <button
+          onClick={toggleRecolorRouteMode}
+          title="Recolor a player's route (tap the player)"
+          className={`${tool} ${recolorRouteMode ? active : inactive}`}
+        >
+          <Palette className="h-4 w-4" />
+          <span className={label}>Recolor Route</span>
         </button>
 
         {playType === 'offense' && (
@@ -360,15 +401,16 @@ export function DesignerToolbar({
       </div>
 
       {/* Active mode label */}
-      {(activeDraw || deleteRouteMode || zoneMode || deleteZoneMode || textMode) && (
+      {(activeDraw || deleteRouteMode || recolorRouteMode || zoneMode || deleteZoneMode || textMode) && (
         <p className="text-[10px] text-chalk/50 px-1 flex items-center gap-1">
           <span className={`font-semibold ${(deleteRouteMode || deleteZoneMode) ? 'text-amber-400' : 'text-primary'}`}>
             {deleteRouteMode && 'Remove route mode'}
+            {recolorRouteMode && 'Recolor route mode'}
             {deleteZoneMode && 'Remove zone mode'}
             {zoneMode && 'Zone mode'}
             {textMode && 'Text mode'}
-            {!deleteRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'straight' && 'Straight line mode'}
-            {!deleteRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'waypoint' && 'Curved route mode'}
+            {!deleteRouteMode && !recolorRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'straight' && 'Straight line mode'}
+            {!deleteRouteMode && !recolorRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'waypoint' && 'Curved route mode'}
           </span>
           {activeDraw && (
             <span>

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -39,7 +39,13 @@ export function PlayDesigner() {
   // can end in a block T-cap and be dashed at the same time.
   const [capStyle, setCapStyle] = useState<CapStyle>('arrow');
   const [dashed, setDashed] = useState(false);
+  // Route color for the next route finished — 'auto' matches the origin
+  // icon (today's only behavior); a hex value draws every new route in that
+  // fixed color instead, independent of player color. Session-only, same as
+  // capStyle/dashed above.
+  const [routeColorMode, setRouteColorMode] = useState<'auto' | string>('auto');
   const [deleteRouteMode, setDeleteRouteMode] = useState(false);
+  const [recolorRouteMode, setRecolorRouteMode] = useState(false);
   const [zoneMode, setZoneMode] = useState(false);
   const [deleteZoneMode, setDeleteZoneMode] = useState(false);
   const [textMode, setTextMode] = useState(false);
@@ -534,8 +540,12 @@ export function PlayDesigner() {
             setCapStyle={setCapStyle}
             dashed={dashed}
             setDashed={setDashed}
+            routeColorMode={routeColorMode}
+            setRouteColorMode={setRouteColorMode}
             deleteRouteMode={deleteRouteMode}
             setDeleteRouteMode={setDeleteRouteMode}
+            recolorRouteMode={recolorRouteMode}
+            setRecolorRouteMode={setRecolorRouteMode}
             zoneMode={zoneMode}
             setZoneMode={setZoneMode}
             deleteZoneMode={deleteZoneMode}
@@ -574,7 +584,9 @@ export function PlayDesigner() {
               drawMode={drawMode}
               capStyle={capStyle}
               dashed={dashed}
+              routeColorMode={routeColorMode}
               deleteRouteMode={deleteRouteMode}
+              recolorRouteMode={recolorRouteMode}
               zoneMode={zoneMode}
               deleteZoneMode={deleteZoneMode}
               textMode={textMode}
@@ -638,8 +650,12 @@ export function PlayDesigner() {
           setCapStyle={setCapStyle}
           dashed={dashed}
           setDashed={setDashed}
+          routeColorMode={routeColorMode}
+          setRouteColorMode={setRouteColorMode}
           deleteRouteMode={deleteRouteMode}
           setDeleteRouteMode={setDeleteRouteMode}
+          recolorRouteMode={recolorRouteMode}
+          setRecolorRouteMode={setRecolorRouteMode}
           zoneMode={zoneMode}
           setZoneMode={setZoneMode}
           deleteZoneMode={deleteZoneMode}

--- a/src/components/designer/PlayerStyleEditor.tsx
+++ b/src/components/designer/PlayerStyleEditor.tsx
@@ -6,8 +6,9 @@ import type { IconShape } from './Canvas';
 export const MAX_PLAYER_LABEL_LENGTH = 5;
 
 /** Every color used across the offense + defense preset rosters, offered as
- *  one-tap swatches. The native color input below covers everything else. */
-const SWATCH_COLORS = [
+ *  one-tap swatches. The native color input below covers everything else.
+ *  Exported so RouteColorEditor's swatch grid matches this one exactly. */
+export const SWATCH_COLORS = [
   '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
   '#8B5CF6', '#EC4899', '#6366F1', '#000000',
   '#F97316', '#14B8A6', '#84CC16', '#E11D48',

--- a/src/components/designer/RouteColorButton.tsx
+++ b/src/components/designer/RouteColorButton.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { RouteColorEditor } from './RouteColorEditor';
+
+const DEFAULT_PREVIEW_COLOR = '#3B82F6';
+
+interface RouteColorButtonProps {
+  /** 'auto' = new routes match their player's color (today's only behavior).
+   *  Anything else is a hex color new routes are drawn with instead. */
+  value: 'auto' | string;
+  onChange: (value: 'auto' | string) => void;
+  /** Full-width left-aligned trigger for the sidebar layout. */
+  fullWidth?: boolean;
+}
+
+/**
+ * Toolbar control for the sticky "next route" color default. Portal-anchored
+ * to the trigger button exactly like FormationMenu's popover — same reason:
+ * the toolbar row scrolls horizontally, which forces overflow-y: auto too,
+ * silently clipping an `absolute`-positioned popover nested inside it.
+ */
+export function RouteColorButton({ value, onChange, fullWidth = false }: RouteColorButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const openedAt = Date.now();
+    const updatePosition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const left = Math.max(8, Math.min(rect.left, window.innerWidth - 230 - 8));
+      const openUp = rect.bottom > window.innerHeight / 2;
+      setCoords(
+        openUp
+          ? { left, bottom: window.innerHeight - rect.top + 4 }
+          : { left, top: rect.bottom + 4 },
+      );
+    };
+    updatePosition();
+    const close = () => setOpen(false);
+    const onScroll = () => {
+      if (Date.now() - openedAt < 300) { updatePosition(); return; }
+      close();
+    };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const btnBase = 'flex items-center rounded-lg transition-colors shrink-0';
+  const inactive = 'text-chalk/60 hover:text-chalk hover:bg-white/10';
+  const active = 'bg-primary/20 text-primary';
+  const isAuto = value === 'auto';
+
+  return (
+    <div className={`relative shrink-0 ${fullWidth ? 'w-full' : ''}`}>
+      <button
+        ref={triggerRef}
+        onClick={() => setOpen((o) => !o)}
+        title="Route color: Auto (match player) or a fixed color for every new route"
+        className={`${btnBase} text-xs font-medium ${
+          fullWidth ? 'w-full justify-start gap-2 px-2.5 py-2' : 'justify-center px-2.5 py-2 gap-1.5'
+        } ${open ? active : inactive}`}
+      >
+        {isAuto ? (
+          <span
+            className="w-4 h-4 rounded-full shrink-0"
+            style={{ background: 'conic-gradient(#3B82F6, #10B981, #F59E0B, #EF4444, #8B5CF6, #3B82F6)' }}
+          />
+        ) : (
+          <span className="w-4 h-4 rounded-full shrink-0" style={{ backgroundColor: value }} />
+        )}
+        <span className={fullWidth ? 'whitespace-nowrap' : 'hidden sm:inline whitespace-nowrap'}>
+          {isAuto ? 'Auto' : 'Route Color'}
+        </span>
+      </button>
+
+      {open && coords && createPortal(
+        <>
+          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          <div className="fixed z-40" style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}>
+            <RouteColorEditor
+              initialColor={isAuto ? DEFAULT_PREVIEW_COLOR : value}
+              initialAuto={isAuto}
+              applyLabel="Set"
+              onApply={(color, auto) => { onChange(auto ? 'auto' : color); setOpen(false); }}
+              onCancel={() => setOpen(false)}
+            />
+          </div>
+        </>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/src/components/designer/RouteColorEditor.tsx
+++ b/src/components/designer/RouteColorEditor.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { SWATCH_COLORS } from './PlayerStyleEditor';
+
+type RouteColorEditorProps = {
+  initialColor: string;
+  initialAuto: boolean;
+  applyLabel: string;
+  onApply: (color: string, auto: boolean) => void;
+  onCancel: () => void;
+};
+
+/**
+ * Small color-only picker for route lines — a sibling to PlayerStyleEditor,
+ * not a generalized version of it: routes have no label or shape, and adding
+ * an "Auto" concept to the icon editor (which always writes a real color)
+ * would only complicate a component that already does its one job well.
+ *
+ * Used in two places with two different positioning shells: the toolbar's
+ * sticky "Route Color" button (portaled like FormationMenu's popover) and
+ * the canvas-anchored Recolor Route popover (positioned like the icon-edit
+ * popover). Both render this same card.
+ */
+export function RouteColorEditor({ initialColor, initialAuto, applyLabel, onApply, onCancel }: RouteColorEditorProps) {
+  const [auto, setAuto] = useState(initialAuto);
+  const [color, setColor] = useState(initialColor);
+
+  const apply = () => onApply(color, auto);
+
+  return (
+    <div
+      className="bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-3 w-[230px]"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <button
+        onClick={() => setAuto(true)}
+        title="Match each route to its player's color"
+        aria-pressed={auto}
+        className={`w-full flex items-center gap-2 px-2 py-1.5 mb-3 rounded-lg border-2 text-xs font-medium transition-colors ${
+          auto ? 'border-primary bg-primary/10 text-chalk' : 'border-transparent text-chalk/70 hover:bg-white/10'
+        }`}
+      >
+        <span
+          className="w-5 h-5 rounded-full shrink-0"
+          style={{ background: 'conic-gradient(#3B82F6, #10B981, #F59E0B, #EF4444, #8B5CF6, #3B82F6)' }}
+        />
+        Auto (match player)
+      </button>
+
+      <div className="grid grid-cols-6 gap-1.5 mb-3">
+        {SWATCH_COLORS.map((c) => (
+          <button
+            key={c}
+            onClick={() => { setColor(c); setAuto(false); }}
+            title={c}
+            aria-label={`Color ${c}`}
+            className={`w-7 h-7 rounded-full border-2 transition-transform ${
+              !auto && color.toLowerCase() === c.toLowerCase() ? 'border-primary scale-110' : 'border-transparent hover:scale-105'
+            }`}
+            style={{ backgroundColor: c }}
+          />
+        ))}
+      </div>
+
+      <label className="flex items-center gap-2 mb-3 text-xs text-chalk/70 cursor-pointer">
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => { setColor(e.target.value); setAuto(false); }}
+          aria-label="Custom route color"
+          className="w-7 h-7 rounded cursor-pointer bg-transparent border border-chalk/20 p-0.5"
+        />
+        More colors…
+      </label>
+
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-xs font-medium text-chalk/70 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={apply}
+          className="px-3 py-1.5 text-xs font-semibold text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+        >
+          {applyLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/renderPlayScene.ts
+++ b/src/lib/renderPlayScene.ts
@@ -93,6 +93,13 @@ export type PathItem = {
    *  forcing a split to land exactly on one distorts the silhouette). See
    *  resolveSegmentDash(). */
   segmentDashed?: boolean[];
+  /** True once this path's color was explicitly set — via a non-Auto sticky
+   *  route-color default at draw time, or the Recolor Route popover — and
+   *  must survive the origin icon being recolored later. Omitted/false =
+   *  today's only behavior: the path's color always follows its icon (see
+   *  applyIconStyle in Canvas.tsx). No migration needed — every existing
+   *  saved play has this omitted and keeps auto-syncing exactly as before. */
+  independentColor?: boolean;
 };
 
 /** The per-segment dash style to actually render/edit, honoring the

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -22,7 +22,7 @@ const AUTH_STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split('.')[0]}-aut
 const TAP_GAP = 450;
 
 type CanvasState = {
-  paths: Array<{ points: { x: number; y: number }[]; color: string; startIconIndex?: number; mode: string; capStyle?: string; dashed?: boolean; segmentDashed?: boolean[] }>;
+  paths: Array<{ points: { x: number; y: number }[]; color: string; startIconIndex?: number; mode: string; capStyle?: string; dashed?: boolean; segmentDashed?: boolean[]; independentColor?: boolean }>;
   playerIcons: Array<{ x: number; y: number; letter: string; color: string; shape?: string }>;
   zones: Array<{ iconIndex: number; cx: number; cy: number; rx: number; ry: number; color: string }>;
   textBoxes: Array<{ x: number; y: number; text: string; color: string; fontSize: number }>;
@@ -2498,4 +2498,271 @@ test('saved roster: signed out, roster editing is not offered', async ({ page })
   await openDesigner(page);
   await expect(btn(page, 'Player Q')).toBeVisible();
   await expect(btn(page, 'Edit your players')).toHaveCount(0);
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Route color independent of player-icon color. A route's color used to have
+ * exactly one source — the origin icon's color at draw time — and got
+ * silently re-baked forever: recoloring the icon later always overwrote the
+ * route's color too. Feedback: rec leagues want routes to keep matching the
+ * player (leave this alone); travel/NFL flag teams want positions
+ * color-coded but every route black, with one "hot route" in red.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const ROUTE_COLOR_TRIGGER = 'Route color: Auto (match player) or a fixed color for every new route';
+
+test('route color: sticky non-Auto default survives the icon being recolored later', async ({ page }) => {
+  await openDesigner(page);
+
+  // Set the sticky default to a fixed color (black) before drawing.
+  await btn(page, ROUTE_COLOR_TRIGGER).click();
+  await page.getByLabel('Color #000000').click();
+  await page.getByRole('button', { name: 'Set' }).click();
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  expect(state.paths[0].color).toBe('#000000');
+  expect(state.paths[0].independentColor).toBe(true);
+  // The icon itself is untouched — only the sticky route default changed.
+  expect(state.playerIcons[0].color).not.toBe('#000000');
+
+  // Recoloring the icon afterward must NOT drag the route's color with it —
+  // this is the actual regression guard for the applyIconStyle fix.
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByLabel('Color #E11D48').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.playerIcons[0].color).toBe('#E11D48');
+  expect(state.paths[0].color).toBe('#000000');
+});
+
+test('route color: Auto (default) still follows the icon, including after a later recolor', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe(state.playerIcons[0].color);
+  expect(state.paths[0].independentColor).toBeFalsy();
+
+  // Pins down the "still syncs when not overridden" baseline explicitly —
+  // nothing previously asserted this for routes, only for zones.
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByLabel('Color #10B981').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.playerIcons[0].color).toBe('#10B981');
+  expect(state.paths[0].color).toBe('#10B981');
+});
+
+test('route color: Recolor Route mode changes only the tapped player\'s route', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spotQ = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spotQ.x, spotQ.y);
+  await btn(page, 'Player R').click();
+  const spotR = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(spotR.x, spotR.y);
+
+  let state = await canvasState(page);
+  await btn(page, 'Straight Line Route').click();
+  const iconQ = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(iconQ.x, iconQ.y);
+  await page.waitForTimeout(TAP_GAP);
+  const endQ = await canvasPoint(page, 0.3, 0.4);
+  await page.mouse.click(endQ.x, endQ.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  const iconR = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(iconR.x, iconR.y);
+  await page.waitForTimeout(TAP_GAP);
+  const endR = await canvasPoint(page, 0.6, 0.4);
+  await page.mouse.click(endR.x, endR.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  state = await canvasState(page);
+  const rOriginalColor = state.paths[1].color;
+
+  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await page.mouse.click(iconQ.x, iconQ.y);
+  await expect(page.getByLabel('Custom route color')).toBeVisible();
+  await page.getByLabel('Color #E11D48').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe('#E11D48');
+  expect(state.paths[0].independentColor).toBe(true);
+  // R's route, drawn from a different icon, is untouched.
+  expect(state.paths[1].color).toBe(rOriginalColor);
+  expect(state.paths[1].independentColor).toBeFalsy();
+});
+
+test('route color: picking Auto in the popover reverts the override and resumes syncing', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  // Override to red via Recolor Route mode.
+  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await page.mouse.click(icon.x, icon.y);
+  await page.getByLabel('Color #E11D48').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+  state = await canvasState(page);
+  expect(state.paths[0].independentColor).toBe(true);
+
+  // Still in Recolor Route mode from above (Apply doesn't exit the mode) —
+  // tapping the icon again reopens the popover; re-clicking the toggle
+  // button here would instead turn the mode OFF.
+  await page.mouse.click(icon.x, icon.y);
+  await page.getByRole('button', { name: 'Auto (match player)' }).click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe(state.playerIcons[0].color);
+  expect(state.paths[0].independentColor).toBeFalsy();
+
+  // And recoloring the icon now propagates again — proves the flag was
+  // genuinely cleared, not just visually reset once.
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByLabel('Color #F59E0B').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe('#F59E0B');
+});
+
+test('route color: Recolor Route mode is mutually exclusive with other tools', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  const state = await canvasState(page);
+
+  await btn(page, 'Straight Line Route').click();
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.4);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  // Enter Recolor Route mode and confirm tapping the icon opens the ROUTE
+  // color popover, not the icon-style popover.
+  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Custom route color')).toBeVisible();
+  await expect(page.getByLabel('Player label')).toHaveCount(0);
+
+  // Switching to Select mode must close that popover AND leave recolor mode,
+  // so the SAME tap now opens the icon-style popover instead.
+  await btn(page, 'Select / Move').click();
+  await expect(page.getByLabel('Custom route color')).toHaveCount(0);
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await expect(page.getByLabel('Custom route color')).toHaveCount(0);
+});
+
+test('route color: overriding a route leaves the icon\'s zone color unaffected', async ({ page }) => {
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'defense', exact: true }).click();
+
+  await btn(page, 'Player S').click();
+  const spot = await canvasPoint(page, 0.5, 0.55);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  // A route AND a zone from the same defender.
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.5, 0.35);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  await btn(page, 'Draw a zone of responsibility (drag from a player)').click();
+  await page.mouse.move(icon.x, icon.y);
+  await page.mouse.down();
+  await page.mouse.move(icon.x + 90, icon.y + 60, { steps: 8 });
+  await page.mouse.up();
+
+  state = await canvasState(page);
+  const originalIconColor = state.playerIcons[0].color;
+  expect(state.zones[0].color).toBe(originalIconColor);
+
+  // Override just the route to black.
+  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await page.mouse.click(icon.x, icon.y);
+  await page.getByLabel('Color #000000').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe('#000000');
+  expect(state.zones[0].color).toBe(originalIconColor);
+
+  // Recoloring the icon: zone follows (as always), route keeps its override.
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByLabel('Color #6366F1').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.playerIcons[0].color).toBe('#6366F1');
+  expect(state.zones[0].color).toBe('#6366F1');
+  expect(state.paths[0].color).toBe('#000000');
 });


### PR DESCRIPTION
## Feedback this addresses

> "It would be nice to be able to change the color of the route lines. In the rec leagues (very few practices) I like it as is to help them visualize their routes. With my NFL flag teams I like to have the positions be color coded but the routes be black. Then the hot route is colored red."

A route's color had exactly one source: the origin icon's color at draw time. Worse, it was re-baked forever — `applyIconStyle` unconditionally overwrote the color of every path tied to an icon whenever that icon was recolored, with no opt-out.

## Two additive pieces

**1. Sticky "Route Color" toolbar control** — `Auto` (today's only behavior, kept as the default) or a fixed color for every new route regardless of player color. Session-only, like the existing Solid/Dotted and Route/Block toggles. Portaled to the trigger button exactly like `FormationMenu`'s popover already is, for the same reason: the toolbar row scrolls horizontally, which forces `overflow-y: auto` and silently clips an `absolute`-positioned popover nested inside it.

**2. "Recolor Route" mode** — tap a player's icon to recolor just their route, mirroring the existing "Remove Route" mode exactly. This codebase has **no click-on-the-polyline hit-testing anywhere** — routes can be smoothed curves — and building point-to-curve distance math from scratch would be a materially bigger, riskier change than this feature needs. Popover positioning reuses the icon-edit popover's clamp/flip math verbatim.

## Data model

`PathItem.independentColor?: boolean` — omitted/false = the old always-sync behavior, so every existing saved play needs no migration. `applyIconStyle` gets one added condition. Zones are untouched — not part of the ask, still follow their icon unconditionally.

## The lockstep bug this caught (worth flagging)

Adding a new exclusive mode meant every *existing* mode toggle needed to reset it too, plus writing its own toggle that resets the other five. I grepped and cross-checked the lockstep programmatically rather than trusting the by-eye list — which caught a real 7th site the initial pass missed: `handlePlayerSelect` (choosing a roster chip) already reset every other mode except this new one. Same class of bug the last two designer features ran into; still worth re-verifying by grep every time rather than assuming a checklist is complete.

## New component

`RouteColorEditor.tsx` is a small sibling to `PlayerStyleEditor`, not a generalized version of it — routes have no label or shape, only color, plus an explicit "Auto (match player)" choice `PlayerStyleEditor` has no use for. `SWATCH_COLORS` is now exported from `PlayerStyleEditor` so both pickers draw from the identical 12-swatch set instead of a second copy that could drift.

## Tests

Six new smoke tests, extending `CanvasState.paths` with `independentColor`:
- a non-Auto sticky default **survives the icon being recolored afterward** — the actual regression guard, confirmed to fail when the `applyIconStyle` condition is reverted
- Auto still propagates on recolor (pins down a baseline nothing previously asserted)
- Recolor Route mode changes only the tapped player's route
- picking Auto in the popover reverts and resumes syncing
- Recolor Route mode is mutually exclusive with other tools
- a route override leaves the same icon's zone color unaffected

Two of the six initially failed because they placed an icon but never actually drew a route before asserting on `paths[0]` — fixed by adding the missing draw step already present in the working tests.

## Verification

Browser-verified at 1280px and 375px against the coach's literal scenario: two color-coded icons, Route Color set to black, both routes draw black, then Recolor Route marks just one red while the other stays black.

`npm run typecheck` clean; `npx eslint` 0 new errors (one additional pre-existing-category warning from exporting `SWATCH_COLORS`, accepted over duplicating the swatch list); `npm run build` ✅; **`npm run smoke` 74/74** (was 68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)