### PR TITLE
Fix: reordering worked once, then every later reorder in the same session collided

### DIFF
--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -337,6 +337,19 @@ export function PlaybooksPage() {
 
     try {
       await writeOrderPositions(affected, selectedPlaybook.id, (item) => item.position);
+      // Sync each affected play's own order_position field to what's now in
+      // the database. `reordered`/`previous` share object references (arrayMove
+      // doesn't clone), so without this, every row's field stays frozen at its
+      // pre-drag value forever — the NEXT reorder would then compute target
+      // positions off stale data that no longer matches the database, easily
+      // colliding with whatever row actually holds that value now.
+      const newPositionByPlayId = new Map(affected.map((item) => [item.play.id, item.position]));
+      setPlaysInPlaybook((current) =>
+        current.map((play) => {
+          const newPosition = newPositionByPlayId.get(play.id);
+          return newPosition === undefined ? play : { ...play, order_position: newPosition };
+        })
+      );
     } catch (error) {
       console.error('Error reordering plays:', error);
       setPlaysInPlaybook(previous);

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2404,6 +2404,53 @@ test('PlaybooksPage: a failed reorder reverts the DATABASE, not just the screen'
   expect(patchCalls[5]).toEqual({ playId: 'play-a', position: 10 });
 });
 
+test('PlaybooksPage: a second reorder after a successful first one does not collide', async ({ page }) => {
+  // Regression test: arrayMove repositions the play objects in state but
+  // never updated each one's own order_position field — it stayed frozen at
+  // its pre-drag value forever. The next reorder computed its target
+  // positions off that stale data, which no longer matched the database
+  // (the first reorder had already changed it), and could try to write a
+  // value some other row already held — 23505 on every reorder after the
+  // first one, exactly as reported.
+  const patchCalls = await mockPlaybookWithPlays(page, [
+    { id: 'play-a', name: 'Play A', order_position: 10 },
+    { id: 'play-b', name: 'Play B', order_position: 20 },
+    { id: 'play-c', name: 'Play C', order_position: 30 },
+  ]);
+
+  let dialogSeen = false;
+  page.on('dialog', (d) => { dialogSeen = true; d.accept(); });
+
+  await page.locator('button[title="List view — drag to reorder"]').click();
+  await expect(rowNames(page)).resolves.toEqual(['Play A', 'Play B', 'Play C']);
+
+  // First reorder: rotate A from the front to the back.
+  await dragPlayRow(page, 'Play A', 'Play C');
+  await expect(rowNames(page)).resolves.toEqual(['Play B', 'Play C', 'Play A']);
+  await expect.poll(() => patchCalls.length).toBe(6); // 3 temp + 3 final
+  expect(patchCalls.slice(3, 6)).toEqual([
+    { playId: 'play-b', position: 10 },
+    { playId: 'play-c', position: 20 },
+    { playId: 'play-a', position: 30 },
+  ]);
+
+  // Second reorder: drag A (now last) back to the front — undoes the rotation.
+  await dragPlayRow(page, 'Play A', 'Play B');
+  await expect.poll(() => rowNames(page)).toEqual(['Play A', 'Play B', 'Play C']);
+
+  expect(dialogSeen).toBe(false); // no "Failed to reorder plays" alert
+  await expect.poll(() => patchCalls.length).toBe(12); // + 3 temp + 3 final
+  // The second operation's final writes must reflect what the first one
+  // actually left in the database (B=10, C=20, A=30) — not each play's
+  // stale pre-drag field (which would instead try B=20, C=30, A=10, and
+  // collide with whichever row already holds that value).
+  expect(patchCalls.slice(9, 12)).toEqual([
+    { playId: 'play-a', position: 10 },
+    { playId: 'play-b', position: 20 },
+    { playId: 'play-c', position: 30 },
+  ]);
+});
+
 /* ────────────────────────────────────────────────────────────────────────────
  * Admin Dashboard — entitlement management.
  *


### PR DESCRIPTION
## Summary
- **Root cause of the still-broken second attempt**: `handleReorderPlays` calls `arrayMove(previous, oldIndex, newIndex)`, which repositions play *objects* within the array — but never updates each object's own `order_position` field. Since `previous`/`reordered` share the same object references (`arrayMove` doesn't clone), that field stays frozen at its pre-drag value forever.
- Every reorder after the first one reads `targetPositions` from that stale field data (`previous.slice(lo, hi + 1).map((p) => p.order_position)`) — which no longer matches what the first reorder actually wrote to the database. Depending on the exact drag sequence, this either writes wrong-but-non-colliding values, or collides with whatever row now legitimately holds that stale value (`23505` on `playbook_plays_playbook_id_order_position_key`) — exactly the "works once, fails every time after" pattern reported.
- Fix: once a reorder's write succeeds, sync each affected play's `order_position` field to its real new value, so the next reorder always starts from data that matches the database.

## Test plan
- [x] `npm run typecheck` / `npx eslint` on touched files — no new errors
- [x] `npm run build`
- [x] `npm run smoke` — 81/81 passing; added `a second reorder after a successful first one does not collide`, which does two reorders in a row on a 3-play playbook (rotate, then undo) and asserts the second operation's writes reflect the database state the first one actually left, not stale pre-drag values
- [x] Proved the new test actually catches this bug: temporarily disabled the field-sync line, confirmed the test failed with exactly the predicted stale values (20/30/10 instead of 10/20/30), restored the fix, confirmed it passes again

No SQL to run — this is a pure client-side bug, nothing in the database needs repair for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)