### PR TITLE
Add drag-to-reorder for plays within a playbook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "youth-football-playbook-pro",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@supabase/supabase-js": "^2.56.0",
         "clsx": "^2.1.0",
         "date-fns": "^3.3.1",
@@ -364,6 +367,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4175,6 +4231,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "verify": "npm run typecheck && npm run lint && npm run build && npm run smoke"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@supabase/supabase-js": "^2.56.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -2,6 +2,9 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   BookOpen,
   Plus,
@@ -17,7 +20,8 @@ import {
   FileText,
   LayoutGrid,
   Lock,
-  Watch
+  Watch,
+  GripVertical
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
@@ -63,6 +67,11 @@ export function PlaybooksPage() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  // Layout for the plays-inside-a-playbook panel specifically — separate
+  // from the unrelated `viewMode` toggle above, which only affects the
+  // left playbooks-list panel.
+  const [playsLayout, setPlaysLayout] = useState<'grid' | 'list'>('grid');
+  const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
@@ -271,6 +280,50 @@ export function PlaybooksPage() {
     } catch (error) {
       console.error('Error removing play from playbook:', error);
       alert('Failed to remove play from playbook. Please try again.');
+    }
+  };
+
+  // Reorder plays within the selected playbook (List view drag-and-drop).
+  // playbook_plays has UNIQUE (playbook_id, order_position), so the affected
+  // rows are bumped to temporary negative positions first (phase A) before
+  // being written to their final positions (phase B) — otherwise a direct
+  // write can collide with another affected row's current position.
+  const handleReorderPlays = async (oldIndex: number, newIndex: number) => {
+    if (!selectedPlaybook || oldIndex === newIndex) return;
+
+    const previous = playsInPlaybook;
+    const reordered = arrayMove(previous, oldIndex, newIndex);
+    setPlaysInPlaybook(reordered);
+
+    const lo = Math.min(oldIndex, newIndex);
+    const hi = Math.max(oldIndex, newIndex);
+    // Reuse the same set of order_position values the affected slice already
+    // held (just permuted onto different rows) so unaffected rows are never
+    // touched and never collide with this write.
+    const targetPositions = previous.slice(lo, hi + 1).map((p) => p.order_position);
+    const affected = reordered.slice(lo, hi + 1).map((play, i) => ({ play, position: targetPositions[i] }));
+
+    try {
+      for (let i = 0; i < affected.length; i++) {
+        const { error } = await supabase
+          .from('playbook_plays')
+          .update({ order_position: -(i + 1) })
+          .eq('playbook_id', selectedPlaybook.id)
+          .eq('play_id', affected[i].play.id);
+        if (error) throw error;
+      }
+      for (const { play, position } of affected) {
+        const { error } = await supabase
+          .from('playbook_plays')
+          .update({ order_position: position })
+          .eq('playbook_id', selectedPlaybook.id)
+          .eq('play_id', play.id);
+        if (error) throw error;
+      }
+    } catch (error) {
+      console.error('Error reordering plays:', error);
+      setPlaysInPlaybook(previous);
+      alert('Failed to reorder plays. Please try again.');
     }
   };
 
