### PR TITLE
Add "Vs. Defense" view: cycle defensive looks over an offensive play

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -150,6 +150,22 @@ the play in the library (and vice versa via the play description).
 Library grows on autopilot; blog↔library interlinking compounds SEO.
 Requires B-31's generation/thumbnail tooling to exist first.
 
+### B-36 · "Vs. Defense" follow-ups
+The read-only `/vs?play=<id>` view ships offense+defense overlay and defense
+cycling only (deliberately lean). Deferred, in rough priority order:
+1. **Per-matchup coaching notes** — a note attached to an offense×defense
+   pairing ("vs Cover 2, hit the flat"). Needs a new table + RLS + an
+   idempotent `.sql` file; **⚠ requires SQL run**.
+2. **Export the matchup** — a PNG/PDF of the overlaid diagram, and a
+   "whole deck vs this play" sheet. `renderOverlayScene()` already renders to
+   any offscreen context, so this is mostly an ExportModal variant. Likely a
+   Pro gate (viewing stays free).
+3. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
+   read. Blocked on there being no "correct read" data on a play at all.
+4. **Community defenses in the deck** — currently the deck is the coach's own
+   defensive plays only, so a coach with none gets an empty state pointing at
+   the designer. Offering public defenses would seed it.
+
 ## Done
 
 - **2026-08-04 · B-35: Automated feedback triage** — a scheduled agent now

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const BlogPostPage = lazy(() => import('./components/blog/BlogPage').then((m) =>
 const AccountSettings = lazy(() => import('./components/auth/AccountSettings'));
 const PlayDesigner = lazy(() => import('./components/designer/PlayDesigner').then((m) => ({ default: m.PlayDesigner })));
 const PlaysPage = lazy(() => import('./components/plays/PlaysPage').then((m) => ({ default: m.PlaysPage })));
+const VsDefenseView = lazy(() => import('./components/vs/VsDefenseView').then((m) => ({ default: m.VsDefenseView })));
 const PlaybooksPage = lazy(() => import('./components/playbooks/PlaybooksPage').then((m) => ({ default: m.PlaybooksPage })));
 const AdminDashboard = lazy(() => import('./components/admin/AdminDashboard').then((m) => ({ default: m.AdminDashboard })));
 const PrivacyPolicy = lazy(() => import('./components/legal/PrivacyPolicy').then((m) => ({ default: m.PrivacyPolicy })));
@@ -108,6 +109,7 @@ function App() {
               <Route path="/plays" element={<PlaysPage />} />
               <Route path="/playbooks" element={<PlaybooksPage />} />
               <Route path="/designer" element={<PlayDesigner />} />
+              <Route path="/vs" element={<VsDefenseView />} />
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="/terms" element={<TermsOfService />} />

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -17,6 +17,8 @@ import {
   TEXT_BOX_SIZES,
   DEFAULT_TEXT_BOX_SIZE,
   DEFAULT_TEXT_BOX_COLOR,
+  EXPORT_WIDTH,
+  EXPORT_HEIGHT,
   REF_SIZE,
   ROUTE_LINE_WIDTH,
   ARROWHEAD_SIZE,
@@ -66,14 +68,6 @@ const DRAG_THRESHOLD_PX = 4;
 // zone creation visible instead of invisibly tiny.
 const MIN_ZONE_RADIUS = 0.035;
 
-// Fixed export resolution (letter-page proportions) — every play prints
-// the same regardless of the screen it was designed on. The on-screen
-// canvas is locked to this aspect ratio too (PlayDesigner's resize
-// handler), so shapes — zone ellipses especially — look the same on
-// screen as in the printed PDF.
-export const EXPORT_WIDTH = 1650;
-export const EXPORT_HEIGHT = 1275;
-
 // ---------------------------------------------
 // Types
 // ---------------------------------------------
@@ -81,7 +75,7 @@ export const EXPORT_HEIGHT = 1275;
 // working — the types themselves now live in ../../lib/renderPlayScene
 // alongside the rendering code that defines their shape.
 export type { DrawMode, CapStyle, PathItem, IconShape, PlayerIcon, Zone, TextBox };
-export { FIELD_YARDS_ABOVE_LOS, FIELD_YARDS_BELOW_LOS, TOTAL_FIELD_YARDS, TEXT_BOX_SIZES, DEFAULT_TEXT_BOX_SIZE, DEFAULT_TEXT_BOX_COLOR };
+export { FIELD_YARDS_ABOVE_LOS, FIELD_YARDS_BELOW_LOS, TOTAL_FIELD_YARDS, TEXT_BOX_SIZES, DEFAULT_TEXT_BOX_SIZE, DEFAULT_TEXT_BOX_COLOR, EXPORT_WIDTH, EXPORT_HEIGHT };
 
 type CanvasProps = {
   width: number;

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -1,7 +1,7 @@
 // PlaybooksPage.tsx - Enhanced with PDF Export Feature
 
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -21,7 +21,8 @@ import {
   LayoutGrid,
   Lock,
   Watch,
-  GripVertical
+  GripVertical,
+  Shield
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
@@ -1521,6 +1522,18 @@ export function PlaybooksPage() {
                               >
                                 Edit Play
                               </button>
+                              {/* Offense only — the vs. view draws this play
+                                  under a defense, so a defensive play here
+                                  would just stack two defenses. */}
+                              {play.type === 'offense' && (
+                                <Link
+                                  to={`/vs?play=${play.id}`}
+                                  title="View this play against your defensive plays"
+                                  className="p-2 bg-white text-black hover:bg-chalk rounded-lg transition-colors"
+                                >
+                                  <Shield className="h-4 w-4" />
+                                </Link>
+                              )}
                               <button
                                 onClick={() => removePlayFromPlaybook(play)}
                                 title="Remove from this playbook"

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Book, Plus, Filter, Trash2, LogIn, Wand2 } from 'lucide-react';
+import { Book, Plus, Filter, Trash2, LogIn, Wand2, Shield } from 'lucide-react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { AddToPlaybookButton } from './AddToPlaybookButton'; // Adjust path as needed
@@ -485,6 +485,18 @@ export function PlaysPage() {
             >
               <Wand2 className="h-4 w-4" />
             </Link>
+
+            {/* Offense only — the vs. view draws this play under a defense,
+                so pointing it at a defensive play would stack two defenses. */}
+            {play.type === 'offense' && (
+              <Link
+                to={`/vs?play=${play.id}`}
+                title="View this play against your defensive plays"
+                className="flex items-center gap-1 px-3 py-2 text-sm bg-board-light hover:bg-board border border-chalk/10 text-chalk/70 hover:text-chalk rounded-lg transition-colors"
+              >
+                <Shield className="h-4 w-4" />
+              </Link>
+            )}
 
             {play.is_public && (
               <PlayVoteButton

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -1,0 +1,393 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, Eye, EyeOff, Home, Shield } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import { getSafeErrorMessage } from '../../lib/errors';
+import { usePageMeta } from '../../lib/seo';
+import { renderOverlayScene, EXPORT_WIDTH, EXPORT_HEIGHT, type SceneLayer } from '../../lib/renderPlayScene';
+import { Logo } from '../Logo';
+
+// ---------------------------------------------
+// Read-only "vs. defense" view: one offensive play with a defensive play drawn
+// on top of it, and prev/next controls to cycle through the coach's saved
+// defenses. Built for teaching quarterback reads — "here's Cover 2 against
+// this concept, now here's man blitz; where do you throw?"
+//
+// Nothing here is editable and nothing is persisted. The two plays stay two
+// separate rows in `plays`; they're only ever composited at render time by
+// renderOverlayScene().
+// ---------------------------------------------
+
+type PlayRow = {
+  id: string;
+  name: string;
+  type: string;
+  description: string | null;
+  metadata: { gameType?: string } | null;
+  canvas_data: string | null;
+};
+
+type DefenseEntry = { id: string; name: string; description: string | null; gameType?: string; scene: SceneLayer };
+
+const EMPTY_SCENE: SceneLayer = { paths: [], playerIcons: [], zones: [], textBoxes: [] };
+
+/**
+ * Parse a plays.canvas_data blob into a drawable scene. Mirrors the defensive
+ * parsing in PlayDesigner's load effect: every array is shape-checked
+ * independently so one bad field can't blank a whole play. Returns null when
+ * the JSON itself is unusable, which lets callers drop that play rather than
+ * fail the page.
+ */
+function parseScene(canvasData: string | null): SceneLayer | null {
+  try {
+    const parsed = JSON.parse(canvasData || '{}');
+    return {
+      paths: Array.isArray(parsed.paths) ? parsed.paths : [],
+      playerIcons: Array.isArray(parsed.playerIcons) ? parsed.playerIcons : [],
+      zones: Array.isArray(parsed.zones) ? parsed.zones : [],
+      textBoxes: Array.isArray(parsed.textBoxes) ? parsed.textBoxes : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function VsDefenseView() {
+  usePageMeta({
+    title: 'Vs. Defense',
+    description: 'View an offensive play against different defensive looks.',
+    path: '/vs',
+  });
+
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const playId = searchParams.get('play');
+  const defenseParam = searchParams.get('d');
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [offensePlay, setOffensePlay] = useState<PlayRow | null>(null);
+  const [offenseScene, setOffenseScene] = useState<SceneLayer>(EMPTY_SCENE);
+  const [defenses, setDefenses] = useState<DefenseEntry[]>([]);
+  const [index, setIndex] = useState(0);
+  const [showDefense, setShowDefense] = useState(true);
+  const [canvasSize, setCanvasSize] = useState({ width: 640, height: 480 });
+
+  const currentDefense = defenses[index] ?? null;
+
+  // ── Load the offense and the deck of defenses ───────────────
+  useEffect(() => {
+    if (!playId) {
+      setError('No play selected.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (!user) {
+          navigate('/auth', { replace: true });
+          return;
+        }
+
+        // The offense may be someone else's public play (RLS allows reading
+        // those), but the defensive deck is always the signed-in coach's own.
+        const [offenseRes, defenseRes] = await Promise.all([
+          supabase
+            .from('plays')
+            .select('id, name, type, description, metadata, canvas_data')
+            .eq('id', playId)
+            .single(),
+          supabase
+            .from('plays')
+            .select('id, name, type, description, metadata, canvas_data')
+            .eq('user_id', user.id)
+            .eq('type', 'defense')
+            .order('name'),
+        ]);
+        if (cancelled) return;
+        if (offenseRes.error) throw offenseRes.error;
+        if (defenseRes.error) throw defenseRes.error;
+
+        const offRow = offenseRes.data as PlayRow;
+        const offScene = parseScene(offRow.canvas_data);
+        if (!offScene) throw new Error('This play could not be opened (unrecognized format).');
+
+        // Defenses whose game format matches the offense sort first, but no
+        // play is excluded: metadata.gameType is optional and missing on older
+        // rows, so filtering on it could silently empty the deck.
+        const offFormat = offRow.metadata?.gameType;
+        const deck: DefenseEntry[] = ((defenseRes.data ?? []) as PlayRow[])
+          .map((row): DefenseEntry | null => {
+            const scene = parseScene(row.canvas_data);
+            if (!scene) return null;
+            return {
+              id: row.id,
+              name: row.name || 'Untitled Defense',
+              description: row.description,
+              gameType: row.metadata?.gameType,
+              scene,
+            };
+          })
+          .filter((d): d is DefenseEntry => d !== null)
+          .sort((a, b) => {
+            const aMatch = offFormat && a.gameType === offFormat ? 0 : 1;
+            const bMatch = offFormat && b.gameType === offFormat ? 0 : 1;
+            return aMatch - bMatch || a.name.localeCompare(b.name);
+          });
+
+        setOffensePlay(offRow);
+        setOffenseScene(offScene);
+        setDefenses(deck);
+        // Honour ?d= on first load / refresh so a specific matchup is linkable.
+        const startAt = deck.findIndex((d) => d.id === defenseParam);
+        setIndex(startAt >= 0 ? startAt : 0);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Vs. defense load error:', err);
+        setError(getSafeErrorMessage(err, 'Failed to load play'));
+        setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+    // defenseParam is deliberately omitted: it's an output of cycling below,
+    // and re-running the fetch on every arrow press would refetch the deck.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playId, navigate]);
+
+  // ── Keep ?d= pointed at the visible defense ─────────────────
+  useEffect(() => {
+    if (!currentDefense) return;
+    if (searchParams.get('d') === currentDefense.id) return;
+    const next = new URLSearchParams(searchParams);
+    next.set('d', currentDefense.id);
+    // replace so Back leaves the view instead of walking the whole deck.
+    setSearchParams(next, { replace: true });
+  }, [currentDefense, searchParams, setSearchParams]);
+
+  // ── Aspect-locked sizing, matching the designer/export ratio ─
+  // Keyed on `loading` because the container lives past the loading/error
+  // early-returns below — on the first pass containerRef is still null, so
+  // observing then would silently leave the canvas at its default size.
+  useEffect(() => {
+    if (loading) return;
+    const update = () => {
+      const el = containerRef.current;
+      if (!el) return;
+      const maxW = Math.max(280, el.clientWidth);
+      const maxH = Math.max(280, el.clientHeight);
+      const ratio = EXPORT_WIDTH / EXPORT_HEIGHT;
+      const w = Math.min(maxW, maxH * ratio);
+      setCanvasSize({ width: w, height: w / ratio });
+    };
+    const frame = requestAnimationFrame(update);
+    const ro = new ResizeObserver(update);
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => { cancelAnimationFrame(frame); ro.disconnect(); };
+  }, [loading]);
+
+  // ── Draw ────────────────────────────────────────────────────
+  const visibleDefenseScene = showDefense ? currentDefense?.scene ?? null : null;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Back the canvas at device resolution so diagrams stay sharp on the
+    // tablet a coach is holding, then draw in CSS pixels.
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(canvasSize.width * dpr);
+    canvas.height = Math.round(canvasSize.height * dpr);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    renderOverlayScene(ctx, canvasSize.width, canvasSize.height, offenseScene, visibleDefenseScene);
+  }, [canvasSize, offenseScene, visibleDefenseScene]);
+
+  // ── Cycling ─────────────────────────────────────────────────
+  const deckLength = defenses.length;
+  const step = useCallback((delta: number) => {
+    if (deckLength < 2) return;
+    setIndex((i) => (i + delta + deckLength) % deckLength);
+  }, [deckLength]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Don't hijack arrows while the coach is in the jump-to dropdown.
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.key === 'ArrowRight') { e.preventDefault(); step(1); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); step(-1); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [step]);
+
+  // ── Dev-only test bridge (mirrors PlayDesigner's __PBP_TEST__) ─
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    (window as any).__PBP_VS_TEST__ = {
+      getState: () => ({
+        offenseIcons: offenseScene.playerIcons,
+        defenseIcons: visibleDefenseScene?.playerIcons ?? [],
+        defenseId: currentDefense?.id ?? null,
+        deckLength: defenses.length,
+        index,
+        showDefense,
+      }),
+    };
+    return () => { delete (window as any).__PBP_VS_TEST__; };
+  }, [offenseScene, visibleDefenseScene, currentDefense, defenses.length, index, showDefense]);
+
+  const ariaLabel = useMemo(() => {
+    const off = offensePlay?.name ?? 'Play';
+    return currentDefense && showDefense
+      ? `${off} diagrammed against the defense ${currentDefense.name}`
+      : `${off} diagrammed on a football field`;
+  }, [offensePlay, currentDefense, showDefense]);
+
+  // ── Render ──────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="fixed inset-0 bg-board flex items-center justify-center text-chalk/50">
+        Loading…
+      </div>
+    );
+  }
+
+  if (error || !offensePlay) {
+    return (
+      <div className="fixed inset-0 bg-board flex flex-col items-center justify-center gap-4 px-6 text-center">
+        <p className="text-chalk/70">{error || 'That play could not be found.'}</p>
+        <Link to="/plays" className="px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors">
+          Back to My Plays
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 flex flex-col bg-board overflow-hidden">
+      {/* ── HEADER ─────────────────────────────────────────────── */}
+      <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 py-2 flex items-center gap-2 z-30">
+        <Link
+          to="/plays"
+          className="p-2 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10"
+          title="Back to My Plays"
+        >
+          <Home className="h-5 w-5" />
+        </Link>
+        <div className="flex items-center gap-1.5 mr-auto min-w-0">
+          <Logo className="h-6 w-6 text-chalk shrink-0" />
+          <span className="font-bold text-chalk text-sm sm:text-base truncate">
+            {offensePlay.name}
+            <span className="font-normal text-chalk/50 ml-1 text-xs hidden sm:inline">vs. defense</span>
+          </span>
+        </div>
+        <button
+          onClick={() => setShowDefense((v) => !v)}
+          disabled={!currentDefense}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          title={showDefense ? 'Hide the defense' : 'Show the defense'}
+        >
+          {showDefense ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          <span className="hidden sm:inline">{showDefense ? 'Hide defense' : 'Show defense'}</span>
+        </button>
+      </header>
+
+      {/* ── CANVAS ─────────────────────────────────────────────── */}
+      <div ref={containerRef} className="flex-1 min-h-0 flex items-center justify-center p-2 sm:p-4">
+        <canvas
+          ref={canvasRef}
+          id="vs-canvas"
+          role="img"
+          aria-label={ariaLabel}
+          style={{ width: canvasSize.width, height: canvasSize.height }}
+          className="rounded-lg shadow-lg"
+        />
+      </div>
+
+      {/* ── CONTROLS ───────────────────────────────────────────── */}
+      <footer className="shrink-0 bg-board-light border-t border-chalk/10 px-3 py-3 z-30">
+        {defenses.length === 0 ? (
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-2 text-center">
+            <p className="text-sm text-chalk/60">
+              You haven&apos;t saved any defensive plays yet — create one to cycle defensive looks against this play.
+            </p>
+            <Link
+              to="/designer"
+              className="shrink-0 inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+            >
+              <Shield className="h-4 w-4" />
+              Create a defense
+            </Link>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 sm:gap-3 max-w-4xl mx-auto">
+            <button
+              onClick={() => step(-1)}
+              disabled={defenses.length < 2}
+              className="p-2 rounded-lg bg-board border border-chalk/20 text-chalk hover:bg-board-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title="Previous defense (←)"
+              aria-label="Previous defense"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+
+            <div className="flex-1 min-w-0 text-center">
+              {/* aria-live so a screen reader announces each new defense as
+                  the coach cycles, since the canvas itself can't. */}
+              <div id="vs-defense-label" aria-live="polite" className="truncate">
+                <span className="text-chalk font-medium">{currentDefense?.name}</span>
+                {currentDefense?.gameType && (
+                  <span className="ml-2 text-xs text-chalk/50 border border-chalk/20 rounded px-1.5 py-0.5">
+                    {currentDefense.gameType}
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-chalk/50 truncate">
+                {index + 1} of {defenses.length}
+                {currentDefense?.description ? ` · ${currentDefense.description}` : ''}
+              </div>
+            </div>
+
+            {defenses.length > 1 && (
+              <select
+                value={currentDefense?.id ?? ''}
+                onChange={(e) => {
+                  const at = defenses.findIndex((d) => d.id === e.target.value);
+                  if (at >= 0) setIndex(at);
+                }}
+                aria-label="Jump to a defense"
+                className="hidden sm:block max-w-[14rem] px-2 py-2 text-sm bg-board border border-chalk/20 text-chalk rounded-lg"
+              >
+                {defenses.map((d) => (
+                  <option key={d.id} value={d.id}>{d.name}</option>
+                ))}
+              </select>
+            )}
+
+            <button
+              onClick={() => step(1)}
+              disabled={defenses.length < 2}
+              className="p-2 rounded-lg bg-board border border-chalk/20 text-chalk hover:bg-board-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title="Next defense (→)"
+              aria-label="Next defense"
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          </div>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/src/lib/renderPlayScene.ts
+++ b/src/lib/renderPlayScene.ts
@@ -9,6 +9,17 @@
 // ---------------------------------------------
 export const REF_SIZE = 600; // reference min(width, height) the base sizes were designed at
 
+// Fixed export resolution (letter-page proportions) — every play prints
+// the same regardless of the screen it was designed on. Every on-screen
+// canvas is locked to this aspect ratio too (PlayDesigner's and
+// VsDefenseView's resize handlers), so shapes — zone ellipses especially —
+// look the same on screen as in the printed PDF. Lives here rather than in
+// Canvas.tsx so read-only views can lock the same ratio without importing
+// the whole interactive designer; Canvas.tsx re-exports both for the
+// existing imports across the designer.
+export const EXPORT_WIDTH = 1650;
+export const EXPORT_HEIGHT = 1275;
+
 export const ROUTE_LINE_WIDTH = 3;
 export const ARROWHEAD_SIZE = 14;
 export const PLAYER_SIZE = 36;
@@ -602,6 +613,16 @@ function drawTextBoxes(
   });
 }
 
+/** Optional per-call tweaks, used when stacking two scenes on one canvas. */
+export type RenderSceneOptions = {
+  /** Skip the clearRect + drawField pair so this scene layers over what's
+   *  already on the context instead of wiping it. */
+  skipFieldReset?: boolean;
+  /** Size icons as if this many were on the field, rather than
+   *  playerIcons.length — see renderOverlayScene for why. */
+  iconCountOverride?: number;
+};
+
 /**
  * Render a complete play scene (field, zones, routes, icons) onto a context
  * at any pixel size. All input data is in normalized 0–1 coordinates; visual
@@ -622,15 +643,19 @@ export function renderScene(
   selectedZoneIndex: number | null = null,
   textBoxes: TextBox[] = [],
   selectedTextIndex: number | null = null,
+  opts: RenderSceneOptions = {},
 ) {
   const scale = Math.min(W, H) / REF_SIZE;
   const toPx = (p: Pt): Pt => ({ x: p.x * W, y: p.y * H });
   const lineWidth = ROUTE_LINE_WIDTH * scale;
   const arrowSize = ARROWHEAD_SIZE * scale;
-  const iconSize = PLAYER_SIZE * scale * iconScaleForCount(playerIcons.length);
+  const iconSize =
+    PLAYER_SIZE * scale * iconScaleForCount(opts.iconCountOverride ?? playerIcons.length);
 
-  ctx.clearRect(0, 0, W, H);
-  drawField(ctx, W, H, scale);
+  if (!opts.skipFieldReset) {
+    ctx.clearRect(0, 0, W, H);
+    drawField(ctx, W, H, scale);
+  }
   // Zones sit on top of the grid (translucent, so it shows through) but
   // underneath routes/icons, which should stay crisp.
   drawZones(ctx, W, H, zones, playerIcons, scale, selectedZoneIndex);
@@ -700,4 +725,57 @@ export function renderScene(
   // Text annotations sit on top of everything — they're meant to stay
   // legible over routes/zones/icons, like handwriting on a printed diagram.
   drawTextBoxes(ctx, W, H, textBoxes, scale, selectedTextIndex);
+}
+
+/** One play's drawable contents — the parsed shape of plays.canvas_data. */
+export type SceneLayer = {
+  paths: PathItem[];
+  playerIcons: PlayerIcon[];
+  zones: Zone[];
+  textBoxes: TextBox[];
+};
+
+/**
+ * Draw an offensive play with a defensive play stacked on the same field, for
+ * the read-only "vs. defense" view where a coach cycles defensive looks against
+ * one offense.
+ *
+ * No coordinate transform is involved: the field window is universal
+ * (FIELD_YARDS_ABOVE_LOS / BELOW_LOS) and offense is drawn below the LOS while
+ * defense is drawn above it, so the two scenes already occupy opposite halves.
+ *
+ * The two plays are rendered as two separate calls rather than by concatenating
+ * their arrays, because PathItem.startIconIndex and Zone.iconIndex are indexes
+ * into the *same call's* playerIcons — merging would mean re-basing every
+ * defensive index.
+ */
+export function renderOverlayScene(
+  ctx: CanvasRenderingContext2D,
+  W: number,
+  H: number,
+  offense: SceneLayer,
+  defense: SceneLayer | null,
+) {
+  // Each side keeps the icon size it has when viewed alone. Summing both
+  // rosters would push a 5v5-on-5v5 matchup to 10 icons and shrink everything
+  // to the 0.8 floor, even though neither play is crowded.
+  const iconCountOverride = Math.max(
+    offense.playerIcons.length,
+    defense?.playerIcons.length ?? 0,
+  );
+
+  // Defense first, so its coverage zones sit underneath the offensive routes
+  // the quarterback is being taught to read.
+  if (defense) {
+    renderScene(
+      ctx, W, H,
+      defense.paths, defense.playerIcons, defense.zones, null, defense.textBoxes, null,
+      { iconCountOverride },
+    );
+  }
+  renderScene(
+    ctx, W, H,
+    offense.paths, offense.playerIcons, offense.zones, null, offense.textBoxes, null,
+    { skipFieldReset: !!defense, iconCountOverride },
+  );
 }

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, Page } from '@playwright/test';
+import { readFileSync } from 'fs';
+
+// Same session-seeding trick as designer.spec.ts — supabase-js reads the
+// session from localStorage under a key derived from VITE_SUPABASE_URL.
+const SUPABASE_URL = readFileSync('.env', 'utf-8').match(/^VITE_SUPABASE_URL=(.+)$/m)?.[1].trim() ?? '';
+const AUTH_STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split('.')[0]}-auth-token`;
+
+/**
+ * Smoke coverage for the read-only "vs. defense" view (/vs?play=…), where a
+ * coach cycles defensive plays over one offensive play to teach QB reads.
+ *
+ * Assertions read real scene state through the dev-only `window.__PBP_VS_TEST__`
+ * bridge (VsDefenseView.tsx) — no pixel sampling. The thing most worth
+ * protecting is that cycling swaps the *defense* while leaving the offense
+ * untouched, which a screenshot would never catch.
+ */
+
+const USER = {
+  id: '44444444-4444-4444-4444-444444444444',
+  aud: 'authenticated', role: 'authenticated', email: 'vs-coach@example.com',
+  app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+};
+
+const scene = (letters: string[], y: number) =>
+  JSON.stringify({
+    version: 4,
+    playerIcons: letters.map((letter, i) => ({ x: 0.2 + i * 0.15, y, letter, color: '#3B82F6' })),
+    paths: [], zones: [], textBoxes: [],
+  });
+
+const OFFENSE = {
+  id: 'off-1', name: 'Smash Concept', type: 'offense', description: null,
+  metadata: { gameType: '5v5' }, canvas_data: scene(['Q', 'C', 'X', 'Y', 'Z'], 0.62),
+};
+
+const DEFENSES = [
+  { id: 'def-1', name: 'Cover 2 Zone', type: 'defense', description: 'Two deep halves',
+    metadata: { gameType: '5v5' }, canvas_data: scene(['D', 'CB', 'CB', 'S', 'S'], 0.45) },
+  { id: 'def-2', name: 'Man Blitz', type: 'defense', description: null,
+    metadata: { gameType: '5v5' }, canvas_data: scene(['D', 'D', 'CB', 'LB'], 0.48) },
+  // Deliberately malformed: must be dropped from the deck, not crash the page.
+  { id: 'def-3', name: 'Corrupt Look', type: 'defense', description: null,
+    metadata: null, canvas_data: '{not json' },
+];
+
+type VsState = {
+  offenseIcons: Array<{ letter: string }>;
+  defenseIcons: Array<{ letter: string }>;
+  defenseId: string | null;
+  deckLength: number;
+  index: number;
+  showDefense: boolean;
+};
+
+async function mockBackend(page: Page, defenses: typeof DEFENSES) {
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: USER, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(USER) }));
+
+  // Both play queries hit /rest/v1/plays — the offense fetch is a .single()
+  // keyed by id, the deck fetch filters type=eq.defense.
+  await page.route('**/rest/v1/plays**', (route) => {
+    const url = route.request().url();
+    const body = url.includes('type=eq.defense') ? JSON.stringify(defenses) : JSON.stringify(OFFENSE);
+    return route.fulfill({ status: 200, contentType: 'application/json', body });
+  });
+}
+
+function vsState(page: Page): Promise<VsState> {
+  return page.evaluate(() =>
+    (window as unknown as { __PBP_VS_TEST__: { getState: () => unknown } }).__PBP_VS_TEST__.getState(),
+  ) as Promise<VsState>;
+}
+
+async function openVs(page: Page, query = `?play=${OFFENSE.id}`) {
+  await page.goto(`/vs${query}`);
+  await page.waitForFunction(() => Boolean((window as unknown as { __PBP_VS_TEST__?: unknown }).__PBP_VS_TEST__));
+  // The bridge mounts on first render, while the view is still "Loading…" —
+  // the canvas only appears once the play and the defensive deck have loaded,
+  // so wait on it or every assertion reads an empty pre-fetch scene.
+  await expect(page.locator('#vs-canvas')).toBeVisible();
+}
+
+test('overlays a defense on the offense and cycles without disturbing the offense', async ({ page }) => {
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+
+  await mockBackend(page, DEFENSES);
+  await openVs(page);
+
+  const first = await vsState(page);
+  // The malformed third row is dropped, the two good ones survive.
+  expect(first.deckLength).toBe(2);
+  expect(first.offenseIcons.map((i) => i.letter)).toEqual(['Q', 'C', 'X', 'Y', 'Z']);
+  expect(first.defenseIcons.map((i) => i.letter)).toEqual(['D', 'CB', 'CB', 'S', 'S']);
+  await expect(page.locator('#vs-defense-label')).toContainText('Cover 2 Zone');
+  await expect(page.getByText('1 of 2', { exact: false })).toBeVisible();
+
+  // Arrow key advances the defense only.
+  await page.keyboard.press('ArrowRight');
+  await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
+  const second = await vsState(page);
+  expect(second.defenseIcons.map((i) => i.letter)).toEqual(['D', 'D', 'CB', 'LB']);
+  expect(second.offenseIcons).toEqual(first.offenseIcons);
+  expect(second.index).toBe(1);
+
+  // Wraps around at the end of the deck.
+  await page.keyboard.press('ArrowRight');
+  expect((await vsState(page)).index).toBe(0);
+  // …and backwards off the front.
+  await page.keyboard.press('ArrowLeft');
+  expect((await vsState(page)).index).toBe(1);
+
+  // Hiding the defense leaves the offense rendered on its own.
+  await page.getByRole('button', { name: /hide defense/i }).click();
+  const hidden = await vsState(page);
+  expect(hidden.showDefense).toBe(false);
+  expect(hidden.defenseIcons).toEqual([]);
+  expect(hidden.offenseIcons).toEqual(first.offenseIcons);
+
+  expect(errors, 'no uncaught page errors').toEqual([]);
+});
+
+test('?d= restores a specific matchup on reload', async ({ page }) => {
+  await mockBackend(page, DEFENSES);
+  await openVs(page, `?play=${OFFENSE.id}&d=def-2`);
+
+  const state = await vsState(page);
+  expect(state.defenseId).toBe('def-2');
+  await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
+
+  // Cycling keeps the URL pointed at what's on screen, so a refresh is stable.
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/d=def-1/);
+});
+
+test('with no saved defenses, the offense still renders and prompts to create one', async ({ page }) => {
+  await mockBackend(page, []);
+  await openVs(page);
+
+  const state = await vsState(page);
+  expect(state.deckLength).toBe(0);
+  expect(state.offenseIcons.map((i) => i.letter)).toEqual(['Q', 'C', 'X', 'Y', 'Z']);
+  expect(state.defenseIcons).toEqual([]);
+  await expect(page.getByRole('link', { name: /create a defense/i })).toBeVisible();
+});


### PR DESCRIPTION
## Why

Coaches asked to see an offensive play with a **defense drawn on top of it**, and to flip quickly between defensive looks — for teaching quarterback reads: *"here's Cover 2 against this concept, now man blitz — where do you throw?"*

Today a play is strictly single-sided (`plays.type` is an enum, locked once the play has content) and every "view a play" affordance routes into the *editable* designer. There was no read-only viewer and nothing rendered two plays together.

**The fact that made this cheap:** offense and defense already sit on opposite sides of the same universal field window (17 yards up / 13 down, LOS at y ≈ 0.567). Verified against the seeded library — every offensive play places icons at y ≥ 0.57, every defensive play at y ≤ 0.55. So overlaying needs **no mirroring and no coordinate transform**, only the ability to draw two scenes onto one canvas.

## What

- **`renderPlayScene.ts`** — optional `opts` on `renderScene` (`skipFieldReset`, `iconCountOverride`), plus `renderOverlayScene()`.
  - The two plays render as **two layers, not merged arrays** — `PathItem.startIconIndex` and `Zone.iconIndex` are indexes into their own call's `playerIcons`, so merging would mean re-basing every defensive index.
  - `iconCountOverride` uses `max(offense, defense)` so each side keeps the icon size it has when viewed alone, instead of a 5v5-on-5v5 matchup counting as 10 icons and hitting the crowding floor.
  - Defense draws first, so coverage zones sit *under* the offensive routes being read.
- **`EXPORT_WIDTH`/`EXPORT_HEIGHT` move** to `renderPlayScene` (re-exported from `Canvas.tsx` for existing importers) so a read-only view can lock the print aspect ratio without pulling the designer into its chunk.
- **New route `/vs?play=<id>`** (`&d=<defenseId>` makes a matchup linkable and refresh-stable): prev/next buttons + arrow keys with wrap-around, jump-to dropdown, hide/show defense, `n of N` with the defense's name/description/format badge.
- **Entry points** on the plays and playbooks pages, offense-only (pointing it at a defensive play would stack two defenses).

## Scope decisions

- **Deck = the coach's own defensive plays.** With none saved, the offense renders alone with a prompt to create one.
- **Format sorts, never filters** — `metadata.gameType` is absent on older rows, so filtering could silently empty the deck.
- **Free for all signed-in users.** Read-only over plays they already own; no export, no new storage. Deliberately no `useEntitlement()` call — this view runs its own `auth.getUser()`, and concurrent gotrue calls deadlock the session lock (B-4).
- **No schema change, no migration, no `canvas_data` version bump.** The two plays stay two rows; they're only composited at render time.

## Verification

- `npm run typecheck` — clean on touched files
- `npm run build` — passes; `VsDefenseView` splits into its own 8.66 kB chunk, confirming the designer didn't leak in
- `npm run smoke` — **87/87**, including 3 new tests driving a dev-only `window.__PBP_VS_TEST__` bridge (asserts cycling swaps the defense while the offense is untouched, `?d=` restores a matchup, malformed `canvas_data` is dropped from the deck rather than crashing, empty-deck state)
- `npx eslint` on touched files — **0 errors** (the 2 `any` warnings are the test bridge, matching `PlayDesigner`'s existing pattern)
- Driven in a real browser against the seeded 11v11 plays (Smash Concept vs. Cover 2 Zone and Fire Zone Blitz)

The browser check caught a bug the tests did not: the `ResizeObserver` was attaching while the view was still in its `loading` early-return, so `containerRef` was null and the canvas stayed at its 640×480 default. Smoke passed both before and after; only the screenshot showed it.

## Note on branching

This branches off `main`, not off `feat/two-routes-per-player` where the work was originally done — that commit touches `Canvas.tsx` and `renderPlayScene.ts` too, and bundling would violate the one-item-per-PR rule. The patch applies cleanly to `main` and was fully re-verified there.

Follow-ups (per-matchup coaching notes, matchup export, quiz mode, community defenses in the deck) are tracked as **BACKLOG B-36**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)