### PR TITLE
⚠ requires SQL run — let coaches edit and delete their own Community posts

### DIFF
--- a/src/components/community/CommunityPage.tsx
+++ b/src/components/community/CommunityPage.tsx
@@ -16,6 +16,14 @@ export function CommunityPage() {
   const [posts, setPosts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  // One-shot lookup, not inside onAuthStateChange — a callback there calling
+  // auth.getUser() re-entrantly is what deadlocked the gotrue session lock
+  // elsewhere in this app (see entitlements.ts's B-4 note).
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setCurrentUserId(user?.id ?? null));
+  }, []);
 
   const fetchPosts = async () => {
     try {
@@ -114,6 +122,8 @@ export function CommunityPage() {
               loading={loading}
               timeRange={timeRange}
               searchQuery={searchQuery}
+              currentUserId={currentUserId}
+              onChanged={fetchPosts}
             />
           </div>
 

--- a/src/components/community/CreatePostButton.tsx
+++ b/src/components/community/CreatePostButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PenSquare } from 'lucide-react';
-import { CreatePostModal } from './CreatePostModal';
+import { PostFormModal } from './PostFormModal';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 
@@ -31,10 +31,10 @@ export function CreatePostButton({ onPostCreated }: CreatePostButtonProps) {
         <span>Create Post</span>
       </button>
 
-      <CreatePostModal
+      <PostFormModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        onPostCreated={onPostCreated}
+        onSaved={onPostCreated}
       />
     </>
   );

--- a/src/components/community/PostFormModal.tsx
+++ b/src/components/community/PostFormModal.tsx
@@ -3,15 +3,18 @@ import { X } from 'lucide-react';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { supabase } from '../../lib/supabase';
 
-interface CreatePostModalProps {
+interface PostFormModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onPostCreated: () => void;
+  onSaved: () => void;
+  /** Present to edit an existing post in place; absent to create a new one. */
+  post?: { id: string; title: string; content: string };
 }
 
-export function CreatePostModal({ isOpen, onClose, onPostCreated }: CreatePostModalProps) {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+export function PostFormModal({ isOpen, onClose, onSaved, post }: PostFormModalProps) {
+  const isEditing = !!post;
+  const [title, setTitle] = useState(post?.title ?? '');
+  const [content, setContent] = useState(post?.content ?? '');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -24,26 +27,36 @@ export function CreatePostModal({ isOpen, onClose, onPostCreated }: CreatePostMo
 
     try {
       const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error('You must be signed in to create a post');
+      if (!user) throw new Error(isEditing ? 'You must be signed in to edit a post' : 'You must be signed in to create a post');
 
-      const { error: postError } = await supabase
-        .from('posts')
-        .insert([
-          {
-            title,
-            content,
-            user_id: user.id
-          }
-        ]);
-
-      if (postError) throw postError;
+      if (isEditing) {
+        // RLS (auth.uid() = user_id, unchanged by this update) already scopes
+        // this to the caller's own posts — the .eq('id', ...) below is just
+        // which row, not the security boundary.
+        const { error: updateError } = await supabase
+          .from('posts')
+          .update({ title, content })
+          .eq('id', post.id);
+        if (updateError) throw updateError;
+      } else {
+        const { error: insertError } = await supabase
+          .from('posts')
+          .insert([
+            {
+              title,
+              content,
+              user_id: user.id
+            }
+          ]);
+        if (insertError) throw insertError;
+      }
 
       setTitle('');
       setContent('');
-      onPostCreated();
+      onSaved();
       onClose();
     } catch (err) {
-      setError(getSafeErrorMessage(err, 'Failed to create post'));
+      setError(getSafeErrorMessage(err, isEditing ? 'Failed to save changes' : 'Failed to create post'));
     } finally {
       setLoading(false);
     }
@@ -56,7 +69,7 @@ export function CreatePostModal({ isOpen, onClose, onPostCreated }: CreatePostMo
 
         <div className="inline-block w-full max-w-2xl my-8 overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
           <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
-            <h3 className="text-2xl font-bold text-chalk">Create Post</h3>
+            <h3 className="text-2xl font-bold text-chalk">{isEditing ? 'Edit Post' : 'Create Post'}</h3>
             <button
               onClick={onClose}
               className="text-chalk/70 hover:text-chalk transition-colors"
@@ -116,7 +129,7 @@ export function CreatePostModal({ isOpen, onClose, onPostCreated }: CreatePostMo
                   disabled={loading}
                   className="px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {loading ? 'Creating...' : 'Create Post'}
+                  {loading ? (isEditing ? 'Saving...' : 'Creating...') : (isEditing ? 'Save Changes' : 'Create Post')}
                 </button>
               </div>
             </div>

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -1,17 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { MessageSquare, ArrowUp, ArrowDown } from 'lucide-react';
+import { MessageSquare, ArrowUp, ArrowDown, Pencil, Trash2 } from 'lucide-react';
 import type { TimeRange } from '../../types/community';
 import { supabase } from '../../lib/supabase';
+import { getSafeErrorMessage } from '../../lib/errors';
+import { PostFormModal } from './PostFormModal';
 
 interface PostListProps {
   posts: any[];
   loading: boolean;
   timeRange: TimeRange;
   searchQuery: string;
+  /** The signed-in viewer's id, or null if signed out — decides which posts
+   *  show Edit/Delete. RLS already scopes the actual writes to the owner;
+   *  this only controls whether the buttons render. */
+  currentUserId: string | null;
+  /** Re-fetches the post list — called after a successful edit or delete. */
+  onChanged: () => void;
 }
 
-export function PostList({ posts, loading, timeRange: _timeRange, searchQuery }: PostListProps) {
+/** A post has been edited if its updated_at moved past created_at. Compared
+ *  as Date values, not strings — Postgres may format an unchanged timestamp
+ *  with different trailing precision than the value it was inserted with. */
+function wasEdited(post: { created_at: string; updated_at?: string }): boolean {
+  if (!post.updated_at) return false;
+  return new Date(post.updated_at).getTime() > new Date(post.created_at).getTime();
+}
+
+export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, currentUserId, onChanged }: PostListProps) {
+  const [editingPost, setEditingPost] = useState<{ id: string; title: string; content: string } | null>(null);
+  const [deleteError, setDeleteError] = useState('');
+
   const handleVote = async (postId: string, voteType: boolean) => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
@@ -30,6 +49,24 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery }:
       if (error) throw error;
     } catch (error) {
       console.error('Error voting:', error);
+    }
+  };
+
+  const handleDelete = async (postId: string) => {
+    if (!confirm('Are you sure you want to delete this post? This action cannot be undone.')) {
+      return;
+    }
+    setDeleteError('');
+    try {
+      const { error } = await supabase
+        .from('posts')
+        .delete()
+        .eq('id', postId);
+      if (error) throw error;
+      onChanged();
+    } catch (err) {
+      console.error('Error deleting post:', err);
+      setDeleteError(getSafeErrorMessage(err, 'Failed to delete post'));
     }
   };
 
@@ -62,61 +99,101 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery }:
 
   return (
     <div className="space-y-4">
-      {posts.map((post) => (
-        <article key={post.id} className="bg-board-light rounded-lg p-6 border border-chalk/10">
-          <div className="flex gap-4">
-            {/* Voting */}
-            <div className="flex flex-col items-center gap-1">
-              <button
-                onClick={() => handleVote(post.id, true)}
-                className="p-1 text-chalk/70 hover:text-primary transition-colors"
-              >
-                <ArrowUp className="h-6 w-6" />
-              </button>
-              <span className="text-chalk font-bold">{post.upvotes - post.downvotes}</span>
-              <button
-                onClick={() => handleVote(post.id, false)}
-                className="p-1 text-chalk/70 hover:text-primary transition-colors"
-              >
-                <ArrowDown className="h-6 w-6" />
-              </button>
-            </div>
+      {deleteError && (
+        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+          <p className="text-red-500">{deleteError}</p>
+        </div>
+      )}
 
-            {/* Content */}
-            <div className="flex-1">
-              <div className="flex items-center gap-3 mb-2">
-                <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center overflow-hidden">
-                  {post.author?.avatar_url ? (
-                    <img src={post.author.avatar_url} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
-                  ) : (
-                    <span className="text-primary text-sm">
-                      {post.author?.username?.[0]?.toUpperCase() || 'U'}
-                    </span>
-                  )}
-                </div>
-                <span className="text-chalk/70">Posted by</span>
-                <span className="text-primary font-medium">
-                  {post.author?.username || 'Anonymous'}
-                </span>
-                <span className="text-chalk/50">•</span>
-                <span className="text-chalk/70">
-                  {formatDistanceToNow(new Date(post.created_at), { addSuffix: true })}
-                </span>
-              </div>
-
-              <h3 className="text-xl font-bold text-chalk mb-2">{post.title}</h3>
-              <p className="text-chalk/70 mb-4">{post.content}</p>
-
-              <div className="flex items-center gap-4">
-                <button className="flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors">
-                  <MessageSquare className="h-5 w-5" />
-                  <span>{post.comment_count || 0} Comments</span>
+      {posts.map((post) => {
+        const isOwnPost = currentUserId !== null && post.user_id === currentUserId;
+        return (
+          <article key={post.id} className="bg-board-light rounded-lg p-6 border border-chalk/10">
+            <div className="flex gap-4">
+              {/* Voting */}
+              <div className="flex flex-col items-center gap-1">
+                <button
+                  onClick={() => handleVote(post.id, true)}
+                  className="p-1 text-chalk/70 hover:text-primary transition-colors"
+                >
+                  <ArrowUp className="h-6 w-6" />
+                </button>
+                <span className="text-chalk font-bold">{post.upvotes - post.downvotes}</span>
+                <button
+                  onClick={() => handleVote(post.id, false)}
+                  className="p-1 text-chalk/70 hover:text-primary transition-colors"
+                >
+                  <ArrowDown className="h-6 w-6" />
                 </button>
               </div>
+
+              {/* Content */}
+              <div className="flex-1">
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center overflow-hidden shrink-0">
+                      {post.author?.avatar_url ? (
+                        <img src={post.author.avatar_url} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
+                      ) : (
+                        <span className="text-primary text-sm">
+                          {post.author?.username?.[0]?.toUpperCase() || 'U'}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-chalk/70 shrink-0">Posted by</span>
+                    <span className="text-primary font-medium shrink-0">
+                      {post.author?.username || 'Anonymous'}
+                    </span>
+                    <span className="text-chalk/50 shrink-0">•</span>
+                    <span className="text-chalk/70 truncate">
+                      {formatDistanceToNow(new Date(post.created_at), { addSuffix: true })}
+                      {wasEdited(post) && <span className="text-chalk/50"> · edited</span>}
+                    </span>
+                  </div>
+
+                  {isOwnPost && (
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => setEditingPost({ id: post.id, title: post.title, content: post.content })}
+                        title="Edit Post"
+                        className="p-1.5 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(post.id)}
+                        title="Delete Post"
+                        className="p-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <h3 className="text-xl font-bold text-chalk mb-2">{post.title}</h3>
+                <p className="text-chalk/70 mb-4">{post.content}</p>
+
+                <div className="flex items-center gap-4">
+                  <button className="flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors">
+                    <MessageSquare className="h-5 w-5" />
+                    <span>{post.comment_count || 0} Comments</span>
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
-        </article>
-      ))}
+          </article>
+        );
+      })}
+
+      {editingPost && (
+        <PostFormModal
+          isOpen={true}
+          onClose={() => setEditingPost(null)}
+          onSaved={onChanged}
+          post={editingPost}
+        />
+      )}
     </div>
   );
 }

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -32,6 +32,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `fix_playbook_plays_positions.sql` | **pending — needs SQL run** | One-off data repair, no schema change: renumbers any `playbook_plays` rows stranded at `order_position <= 0` by the drag-to-reorder bug (a failed reorder only rolled back the browser's on-screen state, never the partial DB write, so retries collided with the stranded row forever). Idempotent — no-op once nothing is `<= 0`. |
 | `add_6v6_game_format.sql` | **pending — needs SQL run** | Widens `custom_formations.game_type` and `user_preferences.default_game_format`'s `CHECK` constraints to allow `'6v6'`, alongside new 6v6 formation templates in `formations.ts`. No new column. |
 | `community_top_contributors.sql` | **pending — needs SQL run** | `get_top_contributors(result_limit int)` — real top-N posters by `user_reputation.reputation` (>0 only), same `auth.users`/`avatar_icons` join pattern as `get_community_authors()`. Fixes the Community page's "Top Contributors" sidebar, which was hardcoded mock data (fake usernames/photos/reputation) presented as real. |
+| `community_posts_updated_at.sql` | **pending — needs SQL run** | `BEFORE UPDATE` trigger on `posts` reusing the existing `update_updated_at_column()` function (already wired to `plays`/`playbooks`, just missing here). Lets the UI show an "(edited)" marker instead of an edit looking identical to the original post. No schema change. |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.
@@ -62,7 +63,7 @@ idempotent `.sql` file and update this doc in the same change.
 ### Community / social
 | Table | Key columns | RLS summary |
 |---|---|---|
-| `posts` | `id`, `user_id`, `title`, `content`, `upvotes`, `downvotes`, timestamps | SELECT public (`true`); insert/update/delete own. |
+| `posts` | `id`, `user_id`, `title`, `content`, `upvotes`, `downvotes`, timestamps | SELECT public (`true`); insert/update/delete own. `updated_at` refreshed on edit by `community_posts_updated_at.sql`'s trigger. |
 | `comments` | `id`, `user_id`, `post_id`, `parent_id`, `content`, `upvotes`, `downvotes` | SELECT public; CRUD own; admins can delete any. |
 | `votes` | `id`, `user_id`, `post_id?`, `comment_id?`, `vote_type bool`; UNIQUE per user+target | SELECT public; CRUD own. Target check: exactly one of post/comment. |
 | `play_votes` | `id`, `user_id`, `play_id`, `created_at`; UNIQUE`(user_id,play_id)` | SELECT public; INSERT own **and only on public plays**; DELETE own. Triggers keep `plays.upvotes` in sync (`play_votes.sql`, B-10). |

--- a/supabase/community_posts_updated_at.sql
+++ b/supabase/community_posts_updated_at.sql
@@ -1,0 +1,14 @@
+-- Keep posts.updated_at accurate when a coach edits their own post.
+-- Run this once in the Supabase SQL Editor. Idempotent — safe to re-run.
+--
+-- posts already has an updated_at column, but unlike plays/playbooks no
+-- trigger refreshes it on UPDATE, so an edited post would render identically
+-- to an unedited one. Reuses the same update_updated_at_column() function
+-- combined_migrations.sql already defines and wires to plays/playbooks —
+-- no new function needed, just the missing trigger for this table.
+
+DROP TRIGGER IF EXISTS update_posts_updated_at ON posts;
+CREATE TRIGGER update_posts_updated_at
+  BEFORE UPDATE ON posts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -3325,6 +3325,171 @@ test('Community Forum: no fabricated "Trending Topics" section (no real topic/ta
 });
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * Community Forum — editing and deleting your own posts. RLS already scopes
+ * the writes to the owner (auth.uid() = user_id); these tests cover the UI
+ * half: the buttons only render on your own posts, and edit/delete actually
+ * reach the backend and update what's on screen afterward.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const COMMUNITY_USER = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+  app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+};
+const OTHER_USER_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function signInAsCommunityUser(page: Page) {
+  return page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: COMMUNITY_USER, storageKey: AUTH_STORAGE_KEY });
+}
+
+async function mockCommunityAuthors(page: Page) {
+  await page.route('**/rest/v1/rpc/get_top_contributors**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/rest/v1/rpc/get_community_authors**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: COMMUNITY_USER.id, username: 'Coach', avatar_url: null },
+        { id: OTHER_USER_ID, username: 'OtherCoach', avatar_url: null },
+      ]),
+    }));
+}
+
+test('Community Forum: Edit/Delete only render on your own post, never on someone else\'s', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+  await page.route('**/rest/v1/posts**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'own-post', title: 'My Post', content: 'Mine', user_id: COMMUNITY_USER.id, upvotes: 0, downvotes: 0, created_at: '2026-08-01T00:00:00Z', updated_at: '2026-08-01T00:00:00Z' },
+        { id: 'other-post', title: 'Their Post', content: 'Not mine', user_id: OTHER_USER_ID, upvotes: 0, downvotes: 0, created_at: '2026-08-01T00:00:00Z', updated_at: '2026-08-01T00:00:00Z' },
+      ]),
+    }));
+
+  await page.goto('/community');
+  await expect(page.getByText('My Post')).toBeVisible();
+  await expect(page.getByText('Their Post')).toBeVisible();
+
+  const ownArticle = page.locator('article', { hasText: 'My Post' });
+  const otherArticle = page.locator('article', { hasText: 'Their Post' });
+  await expect(ownArticle.locator('button[title="Edit Post"]')).toBeVisible();
+  await expect(ownArticle.locator('button[title="Delete Post"]')).toBeVisible();
+  await expect(otherArticle.locator('button[title="Edit Post"]')).toHaveCount(0);
+  await expect(otherArticle.locator('button[title="Delete Post"]')).toHaveCount(0);
+});
+
+test('Community Forum: signed out, no post shows Edit/Delete', async ({ page }) => {
+  await mockCommunityAuthors(page);
+  await page.route('**/rest/v1/posts**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'own-post', title: 'My Post', content: 'Mine', user_id: COMMUNITY_USER.id, upvotes: 0, downvotes: 0, created_at: '2026-08-01T00:00:00Z', updated_at: '2026-08-01T00:00:00Z' },
+      ]),
+    }));
+
+  await page.goto('/community');
+  await expect(page.getByText('My Post')).toBeVisible();
+  await expect(page.locator('button[title="Edit Post"]')).toHaveCount(0);
+  await expect(page.locator('button[title="Delete Post"]')).toHaveCount(0);
+});
+
+test('Community Forum: editing a post saves the change and shows an "edited" marker; an untouched post shows none', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+
+  let edited = false;
+  const patchBodies: any[] = [];
+  await page.route('**/rest/v1/posts**', (route) => {
+    const method = route.request().method();
+    if (method === 'PATCH') {
+      patchBodies.push(route.request().postDataJSON());
+      edited = true;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+    return route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([{
+        id: 'own-post',
+        title: edited ? 'Updated title' : 'Original title',
+        content: edited ? 'Updated content' : 'Original content',
+        user_id: COMMUNITY_USER.id, upvotes: 0, downvotes: 0,
+        created_at: '2026-08-01T00:00:00Z',
+        updated_at: edited ? '2026-08-01T01:00:00Z' : '2026-08-01T00:00:00Z',
+      }]),
+    });
+  });
+
+  await page.goto('/community');
+  await expect(page.getByText('Original title')).toBeVisible();
+  // Not edited yet — no marker.
+  await expect(page.getByText('edited', { exact: false })).toHaveCount(0);
+
+  await page.locator('button[title="Edit Post"]').click();
+  await expect(page.getByRole('heading', { name: 'Edit Post' })).toBeVisible();
+  const titleInput = page.locator('#title');
+  const contentInput = page.locator('#content');
+  await expect(titleInput).toHaveValue('Original title');
+  await expect(contentInput).toHaveValue('Original content');
+
+  await titleInput.fill('Updated title');
+  await contentInput.fill('Updated content');
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+
+  await expect(page.getByText('Updated title')).toBeVisible();
+  await expect(page.getByText('edited', { exact: false })).toBeVisible();
+  expect(patchBodies).toHaveLength(1);
+  expect(patchBodies[0]).toMatchObject({ title: 'Updated title', content: 'Updated content' });
+  // Update never touches user_id — RLS's WITH CHECK is the real boundary, but
+  // the client shouldn't even attempt to send a different one.
+  expect(patchBodies[0].user_id).toBeUndefined();
+});
+
+test('Community Forum: deleting a post confirms, deletes, and removes it from the list', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+
+  let deleted = false;
+  const deletedIds: string[] = [];
+  await page.route('**/rest/v1/posts**', (route) => {
+    const method = route.request().method();
+    if (method === 'DELETE') {
+      deleted = true;
+      const url = new URL(route.request().url());
+      deletedIds.push(url.searchParams.get('id') || '');
+      return route.fulfill({ status: 204, contentType: 'application/json', body: '' });
+    }
+    return route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify(deleted ? [] : [
+        { id: 'own-post', title: 'Doomed Post', content: 'Going away', user_id: COMMUNITY_USER.id, upvotes: 0, downvotes: 0, created_at: '2026-08-01T00:00:00Z', updated_at: '2026-08-01T00:00:00Z' },
+      ]),
+    });
+  });
+
+  await page.goto('/community');
+  await expect(page.getByText('Doomed Post')).toBeVisible();
+
+  page.once('dialog', (dialog) => dialog.accept());
+  await page.locator('button[title="Delete Post"]').click();
+
+  await expect(page.getByText('Doomed Post')).toHaveCount(0);
+  expect(deletedIds[0]).toContain('own-post');
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
  * Two routes per player — a short option and a deep option on one player.
  * ──────────────────────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Why