@@ -1259,6 +1312,30 @@ export function PlaybooksPage() {
                       </p>
                     </div>
                     <div className="flex items-center gap-3">
+                      {playsInPlaybook.length > 0 && (
+                        <div className="flex items-center bg-board rounded-lg border border-chalk/10 p-0.5">
+                          <button
+                            onClick={() => setPlaysLayout('grid')}
+                            title="Grid view"
+                            aria-pressed={playsLayout === 'grid'}
+                            className={`p-1.5 rounded-md transition-colors ${
+                              playsLayout === 'grid' ? 'bg-primary/20 text-primary' : 'text-chalk/50 hover:text-chalk'
+                            }`}
+                          >
+                            <Grid className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => setPlaysLayout('list')}
+                            title="List view — drag to reorder"
+                            aria-pressed={playsLayout === 'list'}
+                            className={`p-1.5 rounded-md transition-colors ${
+                              playsLayout === 'list' ? 'bg-primary/20 text-primary' : 'text-chalk/50 hover:text-chalk'
+                            }`}
+                          >
+                            <List className="h-4 w-4" />
+                          </button>
+                        </div>
+                      )}
                       {/* Export Dropdown */}
                       {playsInPlaybook.length > 0 && (
                         <div className="relative">
@@ -1370,7 +1447,7 @@ export function PlaybooksPage() {
                         Create First Play
                       </button>
                     </div>
-                  ) : (
+                  ) : playsLayout === 'grid' ? (
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
                       {playsInPlaybook.map((play) => (
                         <div
@@ -1427,6 +1504,32 @@ export function PlaybooksPage() {
                         </div>
                       ))}
                     </div>
+                  ) : (
+                    <DndContext
+                      sensors={dndSensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={(event: DragEndEvent) => {
+                        const { active, over } = event;
+                        if (!over || active.id === over.id) return;
+                        const oldIndex = playsInPlaybook.findIndex((p) => p.id === active.id);
+                        const newIndex = playsInPlaybook.findIndex((p) => p.id === over.id);
+                        if (oldIndex === -1 || newIndex === -1) return;
+                        handleReorderPlays(oldIndex, newIndex);
+                      }}
+                    >
+                      <SortableContext items={playsInPlaybook.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+                        <div className="space-y-2">
+                          {playsInPlaybook.map((play) => (
+                            <SortablePlayRow
+                              key={play.id}
+                              play={play}
+                              onEdit={handleEditPlay}
+                              onRemove={removePlayFromPlaybook}
+                            />
+                          ))}
+                        </div>
+                      </SortableContext>
+                    </DndContext>
                   )}
                 </>
               ) : (
@@ -1525,6 +1628,80 @@ export function PlaybooksPage() {
         feature="Playbook PDF export"
         description="Exporting a full playbook to PDF is part of Playbuilder Pro ($39/yr). You can still export any single play for free from the Play Designer."
       />
+    </div>
+  );
+}
+
+// One draggable row in the plays-in-playbook List view. Only the grip handle
+// carries the drag listeners, so the Edit/Remove buttons never fight the
+// drag sensor for a click. `touch-none` on the handle stops a touch-drag
+// from also scrolling the page (same reason Canvas.tsx uses it).
+function SortablePlayRow({
+  play,
+  onEdit,
+  onRemove
+}: {
+  play: PlayInPlaybook;
+  onEdit: (playId: string) => void;
+  onRemove: (play: PlayInPlaybook) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: play.id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 bg-board rounded-lg border border-chalk/10 p-3"
+    >
+      <button
+        {...attributes}
+        {...listeners}
+        className="shrink-0 p-1 text-chalk/40 hover:text-chalk cursor-grab active:cursor-grabbing touch-none"
+        title="Drag to reorder"
+        aria-label={`Drag to reorder ${play.name}`}
+      >
+        <GripVertical className="h-5 w-5" />
+      </button>
+
+      <div className="w-16 h-12 shrink-0 bg-white rounded border border-chalk/10 overflow-hidden">
+        {play.thumbnail ? (
+          <img
+            src={play.thumbnail}
+            alt={play.name}
+            className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-chalk/30">
+            <Play className="h-4 w-4" />
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <h3 className="font-medium text-chalk truncate">{play.name}</h3>
+        <p className="text-xs text-chalk/50 capitalize">{play.type.replace('_', ' ')}</p>
+      </div>
+
+      <button
+        onClick={() => onEdit(play.id)}
+        className="shrink-0 px-3 py-1.5 text-sm font-medium bg-board-light hover:bg-white/10 text-chalk border border-chalk/20 rounded-lg transition-colors"
+      >
+        Edit
+      </button>
+      <button
+        onClick={() => onRemove(play)}
+        title="Remove from this playbook"
+        className="shrink-0 p-2 text-chalk/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
     </div>
   );
 }

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2192,6 +2192,162 @@ test('PlaybooksPage: play count reflects the actual number of plays, not always 
 });
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * PlaybooksPage — drag-to-reorder plays within a playbook (List view).
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+type PlayFixture = { id: string; name: string; order_position: number };
+
+function playbookPlaysRow({ id, name, order_position }: PlayFixture) {
+  return {
+    order_position,
+    plays: {
+      id,
+      name,
+      description: '',
+      thumbnail: '',
+      created_at: '2025-09-01T00:00:00Z',
+      type: 'offense',
+      metadata: {},
+    },
+  };
+}
+
+type PatchCall = { playId: string; position: number };
+
+/** Signs in, stubs the playbooks list (one playbook) and its plays, and
+ * records every playbook_plays PATCH (the reorder mutation) into `patchCalls`. */
+async function mockPlaybookWithPlays(page: Page, plays: PlayFixture[]): Promise<PatchCall[]> {
+  const userJson = {
+    id: '66666666-6666-6666-6666-666666666666',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'free' }) }));
+  await page.route('**/rest/v1/user_preferences**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'pb-1', name: 'Game Plan', description: '', created_at: '2025-09-01T00:00:00Z', user_id: userJson.id, playbook_plays: [{ count: plays.length }] },
+      ]),
+    }));
+
+  const patchCalls: PatchCall[] = [];
+  await page.route('**/rest/v1/playbook_plays**', (route) => {
+    const req = route.request();
+    if (req.method() === 'GET') {
+      return route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify(plays.map(playbookPlaysRow)),
+      });
+    }
+    if (req.method() === 'PATCH') {
+      const url = new URL(req.url());
+      const playId = (url.searchParams.get('play_id') ?? '').replace(/^eq\./, '');
+      const body = req.postDataJSON() as { order_position: number };
+      patchCalls.push({ playId, position: body.order_position });
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+    return route.continue();
+  });
+
+  await page.goto('/playbooks');
+  await page.getByText('Game Plan').click();
+  return patchCalls;
+}
+
+/** Drags a row (via its grip handle) onto another row's position. */
+async function dragPlayRow(page: Page, fromPlayName: string, ontoPlayName: string) {
+  const fromHandle = page.getByLabel(`Drag to reorder ${fromPlayName}`);
+  const toRow = page.getByText(ontoPlayName, { exact: true });
+  const fromBox = await fromHandle.boundingBox();
+  const toBox = await toRow.boundingBox();
+  if (!fromBox || !toBox) throw new Error('row not found');
+
+  const startX = fromBox.x + fromBox.width / 2;
+  const startY = fromBox.y + fromBox.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Small initial move to clear PointerSensor's activation distance, then
+  // step toward the target so dnd-kit's collision detection tracks it.
+  await page.mouse.move(startX, startY + 10, { steps: 5 });
+  await page.mouse.move(toBox.x + toBox.width / 2, toBox.y + toBox.height / 2, { steps: 10 });
+  await page.mouse.up();
+}
+
+const rowNames = (page: Page) => page.locator('h3.truncate').allTextContents();
+
+test('PlaybooksPage: Grid view is the default and unaffected by the List view feature', async ({ page }) => {
+  await mockPlaybookWithPlays(page, [
+    { id: 'play-a', name: 'Play A', order_position: 10 },
+    { id: 'play-b', name: 'Play B', order_position: 20 },
+  ]);
+
+  await expect(page.getByText('Play A')).toBeVisible();
+  await expect(page.getByText('Play B')).toBeVisible();
+  await expect(page.getByLabel(/Drag to reorder/)).toHaveCount(0);
+  await expect(page.locator('button[title="Grid view"]')).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('PlaybooksPage: dragging a play in List view reorders it and writes a two-phase PATCH', async ({ page }) => {
+  const patchCalls = await mockPlaybookWithPlays(page, [
+    { id: 'play-a', name: 'Play A', order_position: 10 },
+    { id: 'play-b', name: 'Play B', order_position: 20 },
+    { id: 'play-c', name: 'Play C', order_position: 30 },
+    { id: 'play-d', name: 'Play D', order_position: 40 },
+  ]);
+
+  await page.locator('button[title="List view — drag to reorder"]').click();
+  await expect(rowNames(page)).resolves.toEqual(['Play A', 'Play B', 'Play C', 'Play D']);
+
+  await dragPlayRow(page, 'Play A', 'Play B');
+
+  // Optimistic update: the visible order flips immediately.
+  await expect(rowNames(page)).resolves.toEqual(['Play B', 'Play A', 'Play C', 'Play D']);
+
+  await expect.poll(() => patchCalls.length).toBe(4);
+  // Phase A: both affected rows bumped to temporary negative positions first.
+  expect(patchCalls[0].position).toBeLessThan(0);
+  expect(patchCalls[1].position).toBeLessThan(0);
+  // Phase B: final real positions — a straight swap of A and B's original values.
+  expect(patchCalls[2]).toEqual({ playId: 'play-b', position: 10 });
+  expect(patchCalls[3]).toEqual({ playId: 'play-a', position: 20 });
+  // Untouched rows never appear in any reorder write.
+  expect(patchCalls.some((c) => c.playId === 'play-c' || c.playId === 'play-d')).toBe(false);
+});
+
+test('PlaybooksPage: a failed reorder write rolls the visible order back', async ({ page }) => {
+  await mockPlaybookWithPlays(page, [
+    { id: 'play-a', name: 'Play A', order_position: 10 },
+    { id: 'play-b', name: 'Play B', order_position: 20 },
+  ]);
+  // Override the PATCH leg only — GET (initial load) must keep succeeding.
+  await page.route('**/rest/v1/playbook_plays**', (route) => {
+    if (route.request().method() === 'PATCH') {
+      return route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'boom' }) });
+    }
+    return route.continue();
+  });
+
+  page.once('dialog', (d) => d.accept());
+  await page.locator('button[title="List view — drag to reorder"]').click();
+  await dragPlayRow(page, 'Play A', 'Play B');
+
+  await expect.poll(() => rowNames(page)).toEqual(['Play A', 'Play B']);
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
  * Admin Dashboard — entitlement management.
  *
  * These are the first tests to touch /admin. The route has no client-side


