### PR TITLE
Wire up commenting on Community posts — was never built, not broken

### DIFF
--- a/src/components/community/CommentThread.tsx
+++ b/src/components/community/CommentThread.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { formatDistanceToNow } from 'date-fns';
+import { Trash2 } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import { getSafeErrorMessage } from '../../lib/errors';
+
+interface CommentRow {
+  id: string;
+  post_id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+  author?: { username: string; avatar_url: string | null };
+}
+
+interface CommentThreadProps {
+  postId: string;
+  /** The signed-in viewer's id, or null if signed out — decides which
+   *  comments show a Delete button. RLS (auth.uid() = user_id) is the real
+   *  boundary; this only controls whether the button renders. */
+  currentUserId: string | null;
+  /** Re-fetches the post list (same callback PostList already gets from
+   *  CommunityPage for post edit/delete) — called after a comment is added
+   *  or removed so the collapsed "N Comments" count stays accurate. Local
+   *  `comments` state below refreshes independently via fetchComments(), so
+   *  this doesn't collapse the open thread. */
+  onCommentsChanged: () => void;
+}
+
+/**
+ * Flat (no nested replies, despite `comments.parent_id` existing in the
+ * schema for that) comment thread for one post — expanded inline under it.
+ * `comments` RLS lets any authenticated user comment on any post, including
+ * their own; this is a UI-only gate (sign-in required to post), not an
+ * ownership restriction, matching the RLS it's built on.
+ */
+export function CommentThread({ postId, currentUserId, onCommentsChanged }: CommentThreadProps) {
+  const navigate = useNavigate();
+  const [comments, setComments] = useState<CommentRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchComments = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const { data, error: fetchError } = await supabase
+        .from('comments')
+        .select('*')
+        .eq('post_id', postId)
+        .order('created_at', { ascending: true });
+      if (fetchError) throw fetchError;
+
+      const rows = data || [];
+      const authorIds = Array.from(new Set(rows.map((c) => c.user_id)));
+      let authorsById: Record<string, { username: string; avatar_url: string | null }> = {};
+      if (authorIds.length > 0) {
+        const { data: authors, error: authorsError } = await supabase.rpc('get_community_authors', {
+          target_ids: authorIds,
+        });
+        if (authorsError) {
+          console.error('Error fetching comment authors:', authorsError);
+        } else {
+          authorsById = Object.fromEntries((authors || []).map((a: any) => [a.id, a]));
+        }
+      }
+
+      setComments(rows.map((c) => ({ ...c, author: authorsById[c.user_id] })));
+    } catch (err) {
+      console.error('Error fetching comments:', err);
+      setError(getSafeErrorMessage(err, 'Failed to load comments'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchComments();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [postId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim()) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        navigate('/auth');
+        return;
+      }
+      const { error: insertError } = await supabase
+        .from('comments')
+        .insert([{ post_id: postId, content: draft.trim(), user_id: user.id }]);
+      if (insertError) throw insertError;
+
+      setDraft('');
+      onCommentsChanged();
+      await fetchComments();
+    } catch (err) {
+      console.error('Error posting comment:', err);
+      setError(getSafeErrorMessage(err, 'Failed to post comment'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    if (!confirm('Delete this comment? This action cannot be undone.')) return;
+    setError('');
+    try {
+      const { error: deleteError } = await supabase
+        .from('comments')
+        .delete()
+        .eq('id', commentId);
+      if (deleteError) throw deleteError;
+      onCommentsChanged();
+      await fetchComments();
+    } catch (err) {
+      console.error('Error deleting comment:', err);
+      setError(getSafeErrorMessage(err, 'Failed to delete comment'));
+    }
+  };
+
+  return (
+    <div className="mt-4 pt-4 border-t border-chalk/10 space-y-3">
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3">
+          <p className="text-red-500 text-sm">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-chalk/50">Loading comments…</p>
+      ) : comments.length === 0 ? (
+        <p className="text-sm text-chalk/50">No comments yet — be the first to reply.</p>
+      ) : (
+        <ul className="space-y-3">
+          {comments.map((comment) => {
+            const isOwnComment = currentUserId !== null && comment.user_id === currentUserId;
+            return (
+              <li key={comment.id} className="flex items-start gap-3">
+                <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center overflow-hidden shrink-0 mt-0.5">
+                  {comment.author?.avatar_url ? (
+                    <img src={comment.author.avatar_url} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
+                  ) : (
+                    <span className="text-primary text-xs">
+                      {comment.author?.username?.[0]?.toUpperCase() || 'U'}
+                    </span>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-primary font-medium text-sm">
+                      {comment.author?.username || 'Anonymous'}
+                    </span>
+                    <span className="text-chalk/50 text-xs">
+                      {formatDistanceToNow(new Date(comment.created_at), { addSuffix: true })}
+                    </span>
+                    {isOwnComment && (
+                      <button
+                        onClick={() => handleDelete(comment.id)}
+                        title="Delete Comment"
+                        className="ml-auto p-1 text-chalk/40 hover:text-red-400 rounded transition-colors"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                  {/* Comments are plain text — never HTML-rendered, so this
+                      needs no sanitization the way post content does. */}
+                  <p className="text-chalk/80 text-sm whitespace-pre-wrap break-words">{comment.content}</p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex items-start gap-2 pt-1">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Write a comment…"
+          rows={2}
+          className="flex-1 rounded-md border border-chalk/20 bg-board text-chalk text-sm shadow-sm px-3 py-2 placeholder-chalk/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !draft.trim()}
+          className="px-3 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors shrink-0"
+        >
+          {submitting ? 'Posting…' : 'Comment'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/community/CommunityPage.tsx
+++ b/src/components/community/CommunityPage.tsx
@@ -68,7 +68,32 @@ export function CommunityPage() {
         }
       }
 
-      setPosts(postsData.map((p: any) => ({ ...p, author: authorsById[p.user_id] })));
+      // Real comment counts, one batched query — not a per-post count (would
+      // be N+1) and not a fabricated placeholder. `posts` has no cached
+      // counter for this, so it's computed client-side from the raw rows;
+      // cheap at this scale (comments has no separate count column to trust
+      // instead).
+      const postIds = postsData.map((p: any) => p.id);
+      const commentCounts: Record<string, number> = {};
+      if (postIds.length > 0) {
+        const { data: commentRows, error: commentCountError } = await supabase
+          .from('comments')
+          .select('post_id')
+          .in('post_id', postIds);
+        if (commentCountError) {
+          console.error('Error fetching comment counts:', commentCountError);
+        } else {
+          for (const row of commentRows || []) {
+            commentCounts[row.post_id] = (commentCounts[row.post_id] || 0) + 1;
+          }
+        }
+      }
+
+      setPosts(postsData.map((p: any) => ({
+        ...p,
+        author: authorsById[p.user_id],
+        comment_count: commentCounts[p.id] || 0,
+      })));
     } catch (err) {
       console.error('Error fetching posts:', err);
       setError(getSafeErrorMessage(err, 'Failed to fetch posts. Please try again later.'));

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -6,6 +6,7 @@ import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { sanitizePostContent } from '../../lib/sanitizeHtml';
 import { PostFormModal } from './PostFormModal';
+import { CommentThread } from './CommentThread';
 
 interface PostListProps {
   posts: any[];
@@ -31,6 +32,7 @@ function wasEdited(post: { created_at: string; updated_at?: string }): boolean {
 export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, currentUserId, onChanged }: PostListProps) {
   const [editingPost, setEditingPost] = useState<{ id: string; title: string; content: string } | null>(null);
   const [deleteError, setDeleteError] = useState('');
+  const [expandedPostId, setExpandedPostId] = useState<string | null>(null);
 
   const handleVote = async (postId: string, voteType: boolean) => {
     try {
@@ -184,11 +186,22 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, c
                 />
 
                 <div className="flex items-center gap-4">
-                  <button className="flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors">
+                  <button
+                    onClick={() => setExpandedPostId((cur) => (cur === post.id ? null : post.id))}
+                    className="flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors"
+                  >
                     <MessageSquare className="h-5 w-5" />
                     <span>{post.comment_count || 0} Comments</span>
                   </button>
                 </div>
+
+                {expandedPostId === post.id && (
+                  <CommentThread
+                    postId={post.id}
+                    currentUserId={currentUserId}
+                    onCommentsChanged={onChanged}
+                  />
+                )}
               </div>
             </div>
           </article>

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -3691,6 +3691,156 @@ test('Community Forum: pasting a Word-style bulleted list produces a real bullet
 });
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * Community Forum — comments. `comments` RLS (auth.uid() = user_id on
+ * INSERT, no ownership-of-post check at all) already allows any signed-in
+ * user to comment on any post, including their own — this was purely a
+ * missing UI: the "N Comments" button had no click handler and the count was
+ * a stub (`post.comment_count || 0` off a field the posts query never
+ * selected, so it always read 0 regardless of real comment count).
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** Stateful mock for `comments`: GET (both the per-post detail fetch and the
+ *  batched post_id-in-list count fetch CommunityPage does), POST, DELETE —
+ *  enough to drive the real create/read/delete flow, not just canned
+ *  responses. */
+function mockComments(page: Page, seed: Array<{ id: string; post_id: string; user_id: string; content: string; created_at: string }>) {
+  let rows = [...seed];
+  let nextId = seed.length + 1;
+  return page.route('**/rest/v1/comments**', (route) => {
+    const req = route.request();
+    const method = req.method();
+    const url = req.url();
+    if (method === 'GET') {
+      const eqMatch = url.match(/post_id=eq\.([^&]+)/);
+      const filtered = eqMatch ? rows.filter((c) => c.post_id === decodeURIComponent(eqMatch[1])) : rows;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(filtered) });
+    }
+    if (method === 'POST') {
+      const body = req.postDataJSON()[0];
+      const row = { id: `c${nextId++}`, created_at: new Date().toISOString(), ...body };
+      rows.push(row);
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify([row]) });
+    }
+    if (method === 'DELETE') {
+      const idMatch = url.match(/id=eq\.([^&]+)/);
+      const id = idMatch ? decodeURIComponent(idMatch[1]) : null;
+      rows = rows.filter((c) => c.id !== id);
+      return route.fulfill({ status: 204, contentType: 'application/json', body: '' });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+}
+
+function mockSinglePost(page: Page, overrides: Partial<{ id: string; title: string; content: string; user_id: string }> = {}) {
+  const post = {
+    id: 'post-1', title: 'Season opener thoughts', content: 'Excited for week one.',
+    user_id: COMMUNITY_USER.id, upvotes: 0, downvotes: 0,
+    created_at: '2026-08-01T00:00:00Z', updated_at: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+  return page.route('**/rest/v1/posts**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([post]) }));
+}
+
+test('Community Forum: comment count reflects real comments, not a stale "0 Comments" stub', async ({ page }) => {
+  await mockCommunityAuthors(page);
+  await mockSinglePost(page);
+  await mockComments(page, [
+    { id: 'c1', post_id: 'post-1', user_id: OTHER_USER_ID, content: 'Good luck this season!', created_at: '2026-08-01T01:00:00Z' },
+    { id: 'c2', post_id: 'post-1', user_id: OTHER_USER_ID, content: 'What formation are you running?', created_at: '2026-08-01T02:00:00Z' },
+  ]);
+
+  await page.goto('/community');
+  await expect(page.getByText('2 Comments')).toBeVisible();
+  await expect(page.getByText('0 Comments')).toHaveCount(0);
+});
+
+test('Community Forum: a signed-in user CAN comment on their own post (regression for the reported bug)', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+  // Post owned by the signed-in user themselves — the exact case reported.
+  await mockSinglePost(page, { user_id: COMMUNITY_USER.id });
+  await mockComments(page, []);
+
+  await page.goto('/community');
+  await page.getByRole('button', { name: '0 Comments' }).click();
+  await expect(page.getByText('No comments yet', { exact: false })).toBeVisible();
+
+  await page.getByPlaceholder('Write a comment…').fill('Following up on my own post');
+  await page.getByRole('button', { name: 'Comment', exact: true }).click();
+
+  await expect(page.getByText('Following up on my own post')).toBeVisible();
+  await expect(page.getByText('1 Comments')).toBeVisible();
+});
+
+test('Community Forum: a signed-in user can comment on another user\'s post', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+  await mockSinglePost(page, { user_id: OTHER_USER_ID });
+  await mockComments(page, []);
+
+  await page.goto('/community');
+  await page.getByRole('button', { name: '0 Comments' }).click();
+  await page.getByPlaceholder('Write a comment…').fill('Great write-up, thanks for sharing');
+  await page.getByRole('button', { name: 'Comment', exact: true }).click();
+
+  await expect(page.getByText('Great write-up, thanks for sharing')).toBeVisible();
+  await expect(page.getByText('1 Comments')).toBeVisible();
+});
+
+test('Community Forum: deleting your own comment removes it; another user\'s comment shows no delete button', async ({ page }) => {
+  await signInAsCommunityUser(page);
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(COMMUNITY_USER) }));
+  await mockCommunityAuthors(page);
+  await mockSinglePost(page, { user_id: OTHER_USER_ID });
+  await mockComments(page, [
+    { id: 'mine', post_id: 'post-1', user_id: COMMUNITY_USER.id, content: 'My own comment', created_at: '2026-08-01T01:00:00Z' },
+    { id: 'theirs', post_id: 'post-1', user_id: OTHER_USER_ID, content: 'Their comment', created_at: '2026-08-01T02:00:00Z' },
+  ]);
+
+  await page.goto('/community');
+  await page.getByRole('button', { name: '2 Comments' }).click();
+  await expect(page.getByText('My own comment')).toBeVisible();
+  await expect(page.getByText('Their comment')).toBeVisible();
+
+  const mineRow = page.locator('li', { hasText: 'My own comment' });
+  const theirsRow = page.locator('li', { hasText: 'Their comment' });
+  await expect(mineRow.locator('button[title="Delete Comment"]')).toBeVisible();
+  await expect(theirsRow.locator('button[title="Delete Comment"]')).toHaveCount(0);
+
+  page.once('dialog', (dialog) => dialog.accept());
+  await mineRow.locator('button[title="Delete Comment"]').click();
+
+  await expect(page.getByText('My own comment')).toHaveCount(0);
+  await expect(page.getByText('Their comment')).toBeVisible();
+  await expect(page.getByText('1 Comments')).toBeVisible();
+});
+
+test('Community Forum: signed out, submitting a comment redirects to sign in instead of posting', async ({ page }) => {
+  await mockCommunityAuthors(page);
+  await mockSinglePost(page, { user_id: OTHER_USER_ID });
+  const postDataSeen: string[] = [];
+  await page.route('**/rest/v1/comments**', (route) => {
+    postDataSeen.push(route.request().method());
+    if (route.request().method() === 'POST') return route.fulfill({ status: 401, body: '' });
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.goto('/community');
+  await page.getByRole('button', { name: '0 Comments' }).click();
+  await page.getByPlaceholder('Write a comment…').fill('Trying to comment while signed out');
+  await page.getByRole('button', { name: 'Comment', exact: true }).click();
+
+  await expect(page).toHaveURL(/\/auth$/);
+  expect(postDataSeen).not.toContain('POST');
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
  * Two routes per player — a short option and a deep option on one player.
  * ──────────────────────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## The report

> Ensure that the comment feature is working for every post. I'm not able to comment on my own post. I want to ensure that users can comment on other users' posts.

## What was actually going on

Nothing was broken — nothing was ever built. `comments` has existed since the original schema (`id`, `user_id`, `post_id`, `parent_id`, `content`, `upvotes`/`downvotes`) with RLS that already allows any authenticated user to comment on **any** post, including their own:

```sql
CREATE POLICY "Users can create comments" ON comments FOR INSERT
  TO authenticated WITH CHECK (auth.uid() = user_id);
```

No ownership-of-post check at all — the permission the report is asking for already existed. What was missing: the "N Comments" button in `PostList.tsx` had **no click handler whatsoever**, and its label was a stub reading `post.comment_count || 0` off a field the `posts` query never selected — so it always showed "0 Comments" regardless of reality.

## What this PR adds

- **`CommentThread.tsx`** — flat comment list + add-comment form, expanded inline under a post when you click its "N Comments" button. `comments.parent_id` supports nested replies in the schema; this stays flat for now, matching the actual ask. Delete on your own comments only (RLS is the real boundary; the button is just UI). Comments are plain text, not rich text like posts — no HTML rendering path here, so no sanitizer needed.
- **`CommunityPage.tsx`** — one batched query alongside the existing `get_community_authors()` lookup (`comments.select('post_id').in(postIds)`, reduced into real per-post counts client-side). Not per-post (would be N+1), and not the old fabricated-always-0 placeholder.
- **No RLS/schema change.** This is UI wired onto permissions that already supported the ask — confirmed by reading the actual policy, not assumed.

## Verification

- **5 new smoke tests**, all confirmed to **fail without this change and pass with it**:
  - real counts render, not the old always-"0 Comments" stub
  - **commenting on your own post works** — the reported bug, directly
  - **commenting on another user's post works** — the explicit ask
  - deleting your own comment removes it; another user's comment shows no delete button
  - signed-out submission redirects to `/auth` instead of silently failing
- `npm run smoke` — **111/111**
- `npm run typecheck` — clean
- `npm run build` — passes
- `npx eslint` on touched files — **0 errors**
- Confirmed in a real browser: commented on both your own post and someone else's, watched both counts go from 0 → 1 accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)