Coaches could post to the Community Forum but had no way to fix a typo or take a post down afterward. RLS on `posts` already permits both (`auth.uid() = user_id` on UPDATE and DELETE) — this was purely a missing UI, not a missing permission, so no RLS/permission change is needed for the core ask.

## What

- **`CreatePostModal.tsx` → `PostFormModal.tsx`**: generalized into create+edit via an optional `post` prop, the same create/update-in-one-component shape `SavePlayModal.tsx` already uses in the designer. Renamed since it's no longer create-only.
- **`PostList.tsx`**: Edit (pencil) and Delete (trash) icon buttons render only on the viewer's own posts (`post.user_id === currentUserId`) — RLS is the actual security boundary, this only controls whether the buttons appear. Delete follows `PlaysPage.handleDeletePlay`'s existing pattern: `confirm()` → delete → refetch.
- **`CommunityPage.tsx`**: resolves the signed-in user once (not inside `onAuthStateChange` — that's what deadlocked the gotrue session lock elsewhere in this app, see the B-4 note in `entitlements.ts`) and passes it + the existing `fetchPosts` refetch callback down to `PostList`.

## The "(edited)" marker — ⚠ requires a SQL run

`posts` has an `updated_at` column, but unlike `plays`/`playbooks`, nothing refreshed it on UPDATE — so an edited post would render identical to an unedited one. Given this app's real history with community content looking more authentic than it is (this same week's PR #43, the Top Contributors fabrication fix), I added the missing trigger rather than ship silent edits:

```sql
DROP TRIGGER IF EXISTS update_posts_updated_at ON posts;
CREATE TRIGGER update_posts_updated_at
  BEFORE UPDATE ON posts
  FOR EACH ROW
  EXECUTE FUNCTION update_updated_at_column();
```

Reuses the function already wired to `plays`/`playbooks` — no new function. `supabase/SCHEMA.md` updated in this same PR. **Please run `supabase/community_posts_updated_at.sql` in the SQL Editor** — until then the marker just won't appear; everything else (editing, deleting) works regardless.

## Deliberately out of scope

**Comments** aren't wired up anywhere in the UI today — the `0 Comments` count is a pre-existing stub, not something this PR touches.

## Verification

- **4 new smoke tests**, all confirmed to **fail without this change and pass with it** (stashed the implementation, reran, watched 3 of 4 fail as expected — the signed-out test is a negative-space guard that trivially passes either way — then restored and reran clean):
  - Edit/Delete render only on your own post, never someone else's
  - Signed out: no post shows Edit/Delete
  - Editing saves the change and shows "(edited)"; an untouched post shows none
  - Deleting confirms, deletes, and removes the post from the list
- `npm run smoke` — **101/101** (3 unrelated tests flaked once under full-suite parallel load — text box, account settings — both reproduced clean in isolation, pre-existing/unrelated to this change)
- `npm run typecheck` — clean
- `npm run build` — passes
- `npx eslint` on touched files — **0 errors**
- Driven in a real browser: created posts as two different users, confirmed the owner-only buttons, edited a post and watched "(edited)" appear, deleted a post and watched it disappear from the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)