### PR TITLE
Allow two routes per player (short + deep option)

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -181,6 +181,9 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // Hover highlight (shows which icon will be used as route origin)
     const [hoveredIconIndex, setHoveredIconIndex] = useState<number | null>(null);
+    /** Which route (index into `paths`) is under the pointer in Delete/Recolor
+     *  Route mode — those two modes target a specific route line, not an icon. */
+    const [hoveredPathIndex, setHoveredPathIndex] = useState<number | null>(null);
 
     // Route-saved flash
     const [savedFlash, setSavedFlash] = useState(false);
@@ -228,7 +231,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // Icon being edited via the tap-to-customize popover (Select mode only).
     const [editingIconIndex, setEditingIconIndex] = useState<number | null>(null);
     // Icon whose route is being recolored via the Recolor Route popover.
-    const [editingRouteColorIconIndex, setEditingRouteColorIconIndex] = useState<number | null>(null);
+    /** Which route (index into `paths`) the Recolor Route popover is editing
+     *  — path-indexed, not icon-indexed, so it targets one specific route
+     *  when a player has 2. */
+    const [editingRouteColorPathIndex, setEditingRouteColorPathIndex] = useState<number | null>(null);
     // Text box being edited via its popover (Select mode, or immediately
     // after placing a new one in Text mode).
     const [editingTextIndex, setEditingTextIndex] = useState<number | null>(null);
@@ -293,18 +299,17 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       setZones((prev) => prev.map((z) => (z.iconIndex === idx ? { ...z, color } : z)));
     }, [pushSnapshot]);
 
