### PR TITLE
Fix My Plays cards clipping their own action buttons (Delete was invisible)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -166,6 +166,23 @@ cycling only (deliberately lean). Deferred, in rough priority order:
    defensive plays only, so a coach with none gets an empty state pointing at
    the designer. Offering public defenses would seed it.
 
+### B-37 · Consolidate the four duplicate play-card implementations
+Surfaced while fixing the My Plays card overflow (PR for that is card-only by
+choice). There is no shared play card: My Plays (`plays/PlaysPage.tsx`),
+Community (`plays/PlayLibrary.tsx`), and the playbook detail grid *and* list
+views (`playbooks/PlaybooksPage.tsx`) each hand-roll their own, which is why
+they drifted apart on shell, thumbnail aspect ratio, and button styling in the
+first place. Meanwhile `designer/PlayCard.tsx` is a fully-built card component
+with `onEdit`/`onDelete`/`onAddToPlaybook` that **nothing imports**.
+Also unimported and worth deleting in the same pass:
+`designer/AddToPlaybookModal.tsx`, `designer/PlaybookSelectionModal.tsx`, and
+`designer/PlaybookSelector.tsx` (whose only consumer, `CreatePlaybookModal`, is
+reachable from nowhere else).
+⚠ Not a mechanical extraction: the Community filter smoke test asserts
+`.grid > div.bg-board-light` structurally, so it must be re-pointed at a
+`data-testid` in the same change. Multi-PR; do the dead-code deletion first as
+its own low-risk PR.
+
 ## Done
 
 - **2026-08-09 · B-36: Daily feedback digest email** — closes the last gap in

