### PR TITLE
Move a player's routes with them when the icon is dragged

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -221,6 +221,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // otherwise every real-world tap would register as a (near-zero) drag
     // and the tap-to-customize popover below would never open.
     const dragMovedRef = useRef(false);
+    // Where the dragged icon sat at the end of the previous move event. Each
+    // move translates the icon's routes by the delta since this point rather
+    // than by the distance from the drag's origin, because the two diverge:
+    // computeSnap can pull the icon onto an alignment guide, so the position
+    // actually applied is not the raw pointer position.
+    const dragIconLastPosRef = useRef<Pt>({ x: 0, y: 0 });
 
     // Icon being edited via the tap-to-customize popover (Select mode only).
     const [editingIconIndex, setEditingIconIndex] = useState<number | null>(null);
@@ -1208,6 +1214,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         draggingIndexRef.current = clicked;
         dragOffsetRef.current = { x: p.x - icon.x, y: p.y - icon.y };
         dragStartRef.current = p;
+        dragIconLastPosRef.current = { x: icon.x, y: icon.y };
         dragMovedRef.current = false;
         setIsDragging(true);
         // Snapshot is deferred to the first actual move (see handlePointerMove)
@@ -1315,11 +1322,32 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         const raw = { x: p.x - dragOffsetRef.current.x, y: p.y - dragOffsetRef.current.y };
         const { pos, guideX, guideY, distX, distY } = computeSnap(raw, draggingIndexRef.current);
         setActiveGuides({ x: guideX, y: guideY, distX, distY });
+        const draggedIdx = draggingIndexRef.current;
         setPlayerIcons((prev) => {
           const c = [...prev];
-          c[draggingIndexRef.current!] = { ...c[draggingIndexRef.current!], x: pos.x, y: pos.y };
+          c[draggedIdx] = { ...c[draggedIdx], x: pos.x, y: pos.y };
           return c;
         });
+        // Carry the player's routes along with them. A route is the player's
+        // assignment, so moving a receiver two yards wider should slide their
+        // whole route over — not leave it stranded, and not rubber-band just
+        // its first point, which would deform the shape the coach drew.
+        // Every point translates by the same delta, so the route keeps its
+        // exact geometry. A player may have more than one route (short + deep
+        // option), so this moves all of them.
+        const dx = pos.x - dragIconLastPosRef.current.x;
+        const dy = pos.y - dragIconLastPosRef.current.y;
+        dragIconLastPosRef.current = pos;
+        if (dx !== 0 || dy !== 0) {
+          setPaths((prev) => {
+            if (!prev.some((path) => path.startIconIndex === draggedIdx)) return prev;
+            return prev.map((path) =>
+              path.startIconIndex === draggedIdx
+                ? { ...path, points: path.points.map((pt) => ({ x: pt.x + dx, y: pt.y + dy })) }
+                : path,
+            );
+          });
+        }
         return;
       }
 

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -3295,3 +3295,160 @@ test('routes: Remove Route mode deletes one of a player\'s two routes independen
   // deep route's y=0.15.
   expect(state.paths[0].points[state.paths[0].points.length - 1].y).toBeCloseTo(0.6, 1);
 });