-    /** Recolor every path belonging to one icon's route (mirrors delete
-     *  route's own `startIconIndex === idx` filter, so a route made of
-     *  multiple legs — not reachable via the current UI, but the data model
-     *  allows it — recolors as one unit rather than partially). Picking
-     *  "Auto" reverts to the icon's current color and clears the override,
-     *  which is what lets applyIconStyle resume following it. */
-    const applyRouteColor = useCallback((idx: number, color: string, auto: boolean) => {
+    /** Recolor one specific route by its index into `paths` — a player can
+     *  have 2 independent routes, each recolored on its own. Picking "Auto"
+     *  reverts to the icon's current color and clears the override, which is
+     *  what lets applyIconStyle resume following it. */
+    const applyRouteColor = useCallback((pathIndex: number, color: string, auto: boolean) => {
       pushSnapshot();
-      const resolvedColor = auto ? playerIcons[idx]?.color ?? color : color;
-      setPaths((prev) => prev.map((p) => (p.startIconIndex === idx
-        ? { ...p, color: resolvedColor, independentColor: auto ? undefined : true }
-        : p)));
+      setPaths((prev) => prev.map((p, i) => {
+        if (i !== pathIndex) return p;
+        const resolvedColor = auto ? (p.startIconIndex !== undefined ? playerIcons[p.startIconIndex]?.color : undefined) ?? color : color;
+        return { ...p, color: resolvedColor, independentColor: auto ? undefined : true };
+      }));
     }, [pushSnapshot, playerIcons]);
 
     /** Update a text box's content/color/size, or remove it if left blank —
@@ -436,11 +441,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     const screenScale = Math.min(width, height) / REF_SIZE;
     const iconRadiusPx = (PLAYER_SIZE * screenScale * iconScaleForCount(playerIcons.length)) / 2;
 
-    /** True if the given icon index already has at least one saved route. */
-    const iconHasRoute = useCallback(
-      (idx: number) => paths.some((p) => p.startIconIndex === idx),
+    /** Number of saved routes already starting at the given icon index — a
+     *  player may have up to 2 (e.g. a short option and a deep option). */
+    const iconRouteCount = useCallback(
+      (idx: number) => paths.filter((p) => p.startIconIndex === idx).length,
       [paths],
     );
+    const MAX_ROUTES_PER_ICON = 2;
 
     /** True if the given icon index already has a zone. */
     const iconHasZone = useCallback(
@@ -647,17 +654,17 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         ctx.restore();
       }
 
-      // Hover highlight ring — only when no origin is locked yet
+      // Hover highlight ring — only when no origin is locked yet. Delete/
+      // Recolor Route highlight the specific route LINE instead (see the
+      // path-hover block below) since an icon can have 2 routes and a
+      // ring around the icon can't tell them apart; this ring is only for
+      // drawing-mode (icon color, or red once the 2-route cap is hit) and
+      // zone tools.
       if (waypointPoints.length === 0 && hoveredIconIndex !== null && playerIcons[hoveredIconIndex]) {
         const hi = toPx(playerIcons[hoveredIconIndex]);
-        const hasRoute = iconHasRoute(hoveredIconIndex);
         const hasZone = iconHasZone(hoveredIconIndex);
-        // Color depends on context:
-        //   delete mode (route or zone) → amber (will delete)
-        //   drawing/zone mode + icon already has that thing → red (blocked)
-        //   normal drawing mode → icon color
-        const blocked = (drawingMode && hasRoute) || (zoneMode && hasZone);
-        const ringColor = (deleteRouteMode || deleteZoneMode)
+        const blocked = (drawingMode && iconRouteCount(hoveredIconIndex) >= MAX_ROUTES_PER_ICON) || (zoneMode && hasZone);
+        const ringColor = deleteZoneMode
           ? '#f59e0b'
           : (blocked ? '#ef4444' : playerIcons[hoveredIconIndex].color);
         ctx.save();
@@ -680,7 +687,31 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         ctx.setLineDash([]);
         ctx.restore();
       }
-    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, waypointSegmentDashed, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, drawMode, capStyle, dashed, deleteRouteMode, drawingMode, zoneMode, deleteZoneMode, iconHasRoute, iconHasZone]);
+
+      // Delete/Recolor Route highlight — an overlay stroke along the
+      // specific targeted route's own points, not a ring around the icon,
+      // so a coach can tell which of a player's up-to-2 routes is under the
+      // pointer (or currently open in the recolor popover).
+      const targetPathIndex = (deleteRouteMode || recolorRouteMode)
+        ? (editingRouteColorPathIndex ?? hoveredPathIndex)
+        : null;
+      if (targetPathIndex !== null && paths[targetPathIndex]) {
+        const highlightColor = deleteRouteMode ? '#f59e0b' : '#ffffff';
+        const pts = paths[targetPathIndex].points.map(toPx);
+        ctx.save();
+        ctx.shadowColor = highlightColor;
+        ctx.shadowBlur = 16 * scale;
+        ctx.strokeStyle = highlightColor;
+        ctx.lineWidth = ROUTE_LINE_WIDTH * scale + 6 * scale;
+        ctx.globalAlpha = 0.55;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.beginPath();
+        pts.forEach((pt, i) => (i === 0 ? ctx.moveTo(pt.x, pt.y) : ctx.lineTo(pt.x, pt.y)));
+        ctx.stroke();
+        ctx.restore();
+      }
+    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, waypointSegmentDashed, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, hoveredPathIndex, editingRouteColorPathIndex, drawMode, capStyle, dashed, deleteRouteMode, recolorRouteMode, drawingMode, zoneMode, deleteZoneMode, iconRouteCount, iconHasZone]);
 
     // Redraw on state change
     useEffect(() => { draw(); }, [draw]);
@@ -755,7 +786,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // (which already resets recolorRouteMode false via DesignerToolbar's
     // toggle handlers), must close it.
     useEffect(() => {
-      if (!recolorRouteMode) setEditingRouteColorIconIndex(null);
+      if (!recolorRouteMode) setEditingRouteColorPathIndex(null);
     }, [recolorRouteMode]);
 
     // ------------------------------------------
@@ -810,7 +841,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setTextBoxes(prevState.textBoxes);
         setSelectedZoneIndex(null);
         setEditingIconIndex(null);