### PR DESCRIPTION
## Summary
- Adds a List view (alongside the existing default Grid view) to the plays-in-playbook panel on the Playbooks page, where plays can be dragged into a new order using `@dnd-kit`.
- Reordering writes `playbook_plays.order_position` through a two-phase update (temp negative positions, then final positions) so the affected rows never collide with the `UNIQUE (playbook_id, order_position)` constraint mid-write. Only the affected slice is touched — unaffected rows are left alone.
- Optimistic UI update on drop, with rollback to the pre-drag order + an alert if the write fails.
- Grid view is untouched and remains the default; reordering is List-view only (deferred: Grid-view reordering has ambiguous drop semantics across a wrapping multi-row grid).
- No migration needed — `order_position` and the RLS UPDATE policy already existed.

## Test plan
- [x] `npm run typecheck` — no new errors
- [x] `npx eslint` on touched files — no new errors/warnings
- [x] `npm run build`
- [x] `npm run smoke` — 79/79 passing, including 3 new tests: reorder + two-phase PATCH shape + affected-slice-only, rollback on a failed write, and Grid-view-unchanged-by-default
- [x] Proved the new two-phase-write test actually catches a regression: temporarily reverted to a naive single-phase write, confirmed the test failed, restored the fix, confirmed it passes again
- [x] Desktop mouse-drag verified via real Playwright mouse events against a mocked backend (not just DOM assertions)
- [ ] Manual on-device touch-drag verification not performed in this environment — `@dnd-kit`'s `PointerSensor` (the touch-first, browser-native Pointer Events API) was specifically chosen for touch compatibility, but that choice hasn't been confirmed on real touch hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)