### PR TITLE
Fix: non-admin users had no way to delete their own plays

### DIFF
--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Book, Plus, Filter, Trash2, LogIn, Wand2 } from 'lucide-react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
-import { checkIsAdmin } from '../../lib/admin';
 import { AddToPlaybookButton } from './AddToPlaybookButton'; // Adjust path as needed
 import { PlayVoteButton } from './PlayVoteButton';
 import { getSafeErrorMessage } from '../../lib/errors';
@@ -208,7 +207,6 @@ export function PlaysPage() {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'offense' | 'defense' | 'special_teams' | 'all'>('all');
   const [votedPlayIds, setVotedPlayIds] = useState<Set<string>>(new Set());
-  const [isAdmin, setIsAdmin] = useState(false);
   const [user, setUser] = useState<import('@supabase/supabase-js').User | null>(null);
   const [totalPlayCount, setTotalPlayCount] = useState(0);
   const [isPro, setIsPro] = useState(false);
@@ -225,7 +223,6 @@ export function PlaysPage() {
 
         if (currentUser) {
           // User is authenticated - show their plays
-          checkIsAdmin(currentUser.id).then(setIsAdmin);
 
           // Total play count + Pro status for the free-tier usage nudge (B-22).
           // Queried directly (not via useEntitlement()) since that hook's own
@@ -499,15 +496,18 @@ export function PlaysPage() {
               />
             )}
 
-            {isAdmin && (
-              <button
-                onClick={() => handleDeletePlay(play.id)}
-                className="flex items-center gap-1 px-3 py-2 text-sm bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
-                title="Delete Play"
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
-            )}
+            {/* This whole list is already scoped to the signed-in user's own
+                plays (fetchPlays queries .eq('user_id', currentUser.id)) —
+                Community plays render via the separate PlayLibrary component,
+                never here. So every play card reaching this point is already
+                owned by `user`; no admin/ownership gate is needed. */}
+            <button
+              onClick={() => handleDeletePlay(play.id)}
+              className="flex items-center gap-1 px-3 py-2 text-sm bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
+              title="Delete Play"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
           </div>
         </>
       ) : (

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2045,6 +2045,59 @@ test('My Plays: card shows a "Use as Template" link to /designer?template=<id>',
   await expect(page.locator('a[href="/designer?template=my-play-1"]')).toBeVisible();
 });
 
+test('My Plays: a non-admin owner can delete their own play', async ({ page }) => {
+  // Regression test: "Delete Play" used to be gated on isAdmin instead of
+  // ownership, so a regular coach had no way to delete a play they made —
+  // even though the DB's RLS policy ("Users can manage their own plays")
+  // already permitted it. This page's query is always scoped to the
+  // signed-in user's own plays (see fetchPlays' .eq('user_id', ...)), so
+  // ownership needs no separate check — the button just needs to render.
+  const userJson = {
+    id: '88888888-8888-8888-8888-888888888888',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  // Explicitly non-admin.
+  await page.route('**/rest/v1/admin_users**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'free' }) }));
+
+  let deleteRequestUrl: string | null = null;
+  await page.route('**/rest/v1/plays**', (route) => {
+    const req = route.request();
+    if (req.method() === 'HEAD') {
+      return route.fulfill({ status: 200, headers: { 'content-range': '*/1', 'access-control-expose-headers': 'content-range' }, body: '' });
+    }
+    if (req.method() === 'DELETE') {
+      deleteRequestUrl = req.url();
+      return route.fulfill({ status: 204, body: '' });
+    }
+    return route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ id: 'my-play-1', name: 'Trips Right', type: 'offense', thumbnail: null, is_public: false, upvotes: 0, user_id: userJson.id }]),
+    });
+  });
+
+  await page.goto('/plays');
+  const deleteButton = page.getByTitle('Delete Play');
+  await expect(deleteButton).toBeVisible();
+
+  page.once('dialog', (dialog) => dialog.accept());
+  await deleteButton.click();
+
+  await expect.poll(() => deleteRequestUrl).not.toBeNull();
+  expect(deleteRequestUrl).toContain('id=eq.my-play-1');
+});
+
 test('PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usage nudge', async ({ page }) => {
   // Regression test for B-23: PlaybooksPage used to resolve its user via
   // getSession() + onAuthStateChange *and* a separate useEntitlement() call


### PR DESCRIPTION
## The bug

"Delete Play" was gated on `isAdmin` instead of ownership. The database's RLS policy already permitted an owner to delete their own rows —

```sql
CREATE POLICY "Users can manage their own plays"
  ON plays FOR ALL
  USING (auth.uid() = user_id)
  WITH CHECK (auth.uid() = user_id);
```

— but the only delete control in the UI required admin status. A regular coach could create, edit, and use their plays, but had no way to delete one.

## Why the fix needs no ownership check

`PlaysPage.tsx`'s `fetchPlays` query is already scoped to `.eq('user_id', currentUser.id)` — Community plays render through the separate `PlayLibrary` component, never here. So every play card that reaches the delete button is already the signed-in user's own. The `isAdmin` gate was simply checking the wrong thing — likely a leftover from before `PlayLibrary` was extracted out (there's already a comment in this file referencing that older combined-list design).

Removed the `isAdmin` state and its `checkIsAdmin()` call entirely rather than leave it around unused — it had no other purpose on this page.

## Verification

New smoke test signs in as an **explicitly non-admin** user (`admin_users` stubbed to `null`) and asserts:
- the Delete Play button is visible
- clicking it (after accepting the `confirm()` dialog) sends a real `DELETE` request with the right `id` filter

Confirmed to **fail** when the button is hidden again, reproducing the original bug — a regression test that doesn't bite isn't worth having.

`npm run typecheck` clean; `npx eslint` 0 new errors (3 pre-existing `any` warnings, unchanged, just shifted line numbers); `npm run build` ✅; **`npm run smoke` 75/75** (was 74).

Browser-verified: a signed-in non-admin "Coach" sees the delete button on both of their own plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)