### PR TITLE
Fix zone connector line disappearing when a zone is stretched

### DIFF
--- a/src/lib/renderPlayScene.ts
+++ b/src/lib/renderPlayScene.ts
@@ -505,6 +505,33 @@ function drawZoneHandles(ctx: CanvasRenderingContext2D, cx: number, cy: number, 
   ctx.restore();
 }
 
+/**
+ * Whether a zone's dashed connector line to its icon should be drawn — true
+ * once the icon sits meaningfully outside the zone's ellipse.
+ *
+ * Deliberately ellipse-relative (each axis normalized by its own radius)
+ * rather than a raw distance compared against a threshold scaled by
+ * max(rx, ry): the latter meant *resizing* the zone changed the very
+ * threshold used to decide whether to show the connector, so stretching a
+ * zone wide (growing rx) could make the line disappear even though the icon
+ * was still visibly outside the ellipse in the y direction. Normalizing per
+ * axis makes the check correct for non-circular zones and stable under
+ * resize — only actually moving the icon relative to the zone changes the
+ * result. Coordinates just need to share a unit (normalized 0–1 or pixel);
+ * only their ratios matter.
+ */
+export function zoneConnectorVisible(
+  zone: Pick<Zone, 'cx' | 'cy' | 'rx' | 'ry'>,
+  icon: Pick<Pt, 'x' | 'y'> | undefined,
+): boolean {
+  if (!icon) return false;
+  if (zone.rx <= 0 || zone.ry <= 0) return true;
+  const normDist = Math.sqrt(
+    ((icon.x - zone.cx) / zone.rx) ** 2 + ((icon.y - zone.cy) / zone.ry) ** 2,
+  );
+  return normDist > 0.6;
+}
+
 /** Draws committed zones — translucent fill (field grid shows through),
  *  a connector line back to the icon once the zone has been moved away
  *  from it, and resize handles on the selected zone. */
@@ -527,8 +554,7 @@ function drawZones(
     if (icon) {
       const ix = icon.x * W;
       const iy = icon.y * H;
-      const dist = Math.sqrt((ix - cx) ** 2 + (iy - cy) ** 2);
-      if (dist > Math.max(rx, ry) * 0.6) {
+      if (zoneConnectorVisible(zone, icon)) {
         ctx.save();
         ctx.strokeStyle = zone.color;
         ctx.globalAlpha = 0.7;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page, CDPSession } from '@playwright/test';
 import { readFileSync } from 'fs';
+import { zoneConnectorVisible } from '../../src/lib/renderPlayScene';
 
 // Mocked-session tests must seed localStorage under the same key the real
 // supabase-js client reads (`sb-<project-ref>-auth-token`, derived from
@@ -3451,4 +3452,96 @@ test('routes: dragging a player leaves another player\'s route untouched', async
   });
   // …while Q's route did move.
   expect(after.paths[qRouteIdx].points[0].y).toBeGreaterThan(before.paths[qRouteIdx].points[0].y + 0.05);
+});
+
+// A zone's dashed connector to its icon is only meaningful once the icon is
+// visibly outside the zone. It used to be decided by comparing the icon's
+// raw distance from the zone center against a threshold scaled off the
+// zone's OWN radius (max(rx, ry) * 0.6) — so stretching the zone larger
+// inflated the very threshold used to decide whether to show the line, and
+// a wide zone could hide the connector even though the icon sat clearly
+// outside the ellipse in the other axis. zoneConnectorVisible() fixes this
+// by normalizing each axis by its own radius (ellipse-relative), which is
+// unit-invariant — normalized 0–1 fractions and pixel coordinates give the
+// same answer, since only the ratios matter.
+test('zone connector: visibility is ellipse-relative, not tied to the zone\'s own size', () => {
+  // Reproduces the reported bug with concrete numbers: a zone dragged well
+  // above its icon (a real vertical gap), then stretched wide horizontally.
+  const zone = { cx: 0.5, cy: 0.3, rx: 0.35, ry: 0.05 };
+  const icon = { x: 0.5, y: 0.45 }; // 0.15 below the zone center — 3x the zone's own height (ry)
+
+  // The old formula, inlined here to document exactly what broke: a single
+  // threshold derived from the zone's largest radius, applied regardless of
+  // which axis the icon actually diverges on.
+  const oldDist = Math.hypot(icon.x - zone.cx, icon.y - zone.cy);
+  const oldVisible = oldDist > Math.max(zone.rx, zone.ry) * 0.6;
+  expect(oldVisible).toBe(false); // the bug: hidden despite the icon being well outside the ellipse
+
+  expect(zoneConnectorVisible(zone, icon)).toBe(true);
+
+  // Sanity check the other direction too: an icon still close to a small,
+  // unstretched zone should not show a connector.
+  expect(zoneConnectorVisible({ cx: 0.5, cy: 0.5, rx: 0.05, ry: 0.05 }, { x: 0.51, y: 0.5 })).toBe(false);
+
+  // No icon (shouldn't happen for a live zone, but iconIndex is a plain
+  // array index with no referential guarantee) never draws a connector.
+  expect(zoneConnectorVisible(zone, undefined)).toBe(false);
+});
+
+test('defense: zone connector stays visible after stretching the zone wide (regression for the reported bug)', async ({ page }) => {
+  await openDesigner(page);
+
+  await page.getByRole('button', { name: 'defense', exact: true }).click();
+  await btn(page, 'Player S').click();
+  const spot = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const iconPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  // Create a zone directly on the icon (creation always centers the zone on
+  // its icon — see Canvas.tsx's zoneDraft) — big enough that its edge sits
+  // well clear of the icon's own hit radius.
+  await btn(page, 'Draw a zone of responsibility (drag from a player)').click();
+  await page.mouse.move(iconPx.x, iconPx.y);
+  await page.mouse.down();
+  await page.mouse.move(iconPx.x + 90, iconPx.y + 60, { steps: 6 });
+  await page.mouse.up();
+
+  // Drag the zone body (not the icon — grabbed away from center, near the
+  // right edge, so this can't land on the icon) straight up, away from the
+  // icon, so a real vertical gap opens up. One continuous drag both selects
+  // the zone and moves it, same as a coach dragging a freshly-drawn zone.
+  await btn(page, 'Select / Move').click();
+  state = await canvasState(page);
+  const grabPx = await canvasPoint(page, state.zones[0].cx + state.zones[0].rx * 0.7, state.zones[0].cy);
+  await page.mouse.move(grabPx.x, grabPx.y);
+  await page.mouse.down();
+  await page.mouse.move(grabPx.x, grabPx.y - 150, { steps: 8 });
+  await page.mouse.up();
+
+  state = await canvasState(page);
+  const zoneAfterMove = state.zones[0];
+  // The move actually landed on the zone, not the icon — the icon is still
+  // where it was placed, and the zone center is now well above it.
+  expect(state.playerIcons[0].y).toBeCloseTo(0.6, 1);
+  expect(zoneAfterMove.cy).toBeLessThan(state.playerIcons[0].y - 0.05);
+  expect(zoneConnectorVisible(zoneAfterMove, state.playerIcons[0])).toBe(true);
+
+  // Now stretch the zone horizontally via its right-edge (x-axis) resize
+  // handle — the exact action reported: "stretching the zone horizontally."
+  const handlePx = await canvasPoint(page, zoneAfterMove.cx + zoneAfterMove.rx, zoneAfterMove.cy);
+  await page.mouse.move(handlePx.x, handlePx.y);
+  await page.mouse.down();
+  await page.mouse.move(handlePx.x + 250, handlePx.y, { steps: 10 });
+  await page.mouse.up();
+
+  state = await canvasState(page);
+  // The stretch actually landed…
+  expect(state.zones[0].rx).toBeGreaterThan(zoneAfterMove.rx + 0.1);
+  // …the resize handle only touched rx, not the vertical gap that makes the
+  // connector meaningful…
+  expect(state.zones[0].ry).toBeCloseTo(zoneAfterMove.ry, 5);
+  expect(state.zones[0].cy).toBeCloseTo(zoneAfterMove.cy, 5);
+  // …and the connector — the actual bug report — is still visible.
+  expect(zoneConnectorVisible(state.zones[0], state.playerIcons[0])).toBe(true);
 });


