### PR TITLE
Fix: reorder's temp position overflowed Postgres integer, failing every attempt

### DIFF
--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -286,14 +286,18 @@ export function PlaybooksPage() {
   // Writes `finalPositionOf(item)` to every item in `affected`, going through
   // a temporary-negative phase first so mid-permutation writes never collide
   // with another affected row's current order_position (UNIQUE(playbook_id,
-  // order_position)). The temp values are unique per call (Date.now()-based),
-  // not small fixed numbers — see handleReorderPlays for why that matters.
+  // order_position)). The temp values are unique per call (epoch-seconds
+  // based), not small fixed numbers — see handleReorderPlays for why that
+  // matters. Seconds, not Date.now()'s milliseconds: order_position is a
+  // Postgres `integer` (max ~2.147e9) and epoch milliseconds (~1.8e12
+  // today) overflows it instantly (22003 "out of range for type integer") —
+  // epoch seconds (~1.8e9 today) comfortably fits until year 2038.
   const writeOrderPositions = async (
     affected: { play: PlayInPlaybook; position: number }[],
     playbookId: string,
     finalPositionOf: (item: { play: PlayInPlaybook; position: number }) => number
   ) => {
-    const tempBase = -(Date.now());
+    const tempBase = -Math.floor(Date.now() / 1000);
     for (let i = 0; i < affected.length; i++) {
       const { error } = await supabase
         .from('playbook_plays')

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2335,8 +2335,13 @@ test('PlaybooksPage: dragging a play in List view reorders it and writes a two-p
 
   await expect.poll(() => patchCalls.length).toBe(4);
   // Phase A: both affected rows bumped to temporary negative positions first.
+  // order_position is a Postgres `integer` (32-bit) — a temp value generated
+  // from Date.now() (epoch milliseconds, ~1.8e12 today) overflows it and
+  // fails with 22003 before any write succeeds. Must stay within int32.
   expect(patchCalls[0].position).toBeLessThan(0);
+  expect(patchCalls[0].position).toBeGreaterThanOrEqual(-2147483648);
   expect(patchCalls[1].position).toBeLessThan(0);
+  expect(patchCalls[1].position).toBeGreaterThanOrEqual(-2147483648);
   // Phase B: final real positions — a straight swap of A and B's original values.
   expect(patchCalls[2]).toEqual({ playId: 'play-b', position: 10 });
   expect(patchCalls[3]).toEqual({ playId: 'play-a', position: 20 });


### PR DESCRIPTION
## Summary
- PR #39's fix for the stuck-row bug switched the temp negative position to a `Date.now()`-based value to guarantee uniqueness across retries. That's epoch **milliseconds** (~1.8×10¹² today) — but `playbook_plays.order_position` is a Postgres `integer` (32-bit, max ~2.147×10⁹). Every write of the temp value overflowed and failed on `22003 "value ... is out of range for type integer"`, before any row could actually be written — which looked identical to the original "every reorder fails" symptom from the user's side, even though the underlying cause (and the fix) is different.
- Switches the temp base to epoch **seconds** (`Math.floor(Date.now() / 1000)`, ~1.8×10⁹ today) — comfortably within `integer` range until 2038, while keeping the same per-call-uniqueness property that made this fix necessary in the first place.
- The `fix_playbook_plays_positions.sql` repair script from PR #39 was never affected by this — its temp offset (`-1000000000 - rn`) was already a safe, small value.

## Test plan
- [x] `npm run typecheck` / `npx eslint` on touched files — no new errors
- [x] `npm run build`
- [x] `npm run smoke` — 80/80 passing; strengthened the existing two-phase-PATCH test to assert the temp value stays within `int32` range
- [x] Proved the strengthened assertion actually catches this exact bug: temporarily reverted to the `Date.now()`-milliseconds version, confirmed the test failed with the same out-of-range shape, restored the fix, confirmed it passes again

🤖 Generated with [Claude Code](https://claude.com/claude-code)