-        setEditingRouteColorIconIndex(null);
+        setEditingRouteColorPathIndex(null);
         setEditingTextIndex(null);
       },
       redo: () => {
@@ -830,13 +861,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setTextBoxes(nextState.textBoxes);
         setSelectedZoneIndex(null);
         setEditingIconIndex(null);
-        setEditingRouteColorIconIndex(null);
+        setEditingRouteColorPathIndex(null);
         setEditingTextIndex(null);
       },
-      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorIconIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointSegmentDashed([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
+      clear: () => { pushSnapshot(); setPaths([]); setPlayerIcons([]); setZones([]); setTextBoxes([]); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorPathIndex(null); setEditingTextIndex(null); setWaypointPoints([]); setWaypointSegmentDashed([]); setWaypointIconIndex(null); setHoveredIconIndex(null); },
       clearRoutes: () => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex === undefined && p.points.length === 0)); },
       removeRouteForIcon: (iconIndex: number) => { pushSnapshot(); setPaths((prev) => prev.filter((p) => p.startIconIndex !== iconIndex)); },
-      loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setTextBoxes(data.textBoxes || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorIconIndex(null); setEditingTextIndex(null); },
+      loadState: (data) => { pushSnapshot(); setPaths(data.paths || []); setPlayerIcons(data.playerIcons || []); setZones(data.zones || []); setTextBoxes(data.textBoxes || []); setSelectedZoneIndex(null); setZoneDraft(null); setEditingIconIndex(null); setEditingRouteColorPathIndex(null); setEditingTextIndex(null); },
       // Replaces the whole scene with the template (routes/zones would
       // otherwise reference icon indices that no longer line up once a
       // different formation is stamped over the old one) — same shape as
@@ -851,7 +882,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         setSelectedZoneIndex(null);
         setZoneDraft(null);
         setEditingIconIndex(null);
-        setEditingRouteColorIconIndex(null);
+        setEditingRouteColorPathIndex(null);
         setWaypointPoints([]);
         setWaypointSegmentDashed([]);
         setWaypointIconIndex(null);
@@ -885,6 +916,37 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         const dy = (icon.y - p.y) * height;
         return Math.sqrt(dx * dx + dy * dy) <= iconRadiusPx + 10;
       });
+
+    /** Shortest on-screen pixel distance from `p` to a polyline. */
+    const distanceToPolylinePx = (p: Pt, points: Pt[]): number => {
+      const px = p.x * width;
+      const py = p.y * height;
+      let min = Infinity;
+      for (let i = 0; i < points.length - 1; i++) {
+        const ax = points[i].x * width, ay = points[i].y * height;
+        const bx = points[i + 1].x * width, by = points[i + 1].y * height;
+        const dx = bx - ax, dy = by - ay;
+        const lenSq = dx * dx + dy * dy;
+        const t = lenSq === 0 ? 0 : Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
+        const cx = ax + t * dx, cy = ay + t * dy;
+        min = Math.min(min, Math.hypot(px - cx, py - cy));
+      }
+      return min;
+    };
+
+    /** Hit-test routes by proximity to their drawn line, not the icon — an
+     *  icon can have 2 routes (see MAX_ROUTES_PER_ICON), so Delete/Recolor
+     *  Route target the specific line under the pointer instead of the icon
+     *  it starts from. Works identically when a player has only 1 route. */
+    const findPathAt = (p: Pt): number => {
+      let best = -1;
+      let bestDist = 14; // hit radius, px — matches the icon hit-test's +10 feel with some slack for thin lines
+      paths.forEach((path, i) => {
+        const d = distanceToPolylinePx(p, path.points);
+        if (d < bestDist) { bestDist = d; best = i; }
+      });
+      return best;
+    };
 
     // ------------------------------------------
     // Finish route helper
@@ -999,28 +1061,28 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         return;
       }
 