### PR DESCRIPTION
## Bug report

> When a player icon is moved on the canvas and a route exists for that player, move the route along with the player icon. [unrelated to this PR — separate report:] I noticed the dotted line connecting the zone disappears once the zone reaches a certain size. I've witnessed this when stretching the zone horizontally. Once it reaches a certain size the dotted line connecting the player to the zone disappears.

## Root cause

`drawZones()` in `renderPlayScene.ts` decided whether to draw the dashed connector by comparing the icon's raw pixel distance from the zone center against a threshold **scaled off the zone's own size**:

```ts
const dist = Math.sqrt((ix - cx) ** 2 + (iy - cy) ** 2);
if (dist > Math.max(rx, ry) * 0.6) { /* draw connector */ }
```

Resizing the zone changes `rx`/`ry` but not `dist` — so stretching a zone wide (growing `rx`) inflates the very threshold used to decide whether to show the line, while a vertical gap to the icon (unaffected by a horizontal stretch) stays fixed. Once the threshold outgrows the distance, the connector disappears — even though the icon is still clearly outside the ellipse. The check was also not aspect-ratio aware: it used `max(rx, ry)` as a single circular threshold regardless of which axis the icon actually diverged on.

## Fix

Extracted the decision into an exported, unit-testable `zoneConnectorVisible()` that normalizes the icon's offset **per axis, by that axis's own radius** (ellipse-relative), instead of a threshold derived from the zone's size:

```ts
const normDist = Math.sqrt(((icon.x - zone.cx) / zone.rx) ** 2 + ((icon.y - zone.cy) / zone.ry) ** 2);
return normDist > 0.6;
```

This only changes when the icon actually moves relative to the zone — not when the zone is resized — and it's correct for non-circular (stretched) zones.

## Verification

- **A numeric unit test** reproduces the reported repro with concrete numbers (a zone dragged well above its icon, then stretched wide): the inlined old formula hides the connector; `zoneConnectorVisible()` doesn't.
- **A smoke test drives the real UI**: place a defender, draw a zone, drag the zone away from its icon (not the icon itself — grabbed off-center so it can't land on the icon), then stretch it via the x-axis resize handle, exactly as reported. Reads the real post-drag geometry and confirms the connector is still visible.
- **Both tests were confirmed to fail against the old formula and pass against the fix** (temporarily swapped `zoneConnectorVisible`'s body back to the buggy math and reran — both failed as expected, then restored and reran — both passed), so they're not tautological.
- `npm run smoke` — **95/95**
- `npm run typecheck` — clean
- `npm run build` — passes
- `npx eslint` on touched files — **0 problems**
- Confirmed visually in a real browser — before/after screenshots of the exact repro (zone dragged away from its icon, then stretched wide) show the connector staying visible throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)