### PR TITLE
Fix: playbook play count always showed 1 regardless of actual plays

### DIFF
--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -130,9 +130,15 @@ export function PlaybooksPage() {
 
       if (error) throw error;
 
+      // playbook_plays(count) is PostgREST's aggregate-embed syntax: it always
+      // returns a ONE-element array wrapping the aggregate object — e.g.
+      // [{ count: 7 }] — never one element per play. `.length` was therefore
+      // always 1 for any playbook with at least one play, regardless of how
+      // many it actually had. See PlaybookPackLibrary.tsx for the same
+      // pattern read correctly.
       const playbooksWithCount = playbooks.map(playbook => ({
         ...playbook,
-        play_count: playbook.playbook_plays.length || 0
+        play_count: playbook.playbook_plays?.[0]?.count ?? 0
       }));
 
       setPlaybooks(playbooksWithCount);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2149,6 +2149,48 @@ test('PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usag
   await expect(page.getByText('1 of 2 free playbooks used.')).toBeVisible();
 });
 
+test('PlaybooksPage: play count reflects the actual number of plays, not always 1', async ({ page }) => {
+  // Regression test: `playbook_plays(count)` is PostgREST's aggregate-embed
+  // syntax — it always returns a ONE-element array wrapping the aggregate
+  // object (e.g. [{ count: 7 }]), never one element per play. Reading
+  // `.length` off that array was therefore always 1 for any playbook with at
+  // least one play, no matter how many it actually had. The fixture below
+  // uses the REAL shape — [{ count: N }] — unlike the usage-nudge test above,
+  // whose `playbook_plays: []` fixture happens to read as 0 under the old
+  // buggy code too, which is exactly how this slipped through unnoticed.
+  const userJson = {
+    id: '55555555-5555-5555-5555-555555555555',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'pro' }) }));
+  await page.route('**/rest/v1/user_preferences**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'pb-1', name: 'Game Plan', description: '', created_at: '2025-09-01T00:00:00Z', user_id: userJson.id, playbook_plays: [{ count: 7 }] },
+        { id: 'pb-2', name: 'Empty Playbook', description: '', created_at: '2025-09-02T00:00:00Z', user_id: userJson.id, playbook_plays: [{ count: 0 }] },
+      ]),
+    }),
+  );
+
+  await page.goto('/playbooks');
+  await expect(page.getByText('7 plays')).toBeVisible();
+  await expect(page.getByText('0 plays')).toBeVisible();
+  await expect(page.getByText('1 plays')).toHaveCount(0);
+});
+
 /* ────────────────────────────────────────────────────────────────────────────
  * Admin Dashboard — entitlement management.
  *


### PR DESCRIPTION
## The bug

`playbook_plays(count)` is PostgREST's aggregate-embed syntax — it always returns a **one-element array wrapping the aggregate object**, e.g. `[{ count: 7 }]`, never one element per play. `PlaybooksPage.tsx` read `.length` off that array, which is therefore `1` for any playbook with at least one play, no matter how many it actually had. It would even misreport a genuinely empty playbook as having 1 play in some paths, since PostgREST returns `[{ count: 0 }]` rather than `[]`.

## The fix

`PlaybookPackLibrary.tsx` already queries the identical shape and reads it correctly:

```ts
play_count: pb.playbook_plays?.[0]?.count ?? 0
```

Used that as the confirmed-correct pattern rather than guessing at PostgREST's contract — this project already had a working example of the right way to read this exact query.

## Why this shipped unnoticed

The existing B-22/B-23 usage-nudge test a few lines above the new one stubs `playbook_plays: []` — which isn't the real PostgREST response shape at all. `[].length` and `[{count:0}]?.[0]?.count` both evaluate to `0`, so that fixture passed identically under the buggy code and the fix. The new test uses a realistic fixture (`[{ count: N }]` for `N > 1`) to actually exercise the bug.

## Verification

Confirmed the new test **fails** when reverted to `.length || 0` — a regression test that doesn't bite isn't worth having.

`npm run typecheck` clean; `npx eslint` 0 new errors (4 pre-existing warnings, unchanged); `npm run build` ✅; **`npm run smoke` 76/76** (was 75).

Browser-verified: three playbooks with counts 12, 3, and 0 all render their own correct number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)