--- a/src/components/plays/AddToPlaybookButton.tsx
+++ b/src/components/plays/AddToPlaybookButton.tsx
@@ -1,6 +1,7 @@
 // Create this file: src/components/plays/AddToPlaybookButton.tsx
 
 import React, { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import { Book, Plus, Check, ChevronDown } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 
@@ -22,12 +23,17 @@ interface AddToPlaybookButtonProps {
   playId: string;
   playName: string;
   onSuccess?: () => void;
+  /** Icon-only square trigger, for card footers where a labelled pill would
+   *  overflow the card. Keeps the primary green so it still reads as the
+   *  primary action without its text. */
+  compact?: boolean;
 }
 
-export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({ 
-  playId, 
-  playName, 
-  onSuccess 
+export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
+  playId,
+  playName,
+  onSuccess,
+  compact = false
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
@@ -56,7 +62,34 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
     setIsOpen((prev) => !prev);
   };
 
-  const dropdownPositionClass = openUpward ? 'bottom-full left-0 mb-2' : 'top-full left-0 mt-2';
+  // Compact triggers sit at the right end of a card's action cluster, so the
+  // panel has to grow leftward — anchored left it would run past the card and
+  // be clipped by the page panel's overflow-hidden.
+  const horizontalAnchor = compact ? 'right-0' : 'left-0';
+  const dropdownPositionClass = openUpward
+    ? `bottom-full ${horizontalAnchor} mb-2`
+    : `top-full ${horizontalAnchor} mt-2`;
+
+  const trigger = compact ? (
+    <button
+      onClick={toggleOpen}
+      className="flex items-center justify-center h-9 w-9 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+      title="Add to Playbook"
+      aria-label="Add to Playbook"
+    >
+      <Book className="w-4 h-4" />
+    </button>
+  ) : (
+    <button
+      onClick={toggleOpen}
+      className="flex items-center gap-2 px-3 py-2 text-sm bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+      title="Add to Playbook"
+    >
+      <Book className="w-4 h-4" />
+      Add to Playbook
+      <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+    </button>
+  );
 
   const fetchPlaybooks = async () => {
     try {
@@ -171,15 +204,7 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
   if (playbooks.length === 0 && !loading && isOpen) {
     return (
       <div className="relative" ref={containerRef}>
-        <button
-          onClick={toggleOpen}
-          className="flex items-center gap-2 px-3 py-2 text-sm bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
-          title="Add to Playbook"
-        >
-          <Book className="w-4 h-4" />
-          Add to Playbook
-          <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-        </button>
+        {trigger}
 
         {isOpen && (
           <>
@@ -191,16 +216,13 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
               <div className="p-4 text-center">
                 <Book className="w-8 h-8 text-chalk/50 mx-auto mb-2" />
                 <p className="text-chalk/70 text-sm mb-3">No playbooks found</p>
-                <button
-                  onClick={() => {
-                    // Navigate to create playbook or handle creation
-                    console.log('Create new playbook');
-                    setIsOpen(false);
-                  }}
-                  className="px-3 py-2 bg-primary hover:bg-primary-dark text-white text-sm rounded-lg transition-colors"
+                <Link
+                  to="/playbooks"
+                  onClick={() => setIsOpen(false)}
+                  className="inline-block px-3 py-2 bg-primary hover:bg-primary-dark text-white text-sm rounded-lg transition-colors"
                 >
                   Create Playbook
-                </button>
+                </Link>
               </div>
             </div>
           </>
@@ -211,15 +233,7 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
 
   return (
     <div className="relative" ref={containerRef}>
-      <button
-        onClick={toggleOpen}
-        className="flex items-center gap-2 px-3 py-2 text-sm bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
-        title="Add to Playbook"
-      >
-        <Book className="w-4 h-4" />
-        Add to Playbook
-        <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
+      {trigger}
 
       {isOpen && (
         <>

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -10,6 +10,14 @@ import { PlayLibrary } from './PlayLibrary';
 import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UsageWarningBanner } from '../UsageWarningBanner';
 
+// Every action in a card footer is the same square pill, so the row's width is
+// predictable and can't outgrow the card the way the old labelled+icon mix did.
+const CARD_ACTION =
+  'flex items-center justify-center h-9 w-9 rounded-lg border border-chalk/10 bg-board hover:bg-board-light text-chalk/70 hover:text-chalk transition-colors';
+
+const THUMBNAIL_FRAME =
+  'block aspect-video bg-board rounded-t-lg overflow-hidden border-b border-chalk/10';
+
 interface Play {
   id: string;
   name: string;
@@ -410,11 +418,17 @@ export function PlaysPage() {
                 {error}
               </div>
             ) : loading ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {[1, 2, 3, 4].map((i) => (
-                  <div key={i} className="animate-pulse">
-                    <div className="bg-board rounded-lg aspect-[4/3] mb-2"></div>
-                    <div className="h-4 bg-board rounded w-2/3"></div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="animate-pulse bg-board-light rounded-lg border border-chalk/10"
+                  >
+                    <div className="bg-board rounded-t-lg aspect-video"></div>
+                    <div className="p-4">
+                      <div className="h-4 bg-board rounded w-2/3 mb-3"></div>
+                      <div className="h-9 bg-board rounded w-1/2 ml-auto"></div>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -446,113 +460,126 @@ export function PlaysPage() {
             ) : (
               <>
                 {/* Visible plays */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-  {visiblePlays.map((play) => (
-    <div key={play.id} className="group relative">
-      {user ? (
-        <>
-          {/* Play Preview */}
-          {/* from=plays tells the designer to return here after an update,
-              instead of leaving the coach on the designer post-save. */}
-          <Link to={`/designer?play=${play.id}&from=plays`} className="block">
-            <div className="bg-board rounded-lg overflow-hidden aspect-[4/3] mb-2 border border-chalk/10 group-hover:border-primary/30 transition-colors">
-              <ThumbnailImage play={play} />
-            </div>
-            <h3 className="text-chalk group-hover:text-primary transition-colors mb-1">
-              {play.name}
-            </h3>
-            <p className="text-sm text-chalk/50 capitalize mb-3">
-              {play.type.replace('_', ' ')}
-            </p>
-          </Link>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {visiblePlays.map((play) => (
+                    /* No overflow-hidden on the shell: the add-to-playbook
+                       dropdown is an absolutely-positioned child and would be
+                       clipped by it. The thumbnail clips itself instead. */
+                    <div
+                      key={play.id}
+                      data-testid="play-card"
+                      className="group relative bg-board-light rounded-lg border border-chalk/10 hover:border-primary/30 transition-colors flex flex-col"
+                    >
+                      {/* Signed-out visitors get the same frame without the
+                          edit link — they don't own these plays. */}
+                      {user ? (
+                        /* from=plays tells the designer to return here after an
+                           update, instead of leaving the coach on the designer
+                           post-save. */
+                        <Link
+                          to={`/designer?play=${play.id}&from=plays`}
+                          className={THUMBNAIL_FRAME}
+                        >
+                          <ThumbnailImage play={play} />
+                        </Link>
+                      ) : (
+                        <div className={THUMBNAIL_FRAME}>
+                          <ThumbnailImage play={play} />
+                        </div>
+                      )}
 
-          {/* Action buttons for authenticated users */}
-          <div className="flex items-center gap-2">
-            <AddToPlaybookButton
-              playId={play.id}
-              playName={play.name}
-              onSuccess={() => {
-                // Optional: Show success notification
-                console.log(`"${play.name}" added to playbook successfully!`);
-              }}
-            />
+                      <div className="p-4 flex-1 flex flex-col">
+                        <div className="flex items-start justify-between gap-2 mb-1">
+                          <h3 className="min-w-0 truncate font-bold text-chalk group-hover:text-primary transition-colors">
+                            {play.name}
+                          </h3>
+                          <span className="px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs capitalize shrink-0">
+                            {play.type.replace('_', ' ')}
+                          </span>
+                        </div>
 
-            {/* Opens this play in the Designer without editingPlayId set, so
-                Save creates a new play instead of updating this one — see
-                PlayDesigner.tsx's load effect. */}
-            <Link
-              to={`/designer?template=${play.id}`}
-              title="Use this play as a starting point for a new one"
-              className="flex items-center gap-1 px-3 py-2 text-sm bg-board-light hover:bg-board border border-chalk/10 text-chalk/70 hover:text-chalk rounded-lg transition-colors"
-            >
-              <Wand2 className="h-4 w-4" />
-            </Link>
+                        {!user && play.profiles && (
+                          <p className="text-xs text-chalk/40">
+                            by {play.profiles.username || 'Anonymous'}
+                          </p>
+                        )}
 
-            {/* Offense only — the vs. view draws this play under a defense,
-                so pointing it at a defensive play would stack two defenses. */}
-            {play.type === 'offense' && (
-              <Link
-                to={`/vs?play=${play.id}`}
-                title="View this play against your defensive plays"
-                className="flex items-center gap-1 px-3 py-2 text-sm bg-board-light hover:bg-board border border-chalk/10 text-chalk/70 hover:text-chalk rounded-lg transition-colors"
-              >
-                <Shield className="h-4 w-4" />
-              </Link>
-            )}
+                        {/* Vote left, actions right. ml-auto keeps the cluster
+                            right-aligned on private plays, which have no vote
+                            button — so the footer doesn't reflow card to card. */}
+                        <div
+                          className={`mt-auto flex items-center justify-between gap-2 flex-wrap ${
+                            user || play.is_public ? 'pt-3' : ''
+                          }`}
+                        >
+                          {play.is_public && (
+                            <PlayVoteButton
+                              playId={play.id}
+                              upvotes={play.upvotes ?? 0}
+                              voted={user ? votedPlayIds.has(play.id) : false}
+                              userId={user?.id}
+                              onError={setError}
+                            />
+                          )}
 
-            {play.is_public && (
-              <PlayVoteButton
-                playId={play.id}
-                upvotes={play.upvotes ?? 0}
-                voted={votedPlayIds.has(play.id)}
-                userId={user.id}
-                onError={setError}
-              />
-            )}
+                          {user && (
+                            <div className="flex items-center gap-1.5 ml-auto">
+                              <AddToPlaybookButton
+                                compact
+                                playId={play.id}
+                                playName={play.name}
+                                onSuccess={() => {
+                                  // Optional: Show success notification
+                                  console.log(`"${play.name}" added to playbook successfully!`);
+                                }}
+                              />
 
-            {/* This whole list is already scoped to the signed-in user's own
-                plays (fetchPlays queries .eq('user_id', currentUser.id)) —
-                Community plays render via the separate PlayLibrary component,
-                never here. So every play card reaching this point is already
-                owned by `user`; no admin/ownership gate is needed. */}
-            <button
-              onClick={() => handleDeletePlay(play.id)}
-              className="flex items-center gap-1 px-3 py-2 text-sm bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
-              title="Delete Play"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          </div>
-        </>
-      ) : (
-        /* Existing non-authenticated user view */
-        <div className="block">
-          <div className="bg-board rounded-lg overflow-hidden aspect-[4/3] mb-2 border border-chalk/10">
-            <ThumbnailImage play={play} />
-          </div>
-          <h3 className="text-chalk">
-            {play.name}
-          </h3>
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-chalk/50 capitalize">
-              {play.type.replace('_', ' ')}
-            </p>
-            {play.profiles && (
-              <p className="text-xs text-chalk/40">
-                by {play.profiles.username || 'Anonymous'}
-              </p>
-            )}
-          </div>
-          {play.is_public && (
-            <div className="mt-2">
-              <PlayVoteButton playId={play.id} upvotes={play.upvotes ?? 0} voted={false} onError={setError} />
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  ))}
-</div>
+                              {/* Opens this play in the Designer without
+                                  editingPlayId set, so Save creates a new play
+                                  instead of updating this one — see
+                                  PlayDesigner.tsx's load effect. */}
+                              <Link
+                                to={`/designer?template=${play.id}`}
+                                title="Use this play as a starting point for a new one"
+                                className={CARD_ACTION}
+                              >
+                                <Wand2 className="h-4 w-4" />
+                              </Link>
+
+                              {/* Offense only — the vs. view draws this play
+                                  under a defense, so pointing it at a defensive
+                                  play would stack two defenses. */}
+                              {play.type === 'offense' && (
+                                <Link
+                                  to={`/vs?play=${play.id}`}
+                                  title="View this play against your defensive plays"
+                                  className={CARD_ACTION}
+                                >
+                                  <Shield className="h-4 w-4" />
+                                </Link>
+                              )}
+
+                              {/* This whole list is already scoped to the
+                                  signed-in user's own plays (fetchPlays queries
+                                  .eq('user_id', currentUser.id)) — Community
+                                  plays render via the separate PlayLibrary
+                                  component, never here. So every play card
+                                  reaching this point is already owned by `user`;
+                                  no admin/ownership gate is needed. */}
+                              <button
+                                onClick={() => handleDeletePlay(play.id)}
+                                className={`${CARD_ACTION} border-transparent bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-400`}
+                                title="Delete Play"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
 
               </>
             )}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2244,6 +2244,89 @@ test('My Plays: a non-admin owner can delete their own play', async ({ page }) =
   expect(deleteRequestUrl).toContain('id=eq.my-play-1');
 });
 
+test('My Plays: every card action fits inside the card instead of being clipped', async ({ page }) => {
+  // Regression test: the action row was a non-wrapping flex whose first child
+  // was a ~165px labelled "Add to Playbook" pill. On a public offense play —
+  // the widest case, five controls — the row outgrew the ~280px xl:grid-cols-4
+  // column, and the page panel's overflow-hidden clipped the trailing Delete
+  // button clean off the card.
+  //
+  // toBeVisible() is not enough to catch that: an element clipped by an
+  // ancestor's overflow-hidden still reports visible. So this asserts geometry.
+  const userJson = {
+    id: '99999999-9999-9999-9999-999999999999',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/admin_users**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'pro' }) }));
+  await page.route('**/rest/v1/play_votes**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/rest/v1/plays**', (route) => {
+    if (route.request().method() === 'HEAD') {
+      return route.fulfill({ status: 200, headers: { 'content-range': '*/1', 'access-control-expose-headers': 'content-range' }, body: '' });
+    }
+    return route.fulfill({
+      status: 200, contentType: 'application/json',
+      // Public + offense = the widest footer: vote, add-to-playbook, template,
+      // vs-defense, delete. Long name exercises the title truncation.
+      body: JSON.stringify([{
+        id: 'wide-play', name: 'Trips Right Zip Motion Y Corner Halfback Wheel',
+        type: 'offense', thumbnail: null, is_public: true, upvotes: 12, user_id: userJson.id,
+      }]),
+    });
+  });
+
+  await page.goto('/plays');
+
+  const card = page.getByTestId('play-card').first();
+  await expect(card).toBeVisible();
+
+  const TITLES = [
+    'Add to Playbook',
+    'Use this play as a starting point for a new one',
+    'View this play against your defensive plays',
+    'Upvote this play',
+    'Delete Play',
+  ];
+  for (const title of TITLES) await expect(page.getByTitle(title)).toBeVisible();
+
+  // Measure card and buttons in one synchronous pass. Separate boundingBox()
+  // round-trips can straddle a layout shift (the fallback thumbnail draws to a
+  // canvas after mount), which makes the comparison itself flaky.
+  const overflow = await page.evaluate((titles) => {
+    const card = document.querySelector('[data-testid="play-card"]')!;
+    const cardRect = card.getBoundingClientRect();
+    return titles.flatMap((title) => {
+      const el = card.querySelector(`[title="${title}"]`);
+      if (!el) return [`${title}: not inside the card`];
+      const r = el.getBoundingClientRect();
+      // 1px of rounding slack on each edge.
+      if (r.left < cardRect.left - 1) return [`${title}: ${cardRect.left - r.left}px past the left edge`];
+      if (r.right > cardRect.right + 1) return [`${title}: ${r.right - cardRect.right}px past the right edge`];
+      return [];
+    });
+  }, TITLES);
+  expect(overflow).toEqual([]);
+
+  // A long name truncates rather than wrapping, so cards keep equal heights.
+  const titleLines = await page.evaluate(() => {
+    const h = document.querySelector('[data-testid="play-card"] h3') as HTMLElement;
+    return Math.round(h.getBoundingClientRect().height / parseFloat(getComputedStyle(h).lineHeight));
+  });
+  expect(titleLines).toBe(1);
+});
+
 test('PlaybooksPage (B-22/B-23): free user one playbook from the cap sees a usage nudge', async ({ page }) => {
   // Regression test for B-23: PlaybooksPage used to resolve its user via
   // getSession() + onAuthStateChange *and* a separate useEntitlement() call


### PR DESCRIPTION
Reported: the buttons under a play thumbnail don't fit the card, and Delete is hidden on most plays.

## Cause

The action row was `flex items-center gap-2` with **no wrap**, and its first child was a ~165px labelled "Add to Playbook" pill while the other four were ~40px icon pills (template, vs-defense, upvote, delete). At `xl:grid-cols-4` inside `max-w-7xl` a column is only ~280px, so the row outgrew the card — and because the page panel is `overflow-hidden`, the overrun was **clipped** rather than merely ugly. Delete, being last, is what disappeared.

## Change

Rebuilt the card as a proper shell — `bg-board-light` + border, `aspect-video` thumbnail, truncating title with a type badge — matching the Community card it sits directly next to, with a split footer: **upvote left, a uniform `h-9 w-9` icon cluster right**. Grid drops to 3 columns max (also matching Community), taking cards from ~280px to ~390px.

Add-to-Playbook goes icon-only. Losing its label is the real cost, so it keeps the primary green and its tooltip to still read as the primary action.

Two details worth not undoing later:

- **No `overflow-hidden` on the card shell**, unlike the Community card. The add-to-playbook dropdown is an absolutely-positioned child and would be clipped by it. The thumbnail clips itself instead.
- **The dropdown anchors `right-0` when compact.** Its trigger now sits at the right end of the cluster, so a left-anchored `w-72` panel would run past the card and hit the same page-panel clipping.

Also replaces that dropdown's dead "Create Playbook" button — it only `console.log`ged — with a link to `/playbooks`.

Scope was deliberately held to the My Plays card. The app has four duplicate play-card implementations and a fully-built `designer/PlayCard.tsx` that nothing imports; that's filed as **B-37** rather than bundled here.

## Verification

- `npm run typecheck` — clean
- `npx eslint` on the touched files — 0 errors, warnings all pre-existing
- `npm run build` — clean
- `npm run smoke` — **122/122**, run five times (the new test flaked once on its first form; measurement now happens in a single synchronous pass instead of separate `boundingBox()` round-trips that could straddle a layout shift)

**The new test asserts geometry, not visibility.** An element clipped by an ancestor's `overflow-hidden` still reports `toBeVisible()` — which is precisely why this shipped in the first place. It seeds a public offense play (the widest footer: all five controls) and asserts each control's rect sits inside the card's rect, plus that a long name renders on one line.

Screenshotted signed in at **1280 / 1024 / 768 / 375** across private, public, offense, defense and long-name plays, and confirmed the dropdown opens fully on-screen from the rightmost column in both the top row (opens down) and bottom row (flips up). The tightest case is 1024 3-up at ~310px, where all five still fit with room to spare.

Existing selectors preserved: the template action stays an `<a href>`, `title="Delete Play"` stays visible and keeps the native `confirm()`, and the `&from=plays` round-trip param is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)