### PR TITLE
Record feedback-triage deployment status + create docs/proposals/

### DIFF
--- a/docs/automation/feedback-triage.md
+++ b/docs/automation/feedback-triage.md
@@ -9,6 +9,39 @@ This routine's prompt is checked in instead. **If you edit the routine in the
 web UI, update this file in the same change** — otherwise it drifts and this
 document becomes a lie.
 
+## Deployment status
+
+The code for this routine is merged, but merged is not running. Every box below
+must be ticked before a single piece of feedback gets triaged — until then
+submissions accumulate untouched in the `feedback` table with
+`triage_state='untriaged'`. Update this table (with the date) as each step
+lands, so "is triage actually live?" is answerable without digging through the
+Supabase dashboard.
+
+| # | Step | Status |
+|---|------|--------|
+| 1 | `supabase/feedback_triage.sql` run in the SQL Editor | ✅ 2026-08-05 (per `supabase/SCHEMA.md`) |
+| 2 | `supabase secrets set FEEDBACK_TRIAGE_SECRET=…` | ⬜ not confirmed |
+| 3 | `supabase functions deploy feedback-triage --no-verify-jwt` | ⬜ not confirmed |
+| 4 | Dry run passed (see [the dry run](#before-scheduling-it-the-dry-run)) | ⬜ not run |
+| 5 | Routine created at claude.ai/code/routines, daily | ⬜ not confirmed |
+
+Do them **in that order**. Steps 2 and 3 together are what makes the endpoint
+reachable: deploying before the secret is set leaves a live function whose
+`secretMatches()` fails closed on every request (a 401 that looks exactly like a
+wrong token), and creating the routine before the dry run means the first real
+exercise of the prompt-injection guardrails happens unsupervised, against real
+user input.
+
+Quick check that steps 2–3 are done — from anywhere, with the secret in hand:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "x-triage-secret: $FEEDBACK_TRIAGE_SECRET" \
+  "https://<project-ref>.supabase.co/functions/v1/feedback-triage?limit=1"
+# 200 → both done.  401 → secret missing or mismatched.  404 → not deployed.
+```
+
 ## Setup
 
 1. Run `supabase/feedback_triage.sql` in the Supabase SQL Editor.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,24 @@
+# Design proposals
+
+Design write-ups for work that has been *thought through* but not built.
+
+Most files here are written by the **feedback triage routine**
+([`../automation/feedback-triage.md`](../automation/feedback-triage.md)): when a
+user submits a feature request, the agent is explicitly forbidden from writing
+feature code and instead lands a `<slug>.md` here plus a `[from feedback]` entry
+in [`BACKLOG.md`](../../BACKLOG.md), on a **draft** PR. The point is to get the
+design reviewed before anyone spends effort on an implementation.
+
+Humans should feel free to add proposals here too, using the same shape:
+
+- **Problem** — in the user's terms, not the codebase's.
+- **Proposed UX** — what the coach actually sees and does.
+- **Affected files/systems** — the real blast radius.
+- **Risks and tradeoffs.**
+- **Open questions needing a human decision.**
+- **Rough size estimate.**
+
+A proposal is not a commitment. Accepted ones graduate into a BACKLOG item and
+get built from there; rejected ones stay for the record, with a short note at
+the top saying why. Never paste raw feedback text or any identifying detail
+about a submitter into a file here — these are public.


### PR DESCRIPTION
First of five PRs building out an end-to-end feedback workflow. This one is docs only — no app code, no SQL.

## Why

The triage routine (B-35) is merged, but nothing in the repo said whether it was **running**. As far as anything checked in can tell, it isn't: the secret, the function deploy, the dry run, and the routine itself were all unverified. Meanwhile submissions accumulate in `feedback` with `triage_state='untriaged'` and no signal to anyone.

## What

- **Deployment-status table** in `docs/automation/feedback-triage.md` — the five steps, with the two that are confirmed marked and dated, and a `curl` that tells 200 / 401 / 404 apart so "is triage live?" is answerable in one command.
- The ordering is spelled out because both wrong orders fail quietly: deploying before the secret is set leaves a live function whose `secretMatches()` fails closed on every request (a 401 indistinguishable from a wrong token), and creating the routine before the dry run means the prompt-injection guardrails are first exercised unsupervised, on real user input.
- **`docs/proposals/README.md`** — the routine prompt has instructed the agent to write `docs/proposals/<slug>.md` since B-35, but the directory never existed.

## Remaining human steps

Tracked in the new table; steps 2–5 (secret, deploy, dry run, schedule) are yours to run.

## Verification

Docs only — no typecheck/build/smoke impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)