+
+// Moving a player carries their route(s) with them. The route is the player's
+// assignment, so a receiver dragged two yards wider should take their whole
+// route along — rigidly translated, not left stranded and not rubber-banded
+// from its first point (which would deform the shape the coach drew).
+test('routes: dragging a player translates their route with them, preserving its shape', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  const state = await canvasState(page);
+  const iconPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  // A dog-leg so the assertion below would catch a shape change, not just a
+  // translation: out to the right, then straight upfield.
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(iconPx.x, iconPx.y);
+  await page.waitForTimeout(TAP_GAP);
+  const mid = await canvasPoint(page, 0.45, 0.6);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.45, 0.25);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  const before = await canvasState(page);
+  expect(before.paths).toHaveLength(1);
+  const iconBefore = before.playerIcons[0];
+  const ptsBefore = before.paths[0].points;
+
+  // Drag the player. Magnet snapping is on by default and there's only one
+  // icon on the field, so nothing can pull the drop point off the pointer.
+  await btn(page, 'Select / Move').click();
+  const from = await canvasPoint(page, iconBefore.x, iconBefore.y);
+  const to = await canvasPoint(page, iconBefore.x + 0.2, iconBefore.y - 0.1);
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(to.x, to.y, { steps: 8 });
+  await page.mouse.up();
+
+  const after = await canvasState(page);
+  const iconAfter = after.playerIcons[0];
+  const ptsAfter = after.paths[0].points;
+
+  // The icon actually moved.
+  const dx = iconAfter.x - iconBefore.x;
+  const dy = iconAfter.y - iconBefore.y;
+  expect(Math.abs(dx)).toBeGreaterThan(0.1);
+  expect(Math.abs(dy)).toBeGreaterThan(0.05);
+
+  // Every route point moved by that same delta — so the route followed AND
+  // kept its exact geometry.
+  expect(ptsAfter).toHaveLength(ptsBefore.length);
+  ptsAfter.forEach((pt, i) => {
+    expect(pt.x).toBeCloseTo(ptsBefore[i].x + dx, 5);
+    expect(pt.y).toBeCloseTo(ptsBefore[i].y + dy, 5);
+  });
+
+  // The route's origin still sits on the player it belongs to.
+  expect(ptsAfter[0].x).toBeCloseTo(iconAfter.x, 5);
+  expect(ptsAfter[0].y).toBeCloseTo(iconAfter.y, 5);
+
+  // One undo reverts the whole drag — icon and route together, not the icon
+  // alone leaving the route displaced.
+  await btn(page, 'Undo').click();
+  const undone = await canvasState(page);
+  expect(undone.playerIcons[0].x).toBeCloseTo(iconBefore.x, 5);
+  expect(undone.playerIcons[0].y).toBeCloseTo(iconBefore.y, 5);
+  undone.paths[0].points.forEach((pt, i) => {
+    expect(pt.x).toBeCloseTo(ptsBefore[i].x, 5);
+    expect(pt.y).toBeCloseTo(ptsBefore[i].y, 5);
+  });
+});
+
+// A player may carry two routes (short + deep option) — dragging them must
+// move both, not just the first one found.
+test('routes: dragging a player with two routes moves both', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  const state = await canvasState(page);
+  const iconPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  await drawStraightRoute(page, iconPx, await canvasPoint(page, 0.5, 0.6));
+  await drawStraightRoute(page, iconPx, await canvasPoint(page, 0.3, 0.2));
+
+  const before = await canvasState(page);
+  expect(before.paths).toHaveLength(2);
+  const iconBefore = before.playerIcons[0];
+
+  await btn(page, 'Select / Move').click();
+  const from = await canvasPoint(page, iconBefore.x, iconBefore.y);
+  const to = await canvasPoint(page, iconBefore.x + 0.15, iconBefore.y);
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(to.x, to.y, { steps: 8 });
+  await page.mouse.up();
+
+  const after = await canvasState(page);
+  const dx = after.playerIcons[0].x - iconBefore.x;
+  expect(Math.abs(dx)).toBeGreaterThan(0.1);
+
+  after.paths.forEach((path, pi) => {
+    path.points.forEach((pt, i) => {
+      expect(pt.x).toBeCloseTo(before.paths[pi].points[i].x + dx, 5);
+      expect(pt.y).toBeCloseTo(before.paths[pi].points[i].y, 5);
+    });
+  });
+});
+
+// Only the dragged player's routes move — a teammate's route must stay put.
+test('routes: dragging a player leaves another player\'s route untouched', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.7, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  const state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(2);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+
+  await drawStraightRoute(page, qPx, await canvasPoint(page, 0.3, 0.25));
+  await drawStraightRoute(page, xPx, await canvasPoint(page, 0.7, 0.25));
+
+  const before = await canvasState(page);
+  expect(before.paths).toHaveLength(2);
+  const qRouteIdx = before.paths.findIndex((p) => p.startIconIndex === 0);
+  const xRouteIdx = before.paths.findIndex((p) => p.startIconIndex === 1);
+  const xPtsBefore = before.paths[xRouteIdx].points;
+
+  // Drag Q straight down; X and X's route must not budge.
+  await btn(page, 'Select / Move').click();
+  const from = await canvasPoint(page, before.playerIcons[0].x, before.playerIcons[0].y);
+  const to = await canvasPoint(page, before.playerIcons[0].x, before.playerIcons[0].y + 0.12);
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(to.x, to.y, { steps: 8 });
+  await page.mouse.up();
+
+  const after = await canvasState(page);
+  expect(after.playerIcons[1].x).toBeCloseTo(before.playerIcons[1].x, 5);
+  expect(after.playerIcons[1].y).toBeCloseTo(before.playerIcons[1].y, 5);
+  after.paths[xRouteIdx].points.forEach((pt, i) => {
+    expect(pt.x).toBeCloseTo(xPtsBefore[i].x, 5);
+    expect(pt.y).toBeCloseTo(xPtsBefore[i].y, 5);
+  });
+  // …while Q's route did move.
+  expect(after.paths[qRouteIdx].points[0].y).toBeGreaterThan(before.paths[qRouteIdx].points[0].y + 0.05);
+});


### PR DESCRIPTION
## Why

Dragging a player left their routes behind, so repositioning a receiver meant redrawing the route by hand. A route is that player's **assignment** — it should travel with them.

## What

In `Canvas.tsx`'s icon-drag handler, every point of the dragged player's routes translates by the same delta as the icon.

Three details worth calling out:

- **Rigid translation, not a rubber band.** Moving only the route's first point would deform the shape near the origin; translating every point keeps the exact geometry the coach drew. The new test uses a dog-leg route specifically so a shape change would fail the assertion, not just a missing translation.
- **The delta is measured against the icon's position at the end of the previous move event**, not against the drag's origin. `computeSnap` can pull the icon onto an alignment guide, so the position actually applied is not the raw pointer position — measuring from the origin would let icon and route drift apart over a drag.
- **Both routes move.** A player may carry two routes (short + deep option) since #44, so this filters on `startIconIndex` rather than finding one.

Undo needed no change: `pushSnapshot` already captures paths and icons together, and it fires once on the first real move — so one undo reverts the icon and its routes as a single action.

## Deliberately not included

**Zones stay put.** `Zone.iconIndex` anchors a zone to a defender, but the designer deliberately supports dragging a zone *away* from its icon — it draws a dashed connector once it's far enough. Zone position is independent by design, so making zones follow the icon is a separate product call rather than something to fold in here. Happy to do it if you want it.

Route points are not clamped to the field. Dragging a player to the sideline can push part of their route past the edge, which seemed better than clamping each point independently — that would silently deform the route.

## Verification

- **3 new smoke tests**, each confirmed to **fail on `main` and pass with this change**:
  - a dog-leg route follows the player and keeps its shape; one undo reverts both
  - a player with two routes moves both
  - dragging one player leaves a teammate's route untouched
- `npm run smoke` — **93/93**
- `npm run typecheck` — clean on touched files
- `npm run build` — passes
- `npx eslint` on touched files — **0 errors**
- Driven in a real browser: dog-leg route follows the drag, stays attached to the icon, and a single undo restores both

🤖 Generated with [Claude Code](https://claude.com/claude-code)