### PR TITLE
[feedback] fix: Give Feedback panel rendering behind the homepage hero

### DIFF
--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -173,7 +173,7 @@ export function FeedbackButton() {
     return (
       <button
         onClick={openPanel}
-        className="fixed bottom-4 right-4 bg-primary hover:bg-primary-dark text-white rounded-full p-3 shadow-lg transition-colors"
+        className="fixed bottom-4 right-4 z-40 bg-primary hover:bg-primary-dark text-white rounded-full p-3 shadow-lg transition-colors"
         title="Give Feedback"
       >
         <MessageSquare className="h-6 w-6" />
@@ -187,7 +187,7 @@ export function FeedbackButton() {
     <div
       role="dialog"
       aria-label="Give Feedback"
-      className="fixed bottom-4 right-4 w-96 max-w-[calc(100vw-2rem)] bg-board-light rounded-lg shadow-xl border border-chalk/10"
+      className="fixed bottom-4 right-4 z-40 w-96 max-w-[calc(100vw-2rem)] bg-board-light rounded-lg shadow-xl border border-chalk/10"
     >
       <div className="flex items-center justify-between px-4 py-3 border-b border-chalk/10">
         <h3 className="text-lg font-semibold text-chalk">Give Feedback</h3>


### PR DESCRIPTION
## What was reported

The Give Feedback menu was popping up behind the play designer demo on the homepage hero.

## Root cause

`Hero.tsx`'s content wrapper is `relative z-10`, which creates a stacking context that paints above any `z-index: auto` sibling regardless of DOM order. `FeedbackButton`'s fixed-position button and panel had no `z-index` at all, so on the homepage they painted underneath the hero's stacking context instead of on top of the page.

## Fix

Gave the floating button and its open panel an explicit `z-40` — matching the level already used by other non-modal floating overlays (`FormationMenu`, `RouteColorButton`'s popovers), staying below real modals (`z-50`/`z-60`) and above normal page content.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/components/FeedbackButton.tsx` — 0 errors/warnings
- `npm run build` — succeeds
- Full Playwright smoke suite — 121/121 passed. (An initial run showed 2 unrelated "Sign Out" test timeouts from resource contention during the ~15-minute parallel run; both pass cleanly in isolation and touch no code this change modified.)

---
_Generated by [Claude Code](https://claude.ai/code/session_019b8PXjqVwL8HoNuzqJzqzX)_