### PR TITLE
[feedback] fix: label the icon-only "Use as Template" / "Vs." play card buttons

### DIFF
--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -483,9 +483,15 @@ export function PlaysPage() {
             <Link
               to={`/designer?template=${play.id}`}
               title="Use this play as a starting point for a new one"
+              aria-label="Use this play as a starting point for a new one"
               className="flex items-center gap-1 px-3 py-2 text-sm bg-board-light hover:bg-board border border-chalk/10 text-chalk/70 hover:text-chalk rounded-lg transition-colors"
             >
               <Wand2 className="h-4 w-4" />
+              {/* Icon-only relied on the `title` tooltip, which touch devices
+                  never show — a mobile user had no way to tell what this
+                  button did. Always show the label; the card grid is one
+                  column wide on mobile, so there's room. */}
+              <span className="text-xs">Template</span>
             </Link>
 
             {/* Offense only — the vs. view draws this play under a defense,
@@ -494,9 +500,11 @@ export function PlaysPage() {
               <Link
                 to={`/vs?play=${play.id}`}
                 title="View this play against your defensive plays"
+                aria-label="View this play against your defensive plays"
                 className="flex items-center gap-1 px-3 py-2 text-sm bg-board-light hover:bg-board border border-chalk/10 text-chalk/70 hover:text-chalk rounded-lg transition-colors"
               >
                 <Shield className="h-4 w-4" />
+                <span className="text-xs">Vs.</span>
               </Link>
             )}
 


### PR DESCRIPTION
## What was reported

A user reported that on the Plays page, an icon-only action button's tooltip explained what it did, but the button showed no visible text label — so on mobile (where hover tooltips don't appear) there was no way to tell what tapping it would do.

## Root cause

The "Use as Template" and "Vs. Defense" buttons on each play card (`PlaysPage.tsx`) render only a `lucide-react` icon with a `title` attribute. `title` tooltips are a hover-only affordance; touch devices have no equivalent, so mobile users see a bare icon with no way to discover its meaning short of tapping and hoping.

## Fix

Added always-visible short text labels next to each icon ("Template", "Vs.") and matching `aria-label` attributes for screen reader users. The play card grid is a single column on mobile, so there's room without crowding the row.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/components/plays/PlaysPage.tsx` — only pre-existing warnings, no new errors
- `npm run build` — succeeds
- Full Playwright smoke suite — 121/121 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_019b8PXjqVwL8HoNuzqJzqzX)_