-      // Delete-route mode — tap any icon to remove its route
+      // Delete-route mode — tap a route's line to remove just that one (an
+      // icon can have 2 routes, so this targets the specific line under the
+      // pointer rather than the icon it starts from).
       if (deleteRouteMode) {
-        if (clicked >= 0) {
-          if (iconHasRoute(clicked)) {
-            pushSnapshot();
-            setPaths((prev) => prev.filter((p) => p.startIconIndex !== clicked));
-            if (deletedFlashTimerRef.current) clearTimeout(deletedFlashTimerRef.current);
-            setDeletedFlash(true);
-            deletedFlashTimerRef.current = setTimeout(() => setDeletedFlash(false), 1500);
-          }
-          setHoveredIconIndex(null);
+        const pathHit = findPathAt(p);
+        if (pathHit >= 0) {
+          pushSnapshot();
+          setPaths((prev) => prev.filter((_, i) => i !== pathHit));
+          if (deletedFlashTimerRef.current) clearTimeout(deletedFlashTimerRef.current);
+          setDeletedFlash(true);
+          deletedFlashTimerRef.current = setTimeout(() => setDeletedFlash(false), 1500);
         }
+        setHoveredPathIndex(null);
         return;
       }
 
-      // Recolor-route mode — tap any icon with a route to open its
-      // color popover (mirrors delete-route mode above exactly).
+      // Recolor-route mode — tap a route's line to open its color popover
+      // (mirrors delete-route mode above exactly).
       if (recolorRouteMode) {
-        if (clicked >= 0) {
-          if (iconHasRoute(clicked)) setEditingRouteColorIconIndex(clicked);
-          setHoveredIconIndex(null);
-        }
+        const pathHit = findPathAt(p);
+        if (pathHit >= 0) setEditingRouteColorPathIndex(pathHit);
+        setHoveredPathIndex(null);
         return;
       }
 
@@ -1063,8 +1125,9 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
         if (waypointPoints.length === 0) {
           if (clicked >= 0) {
-            // Block starting a second route on an icon that already has one
-            if (iconHasRoute(clicked)) {
+            // A player can have up to 2 routes (e.g. a short option and a
+            // deep option) — block a 3rd.
+            if (iconRouteCount(clicked) >= MAX_ROUTES_PER_ICON) {
               if (conflictFlashTimerRef.current) clearTimeout(conflictFlashTimerRef.current);
               setConflictFlash(true);
               conflictFlashTimerRef.current = setTimeout(() => setConflictFlash(false), 2500);
@@ -1287,12 +1350,23 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         return;
       }
 
-      // Hover highlight: show which icon will be the route origin (or deletion target)
-      if ((drawingMode && waypointPoints.length === 0) || deleteRouteMode || zoneMode || deleteZoneMode) {
+      // Hover highlight: show which icon will be the route origin, or which
+      // zone will be affected.
+      if ((drawingMode && waypointPoints.length === 0) || zoneMode || deleteZoneMode) {
         const idx = findIcon(p);
         setHoveredIconIndex(idx >= 0 ? idx : null);
       } else if (hoveredIconIndex !== null) {
         setHoveredIconIndex(null);
+      }
+
+      // Delete/Recolor Route hover which specific route LINE is under the
+      // pointer (an icon can have 2 routes, so icon-based hover can't tell
+      // them apart — see findPathAt).
+      if (deleteRouteMode || recolorRouteMode) {
+        const idx = findPathAt(p);
+        setHoveredPathIndex(idx >= 0 ? idx : null);
+      } else if (hoveredPathIndex !== null) {
+        setHoveredPathIndex(null);
       }
     };
 
@@ -1405,8 +1479,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // ── Route-color popover placement ─────────────────────────────
     // Same clamp/flip mechanism as the icon editor above, anchored to the
-    // icon whose route is being recolored.
-    const editingRouteColorIcon = editingRouteColorIconIndex !== null ? playerIcons[editingRouteColorIconIndex] : null;
+    // icon the targeted route starts from.
+    const editingRouteColorPath = editingRouteColorPathIndex !== null ? paths[editingRouteColorPathIndex] : null;
+    const editingRouteColorIcon = editingRouteColorPath?.startIconIndex !== undefined
+      ? playerIcons[editingRouteColorPath.startIconIndex]
+      : null;
     let routeColorEditorLeft = 0;
     let routeColorEditorTop = 0;
     if (editingRouteColorIcon) {
@@ -1440,18 +1517,20 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // ── Instruction text for the canvas overlay ──────────────────
     const originIcon = waypointIconIndex !== null ? playerIcons[waypointIconIndex] : null;
-    const hoveredHasRoute = hoveredIconIndex !== null && iconHasRoute(hoveredIconIndex);
     const hoveredHasZone = hoveredIconIndex !== null && iconHasZone(hoveredIconIndex);
+    const hoveredPath = hoveredPathIndex !== null ? paths[hoveredPathIndex] : null;
+    const hoveredPathOriginLetter = hoveredPath?.startIconIndex !== undefined
+      ? playerIcons[hoveredPath.startIconIndex]?.letter
+      : undefined;
     let instructionText: string | null = null;
     if (deleteRouteMode) {
-      if (hoveredIconIndex !== null && playerIcons[hoveredIconIndex]) {
-        const ltr = playerIcons[hoveredIconIndex].letter;
-        instructionText = hoveredHasRoute
-          ? `Tap to remove "${ltr}"'s route`
-          : `"${ltr}" has no route to remove`;
-      } else {
-        instructionText = 'Tap a player to remove their route';
-      }
+      instructionText = hoveredPath
+        ? `Tap to remove ${hoveredPathOriginLetter ? `"${hoveredPathOriginLetter}"'s` : 'this'} route`
+        : 'Tap a route to remove it';
+    } else if (recolorRouteMode) {
+      instructionText = hoveredPath
+        ? `Tap to recolor ${hoveredPathOriginLetter ? `"${hoveredPathOriginLetter}"'s` : 'this'} route`
+        : 'Tap a route to recolor it';
     } else if (deleteZoneMode) {
       if (hoveredIconIndex !== null && playerIcons[hoveredIconIndex]) {
         const ltr = playerIcons[hoveredIconIndex].letter;
@@ -1474,8 +1553,8 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       instructionText = 'Tap the field to add a text box';
     } else if (drawingMode) {
       if (waypointPoints.length === 0) {
-        if (hoveredHasRoute) {
-          instructionText = 'This player already has a route · Use Remove Route to clear it first';
+        if (hoveredIconIndex !== null && iconRouteCount(hoveredIconIndex) >= MAX_ROUTES_PER_ICON) {
+          instructionText = 'This player already has 2 routes · Use Remove Route to clear one first';
         } else {
           instructionText = 'Press and drag from a player to draw, or tap them to start a route';
         }
@@ -1520,7 +1599,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
                 : deletedFlash ? '✓ Route removed'
                 : deletedZoneFlash ? '✓ Zone removed'
                 : finishFirstFlash ? 'Finish or cancel the current route first'
-                : conflictFlash ? 'This player already has a route · Use Remove Route to clear it'
+                : conflictFlash ? 'This player already has 2 routes · Use Remove Route to clear one'
                 : instructionText}
             </div>
           </div>
@@ -1544,19 +1623,19 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
           </div>
         )}
 
-        {/* ── Recolor Route popover (tap an icon in Recolor Route mode) ── */}
-        {editingRouteColorIcon && editingRouteColorIconIndex !== null && (
+        {/* ── Recolor Route popover (tap a route line in Recolor Route mode) ── */}
+        {editingRouteColorIcon && editingRouteColorPath && editingRouteColorPathIndex !== null && (
           <div className="absolute z-20" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
             <RouteColorEditor
-              key={editingRouteColorIconIndex}
-              initialColor={paths.find((p) => p.startIconIndex === editingRouteColorIconIndex)?.color ?? editingRouteColorIcon.color}
-              initialAuto={!paths.find((p) => p.startIconIndex === editingRouteColorIconIndex)?.independentColor}
+              key={editingRouteColorPathIndex}
+              initialColor={editingRouteColorPath.color}
+              initialAuto={!editingRouteColorPath.independentColor}
               applyLabel="Apply"
               onApply={(color, auto) => {
-                applyRouteColor(editingRouteColorIconIndex, color, auto);
-                setEditingRouteColorIconIndex(null);
+                applyRouteColor(editingRouteColorPathIndex, color, auto);
+                setEditingRouteColorPathIndex(null);
               }}
-              onCancel={() => setEditingRouteColorIconIndex(null)}
+              onCancel={() => setEditingRouteColorPathIndex(null)}
             />
           </div>
         )}

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -283,23 +283,25 @@ export function DesignerToolbar({
             color-coded positions. Sticky until changed, like capStyle/dashed. */}
         <RouteColorButton value={routeColorMode} onChange={setRouteColorMode} fullWidth={vertical} />
 
-        {/* Remove Route for a player */}
+        {/* Remove Route: tap the route's own line, not the player icon — a
+            player can have 2 routes (a short option and a deep option), so
+            targeting has to be by line, not by icon. */}
         <button
           onClick={toggleDeleteRouteMode}
-          title="Remove a player's route (tap the player)"
+          title="Remove a route (tap the route)"
           className={`${tool} ${deleteRouteMode ? 'bg-amber-500/20 text-amber-400' : inactive}`}
         >
           <RouteOff className="h-4 w-4" />
           <span className={label}>Remove Route</span>
         </button>
 
-        {/* Recolor Route for a player: tap their icon to set just that route's
-            color, independent of the sticky default above. Not destructive,
-            so it uses the standard active (primary) styling, not Remove
-            Route's amber warning color. */}
+        {/* Recolor Route: tap the route's own line to set just that route's
+            color, independent of the sticky default above and of a player's
+            other route. Not destructive, so it uses the standard active
+            (primary) styling, not Remove Route's amber warning color. */}
         <button
           onClick={toggleRecolorRouteMode}
-          title="Recolor a player's route (tap the player)"
+          title="Recolor a route (tap the route)"
           className={`${tool} ${recolorRouteMode ? active : inactive}`}
         >
           <Palette className="h-4 w-4" />

--- a/src/lib/renderPlayScene.ts
+++ b/src/lib/renderPlayScene.ts
@@ -635,20 +635,18 @@ export function renderScene(
   // underneath routes/icons, which should stay crisp.
   drawZones(ctx, W, H, zones, playerIcons, scale, selectedZoneIndex);
 
-  // Routes — arrowhead only on the last path of each icon's chain
-  const lastByIcon = new Map<number, number>();
-  paths.forEach((p, i) => { if (p.startIconIndex !== undefined) lastByIcon.set(p.startIconIndex, i); });
-
-  paths.forEach((p, i) => {
+  // Routes — every path is a complete, independent route (a player may have
+  // up to 2, e.g. a short option and a deep option), so every one gets its
+  // own arrowhead at its own end.
+  paths.forEach((p) => {
     const pts = p.points.map(toPx);
-    const isLast = p.startIconIndex !== undefined ? lastByIcon.get(p.startIconIndex) === i : true;
     // p.mode === 'block' is the back-compat fallback for plays saved before
     // capStyle existed, when 'block' was a whole mode rather than an ending.
     const useBlockCap = p.capStyle === 'block' || p.mode === 'block';
     // Stop the stroked line short of the tip so it tucks behind the
     // arrowhead. Skipped for the block cap, which sits on the endpoint
     // rather than tapering to it.
-    const stroked = isLast && !useBlockCap ? trimEnd(pts, arrowSize * 0.8) : pts;
+    const stroked = !useBlockCap ? trimEnd(pts, arrowSize * 0.8) : pts;
     if (p.mode === 'waypoint') {
       ctx.save();
       ctx.setLineDash(p.dashed ? [lineWidth * 2.5, lineWidth * 2] : []);
@@ -667,10 +665,8 @@ export function renderScene(
       strokeStraight(ctx, stroked, p.color, lineWidth);
       ctx.restore();
     }
-    if (isLast) {
-      if (useBlockCap) drawBlockCap(ctx, pts, p.color, arrowSize);
-      else drawArrowhead(ctx, pts, p.color, arrowSize);
-    }
+    if (useBlockCap) drawBlockCap(ctx, pts, p.color, arrowSize);
+    else drawArrowhead(ctx, pts, p.color, arrowSize);
   });
 
   // Player icons

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2986,7 +2986,7 @@ test('route color: Recolor Route mode changes only the tapped player\'s route', 
   state = await canvasState(page);
   const rOriginalColor = state.paths[1].color;
 
-  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await btn(page, 'Recolor a route (tap the route)').click();
   await page.mouse.click(iconQ.x, iconQ.y);
   await expect(page.getByLabel('Custom route color')).toBeVisible();
   await page.getByLabel('Color #E11D48').click();
@@ -3018,7 +3018,7 @@ test('route color: picking Auto in the popover reverts the override and resumes 
   await page.getByRole('button', { name: 'Finish Route' }).click();
 
   // Override to red via Recolor Route mode.
-  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await btn(page, 'Recolor a route (tap the route)').click();
   await page.mouse.click(icon.x, icon.y);
   await page.getByLabel('Color #E11D48').click();
   await page.getByRole('button', { name: 'Apply' }).click();
@@ -3067,7 +3067,7 @@ test('route color: Recolor Route mode is mutually exclusive with other tools', a
 
   // Enter Recolor Route mode and confirm tapping the icon opens the ROUTE
   // color popover, not the icon-style popover.
-  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await btn(page, 'Recolor a route (tap the route)').click();
   await page.mouse.click(icon.x, icon.y);
   await expect(page.getByLabel('Custom route color')).toBeVisible();
   await expect(page.getByLabel('Player label')).toHaveCount(0);
@@ -3111,7 +3111,7 @@ test('route color: overriding a route leaves the icon\'s zone color unaffected',
   expect(state.zones[0].color).toBe(originalIconColor);
 
   // Override just the route to black.
-  await btn(page, 'Recolor a player\'s route (tap the player)').click();
+  await btn(page, 'Recolor a route (tap the route)').click();
   await page.mouse.click(icon.x, icon.y);
   await page.getByLabel('Color #000000').click();
   await page.getByRole('button', { name: 'Apply' }).click();
@@ -3187,4 +3187,111 @@ test('Community Forum: no fabricated "Trending Topics" section (no real topic/ta
   await expect(page.getByText('Top Contributors')).toBeVisible(); // page loaded correctly
   await expect(page.getByText('Trending Topics')).toHaveCount(0);
   await expect(page.getByText('#defensivestrategies')).toHaveCount(0);
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Two routes per player — a short option and a deep option on one player.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** Draws one straight-line route from `origin` to `end` (page coords) and
+ * finishes it — the same click/wait/click/Finish sequence used throughout
+ * this file's existing route-drawing tests. */
+async function drawStraightRoute(page: Page, origin: { x: number; y: number }, end: { x: number; y: number }) {
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(origin.x, origin.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.mouse.click(end.x, end.y);
+  await page.waitForTimeout(TAP_GAP);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+}
+
+test('routes: a player can have two independent routes (short + deep option); a third is blocked', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  const shortEnd = await canvasPoint(page, 0.5, 0.6);
+  await drawStraightRoute(page, icon, shortEnd);
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+
+  const deepEnd = await canvasPoint(page, 0.3, 0.15);
+  await drawStraightRoute(page, icon, deepEnd);
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+  expect(state.paths[0].startIconIndex).toBe(0);
+  expect(state.paths[1].startIconIndex).toBe(0);
+
+  // A third attempt on the same player is blocked (cap is 2).
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByText('This player already has 2 routes', { exact: false })).toBeVisible();
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+});
+
+test('routes: Recolor Route mode targets one of a player\'s two routes independently', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  const shortEnd = await canvasPoint(page, 0.5, 0.6);
+  await drawStraightRoute(page, icon, shortEnd);
+  const deepEnd = await canvasPoint(page, 0.3, 0.15);
+  await drawStraightRoute(page, icon, deepEnd);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+  const deepRouteOriginalColor = state.paths[1].color;
+
+  // Recolor only the SHORT route by tapping near ITS end, away from the
+  // shared origin the two routes both start from.
+  await btn(page, 'Recolor a route (tap the route)').click();
+  await page.mouse.click(shortEnd.x, shortEnd.y);
+  await expect(page.getByLabel('Custom route color')).toBeVisible();
+  await page.getByLabel('Color #E11D48').click();
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  state = await canvasState(page);
+  expect(state.paths[0].color).toBe('#E11D48');
+  expect(state.paths[0].independentColor).toBe(true);
+  // The deep route, drawn from the same icon, is untouched.
+  expect(state.paths[1].color).toBe(deepRouteOriginalColor);
+  expect(state.paths[1].independentColor).toBeFalsy();
+});
+
+test('routes: Remove Route mode deletes one of a player\'s two routes independently', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  const shortEnd = await canvasPoint(page, 0.5, 0.6);
+  await drawStraightRoute(page, icon, shortEnd);
+  const deepEnd = await canvasPoint(page, 0.3, 0.15);
+  await drawStraightRoute(page, icon, deepEnd);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+
+  // Remove only the DEEP route by tapping near its end.
+  await btn(page, 'Remove a route (tap the route)').click();
+  await page.mouse.click(deepEnd.x, deepEnd.y);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(1);
+  // The survivor is the SHORT route — its last point is near y=0.6, not the
+  // deep route's y=0.15.
+  expect(state.paths[0].points[state.paths[0].points.length - 1].y).toBeCloseTo(0.6, 1);
 });


### PR DESCRIPTION
## Summary
Coaches asked for the ability to draw two routes for the same player (e.g. "my playbook features some plays that have a short and a deep option"). Confirmed via code reading that the data model already fully supported this — `PathItem.startIconIndex` has no uniqueness constraint, and delete/recolor already operated via `.filter`/`.map` over every path matching an icon, not a single lookup. The only real blocker was a UI guard capping a player at one route. **No schema change, no migration.**

- Raises the drawing cap from 1 to **2** routes per player (matches the request; avoids the "which of N did I click" complexity an unbounded cap would need).
- **Delete Route** and **Recolor Route** used to target a player by tapping their *icon* — with 2 routes sharing an icon, that can't disambiguate. Both now hit-test the pointer against each route's own drawn line (new point-to-segment distance check), with hover feedback that highlights the specific targeted line (not a ring around the icon). Behaves identically for a player with only one route.
- Fixed `renderPlayScene.ts`'s arrowhead logic, which only drew an arrowhead on the array-last path per icon (assuming one continuous chain) — every route is independently complete, so every one now gets its own arrowhead.
- Toolbar tooltips updated ("tap the route" instead of "tap the player") to match the new interaction.

## Test plan
- [x] `npm run typecheck` / `npx eslint` on touched files — no new errors (8 pre-existing warnings, confirmed via `git stash` against `main`)
- [x] `npm run build`
- [x] `npm run smoke` — 87/87 passing. All 84 pre-existing tests pass unchanged (confirms the delete/recolor refactor is backward compatible for the single-route case). Added 3 new tests: drawing 2 routes on one player + a 3rd being blocked, Recolor Route targeting one of two routes independently, Remove Route deleting one of two independently.
- [x] Proved the new tests actually catch regressions: temporarily lowered the cap back to 1 (3rd-route test failed as expected), and temporarily reverted delete-targeting to icon-wide (independent-delete test failed as expected) — restored both, all pass again.
- [x] Manual browser verification (Playwright-driven against a real dev server, screenshots): drew a short + deep route on one player, confirmed **both** render with their own arrowhead; confirmed Remove Route mode highlights only the hovered route's line in amber; confirmed deleting the deep route leaves the short route fully intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)