### PR TITLE
[nightly] B-36 (1): Per-matchup coaching notes on Vs. Defense

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -151,18 +151,16 @@ Library grows on autopilot; blog↔library interlinking compounds SEO.
 Requires B-31's generation/thumbnail tooling to exist first.
 
 ### B-36 · "Vs. Defense" follow-ups
-The read-only `/vs?play=<id>` view ships offense+defense overlay and defense
-cycling only (deliberately lean). Deferred, in rough priority order:
-1. **Per-matchup coaching notes** — a note attached to an offense×defense
-   pairing ("vs Cover 2, hit the flat"). Needs a new table + RLS + an
-   idempotent `.sql` file; **⚠ requires SQL run**.
-2. **Export the matchup** — a PNG/PDF of the overlaid diagram, and a
+The read-only `/vs?play=<id>` view ships offense+defense overlay, defense
+cycling, and (as of the item below) per-matchup notes. Still deferred, in
+rough priority order:
+1. **Export the matchup** — a PNG/PDF of the overlaid diagram, and a
    "whole deck vs this play" sheet. `renderOverlayScene()` already renders to
    any offscreen context, so this is mostly an ExportModal variant. Likely a
    Pro gate (viewing stays free).
-3. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
+2. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
    read. Blocked on there being no "correct read" data on a play at all.
-4. **Community defenses in the deck** — currently the deck is the coach's own
+3. **Community defenses in the deck** — currently the deck is the coach's own
    defensive plays only, so a coach with none gets an empty state pointing at
    the designer. Offering public defenses would seed it.
 
@@ -184,6 +182,40 @@ reachable from nowhere else).
 its own low-risk PR.
 
 ## Done
+
+- **2026-08-10 · B-36 (1): Per-matchup coaching notes** — the first of B-36's
+  deferred follow-ups: a coach can now attach a personal note to one
+  offense×defense pairing on `/vs?play=<id>` (e.g. "vs Cover 2, hit the
+  flat"), toggled via a new "Notes" button in the header (badge dot when a
+  note exists for the defense on screen). `matchup_notes` is keyed
+  `(user_id, offense_play_id, defense_play_id)` rather than tied to either
+  play's ownership — the offense being viewed can be someone else's public
+  play, but the note is always the viewer's own. All notes for the offense
+  load in one query alongside the defensive deck; switching defenses swaps
+  the textarea to that pairing's note (or empty) without a refetch, and
+  saving (blur or the Save button) upserts, or deletes the row if the note
+  is cleared to empty. Notes load best-effort — a fetch failure (e.g. the
+  migration not yet run) logs and leaves the view otherwise fully working.
+  **Bug fix along the way:** found while writing the smoke test — clicking
+  the existing Previous/Next defense buttons (all prior tests only used the
+  arrow-key shortcut) was silently swallowed on a fresh session, because the
+  cookie consent banner (`fixed bottom-0`, z-50) was never excluded from
+  `/vs` and sat directly on top of its fixed-bottom footer controls. Fixed
+  by extending the existing `/designer` exclusion on `ConsentBanner`,
+  `Footer`, and `FeedbackButton` to also cover `/vs` — same "full-screen
+  tool with its own fixed controls" reasoning already documented for the
+  designer. **⚠ requires SQL run:** `supabase/matchup_notes.sql` (new table,
+  additive, idempotent). **Verification:** `npx tsc --noEmit` clean;
+  `npx eslint` on touched files shows only the two pre-existing
+  `no-explicit-any` warnings on the unrelated test-bridge lines (no new
+  errors); `npm run build` succeeds. Full Playwright smoke suite run
+  against a throwaway placeholder `.env` and the container's pre-installed
+  Chromium binary via a temporary `launchOptions.executablePath` in
+  `playwright.config.ts` (same recurring environment mismatch noted in
+  B-33/B-34 — reverted after the run, not part of this commit); new
+  `vs-defense.spec.ts` test covers loading an existing note, editing,
+  saving, and that switching defenses shows each pairing's own note instead
+  of leaking the one just edited.
 
 - **2026-08-09 · B-36: Daily feedback digest email** — closes the last gap in
   the feedback loop: nothing told anyone a submission had arrived. The admin

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -5,8 +5,10 @@ import { getStoredConsent, storeConsent } from '../lib/analytics';
 /**
  * Cookie consent banner (BACKLOG B-19). GA only loads once the visitor
  * accepts; declining stores the choice and no analytics cookies are ever set.
- * Hidden on the Play Designer, a full-screen tool (same precedent as
- * Footer/FeedbackButton).
+ * Hidden on the Play Designer and the Vs. Defense view, both full-screen
+ * tools with their own fixed-bottom controls this banner would otherwise
+ * cover (same precedent as Footer/FeedbackButton) — found covering /vs's
+ * Previous/Next defense buttons while adding B-36's coaching notes.
  */
 export function ConsentBanner() {
   const { pathname } = useLocation();
@@ -16,7 +18,7 @@ export function ConsentBanner() {
     setVisible(getStoredConsent() === null);
   }, []);
 
-  if (pathname.startsWith('/designer') || !visible) return null;
+  if (pathname.startsWith('/designer') || pathname.startsWith('/vs') || !visible) return null;
 
   const choose = (choice: 'granted' | 'denied') => {
     storeConsent(choice);

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -67,9 +67,9 @@ export function FeedbackButton() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // The Play Designer covers the full screen; the floating button would
-  // overlap the mobile toolbar's player icons and route action buttons.
-  const hidden = location.pathname === '/designer';
+  // The Play Designer and Vs. Defense view cover the full screen; the
+  // floating button would overlap their own fixed-position controls.
+  const hidden = location.pathname === '/designer' || location.pathname === '/vs';
 
   // getSession() reads the locally stored session — no network round trip on
   // every page load for signed-out visitors. The authoritative getUser() check

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,11 +4,11 @@ import { Logo, Wordmark } from './Logo';
 
 /**
  * Site-wide footer with the legal links every page must carry.
- * Hidden on the Play Designer, which is a full-screen tool.
+ * Hidden on the Play Designer and the Vs. Defense view, both full-screen tools.
  */
 export function Footer() {
   const { pathname } = useLocation();
-  if (pathname.startsWith('/designer')) return null;
+  if (pathname.startsWith('/designer') || pathname.startsWith('/vs')) return null;
 
   return (
     <footer className="bg-board border-t border-chalk/10 mt-auto">

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Eye, EyeOff, Home, Shield } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Eye, EyeOff, Home, Shield, StickyNote, X } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { usePageMeta } from '../../lib/seo';
@@ -76,6 +76,12 @@ export function VsDefenseView() {
   const [showDefense, setShowDefense] = useState(true);
   const [canvasSize, setCanvasSize] = useState({ width: 640, height: 480 });
 
+  const [userId, setUserId] = useState<string | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [notesOpen, setNotesOpen] = useState(false);
+  const [noteDraft, setNoteDraft] = useState('');
+  const [noteSaveState, setNoteSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
   const currentDefense = defenses[index] ?? null;
 
   // ── Load the offense and the deck of defenses ───────────────
@@ -95,10 +101,12 @@ export function VsDefenseView() {
           navigate('/auth', { replace: true });
           return;
         }
+        setUserId(user.id);
 
         // The offense may be someone else's public play (RLS allows reading
-        // those), but the defensive deck is always the signed-in coach's own.
-        const [offenseRes, defenseRes] = await Promise.all([
+        // those), but the defensive deck — and any coaching notes — are
+        // always the signed-in coach's own.
+        const [offenseRes, defenseRes, notesRes] = await Promise.all([
           supabase
             .from('plays')
             .select('id, name, type, description, metadata, canvas_data')
@@ -110,10 +118,26 @@ export function VsDefenseView() {
             .eq('user_id', user.id)
             .eq('type', 'defense')
             .order('name'),
+          supabase
+            .from('matchup_notes')
+            .select('defense_play_id, note')
+            .eq('user_id', user.id)
+            .eq('offense_play_id', playId),
         ]);
         if (cancelled) return;
         if (offenseRes.error) throw offenseRes.error;
         if (defenseRes.error) throw defenseRes.error;
+        // Notes are a nice-to-have on top of the core view — a failed fetch
+        // (e.g. the migration hasn't been run yet) shouldn't block the page.
+        if (notesRes.error) {
+          console.error('Matchup notes load error:', notesRes.error);
+        } else {
+          const noteMap: Record<string, string> = {};
+          for (const row of (notesRes.data ?? []) as { defense_play_id: string; note: string }[]) {
+            noteMap[row.defense_play_id] = row.note;
+          }
+          setNotes(noteMap);
+        }
 
         const offRow = offenseRes.data as PlayRow;
         const offScene = parseScene(offRow.canvas_data);
@@ -172,6 +196,52 @@ export function VsDefenseView() {
     // replace so Back leaves the view instead of walking the whole deck.
     setSearchParams(next, { replace: true });
   }, [currentDefense, searchParams, setSearchParams]);
+
+  // ── Keep the notes textarea in sync with whichever defense is on screen ─
+  useEffect(() => {
+    setNoteDraft(currentDefense ? (notes[currentDefense.id] ?? '') : '');
+    setNoteSaveState('idle');
+    // Only re-sync when the matchup itself changes — not on every keystroke
+    // (noteDraft) or every notes refetch, which would stomp an in-progress edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentDefense?.id]);
+
+  const saveNote = useCallback(async () => {
+    if (!userId || !offensePlay || !currentDefense) return;
+    const trimmed = noteDraft.trim();
+    const existed = currentDefense.id in notes;
+    if (!trimmed && !existed) return; // nothing to save, nothing to clear
+    setNoteSaveState('saving');
+    try {
+      if (trimmed) {
+        const { error } = await supabase
+          .from('matchup_notes')
+          .upsert(
+            { user_id: userId, offense_play_id: offensePlay.id, defense_play_id: currentDefense.id, note: trimmed },
+            { onConflict: 'user_id,offense_play_id,defense_play_id' },
+          );
+        if (error) throw error;
+      } else {
+        const { error } = await supabase
+          .from('matchup_notes')
+          .delete()
+          .eq('user_id', userId)
+          .eq('offense_play_id', offensePlay.id)
+          .eq('defense_play_id', currentDefense.id);
+        if (error) throw error;
+      }
+      setNotes((prev) => {
+        const next = { ...prev };
+        if (trimmed) next[currentDefense.id] = trimmed;
+        else delete next[currentDefense.id];
+        return next;
+      });
+      setNoteSaveState('saved');
+    } catch (err) {
+      console.error('Matchup note save error:', err);
+      setNoteSaveState('error');
+    }
+  }, [userId, offensePlay, currentDefense, noteDraft, notes]);
 
   // ── Aspect-locked sizing, matching the designer/export ratio ─
   // Keyed on `loading` because the container lives past the loading/error
@@ -243,10 +313,14 @@ export function VsDefenseView() {
         deckLength: defenses.length,
         index,
         showDefense,
+        notesOpen,
+        noteDraft,
+        noteSaveState,
+        hasNoteForCurrentDefense: currentDefense ? currentDefense.id in notes : false,
       }),
     };
     return () => { delete (window as any).__PBP_VS_TEST__; };
-  }, [offenseScene, visibleDefenseScene, currentDefense, defenses.length, index, showDefense]);
+  }, [offenseScene, visibleDefenseScene, currentDefense, defenses.length, index, showDefense, notesOpen, noteDraft, noteSaveState, notes]);
 
   const ariaLabel = useMemo(() => {
     const off = offensePlay?.name ?? 'Play';
@@ -302,7 +376,62 @@ export function VsDefenseView() {
           {showDefense ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
           <span className="hidden sm:inline">{showDefense ? 'Hide defense' : 'Show defense'}</span>
         </button>
+        <button
+          onClick={() => setNotesOpen((v) => !v)}
+          disabled={!currentDefense}
+          className="relative flex items-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          title={notesOpen ? 'Close coaching notes' : 'Coaching notes for this matchup'}
+          aria-pressed={notesOpen}
+        >
+          <StickyNote className="h-4 w-4" />
+          <span className="hidden sm:inline">Notes</span>
+          {currentDefense && currentDefense.id in notes && (
+            <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+          )}
+        </button>
       </header>
+
+      {/* ── NOTES PANEL ────────────────────────────────────────── */}
+      {notesOpen && currentDefense && (
+        <div className="absolute right-3 top-14 sm:top-16 z-40 w-[calc(100vw-1.5rem)] max-w-sm bg-board-light border border-chalk/20 rounded-lg shadow-xl p-3 flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium text-chalk truncate">
+              Note · vs {currentDefense.name}
+            </span>
+            <button
+              onClick={() => setNotesOpen(false)}
+              className="p-1 text-chalk/50 hover:text-chalk rounded"
+              aria-label="Close notes"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <textarea
+            id="matchup-note-textarea"
+            value={noteDraft}
+            onChange={(e) => { setNoteDraft(e.target.value); setNoteSaveState('idle'); }}
+            onBlur={saveNote}
+            maxLength={2000}
+            rows={4}
+            placeholder="e.g. vs Cover 2, hit the flat…"
+            className="w-full resize-none bg-board border border-chalk/20 text-chalk text-sm rounded-lg px-2 py-1.5 placeholder:text-chalk/30 focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-chalk/50" aria-live="polite">
+              {noteSaveState === 'saving' && 'Saving…'}
+              {noteSaveState === 'saved' && 'Saved'}
+              {noteSaveState === 'error' && 'Could not save — try again'}
+            </span>
+            <button
+              onClick={saveNote}
+              disabled={noteSaveState === 'saving'}
+              className="px-3 py-1 text-xs bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors disabled:opacity-50"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* ── CANVAS ─────────────────────────────────────────────── */}
       <div ref={containerRef} className="flex-1 min-h-0 flex items-center justify-center p-2 sm:p-4">

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -36,6 +36,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `add_6v6_game_format.sql` | applied (2026-08-09) | Widens `custom_formations.game_type` and `user_preferences.default_game_format`'s `CHECK` constraints to allow `'6v6'`, alongside new 6v6 formation templates in `formations.ts`. No new column. |
 | `community_top_contributors.sql` | applied (2026-08-09) | `get_top_contributors(result_limit int)` — real top-N posters by `user_reputation.reputation` (>0 only), same `auth.users`/`avatar_icons` join pattern as `get_community_authors()`. Fixes the Community page's "Top Contributors" sidebar, which was hardcoded mock data (fake usernames/photos/reputation) presented as real. |
 | `community_posts_updated_at.sql` | applied (2026-08-09) | `BEFORE UPDATE` trigger on `posts` reusing the existing `update_updated_at_column()` function (already wired to `plays`/`playbooks`, just missing here). Lets the UI show an "(edited)" marker instead of an edit looking identical to the original post. No schema change. |
+| `matchup_notes.sql` | **not yet applied** | B-36 (1): `matchup_notes` table for the "Vs. Defense" view — a coach's own note on one offense×defense pairing, keyed `(user_id, offense_play_id, defense_play_id)` rather than tied to play ownership (the offense can be someone else's public play). RLS: owner full access only. |
 
 > "verify applied" = created recently; confirm it has been run in Supabase before
 > relying on the behavior.
@@ -62,6 +63,7 @@ idempotent `.sql` file and update this doc in the same change.
 | `formations` | `id`, `user_id`, `name`, `type`, `template`, `is_system bool` | Read if `is_system` or owner; manage own non-system rows. **Unused** — no frontend references; superseded by `custom_formations` below. |
 | `custom_formations` | `id`, `user_id`, `name`, `game_type ('5v5'\|'6v6'\|'7v7'\|'11v11')`, `icons jsonb` (offense-only `PlayerIcon[]`, same shape as the curated templates in `formations.ts`), `created_at` | Owner full access. `BEFORE INSERT` trigger blocks all non-`is_pro()` users — Pro-only feature, not just free-tier-capped (`custom_formations.sql`). |
 | `categories` | `id`, `name`, `type`, `parent_id`, `playbook_id`, `order_position` | Access via owning playbook. |
+| `matchup_notes` | `id`, `user_id`, `offense_play_id→plays`, `defense_play_id→plays`, `note` (≤2000 chars), timestamps; UNIQUE `(user_id, offense_play_id, defense_play_id)` | Owner full access only (`matchup_notes.sql`, **not yet applied**). Personal coaching notes on the `/vs` overlay view — keyed on the viewer, not either play's owner. |
 
 ### Community / social
 | Table | Key columns | RLS summary |

--- a/supabase/matchup_notes.sql
+++ b/supabase/matchup_notes.sql
@@ -1,0 +1,42 @@
+-- B-36 (1): Per-matchup coaching notes on the "Vs. Defense" view.
+-- Run this once in the Supabase SQL Editor. Idempotent — safe to re-run.
+--
+-- A note is personal to the coach viewing a matchup, not tied to who owns
+-- either play — the offense on /vs?play=<id> can be someone else's public
+-- play (RLS already allows reading those), but the note itself only ever
+-- belongs to the signed-in viewer. Keyed on (user_id, offense_play_id,
+-- defense_play_id) rather than a play_id column, since it's the pairing
+-- that's being annotated ("vs Cover 2, hit the flat"), not either play alone.
+
+CREATE TABLE IF NOT EXISTS matchup_notes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  offense_play_id uuid NOT NULL REFERENCES plays(id) ON DELETE CASCADE,
+  defense_play_id uuid NOT NULL REFERENCES plays(id) ON DELETE CASCADE,
+  note text NOT NULL CHECK (char_length(note) <= 2000),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, offense_play_id, defense_play_id)
+);
+
+-- Loading a matchup fetches every note for the offense in one query
+-- (VsDefenseView loads the whole defensive deck up front), so this is the
+-- lookup path that matters.
+CREATE INDEX IF NOT EXISTS matchup_notes_lookup_idx
+  ON matchup_notes (user_id, offense_play_id);
+
+ALTER TABLE matchup_notes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users manage their own matchup notes" ON matchup_notes;
+CREATE POLICY "Users manage their own matchup notes"
+  ON matchup_notes FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Reuses the same update_updated_at_column() function combined_migrations.sql
+-- already defines and wires to plays/playbooks — no new function needed.
+DROP TRIGGER IF EXISTS update_matchup_notes_updated_at ON matchup_notes;
+CREATE TRIGGER update_matchup_notes_updated_at
+  BEFORE UPDATE ON matchup_notes
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -51,9 +51,13 @@ type VsState = {
   deckLength: number;
   index: number;
   showDefense: boolean;
+  notesOpen: boolean;
+  noteDraft: string;
+  noteSaveState: 'idle' | 'saving' | 'saved' | 'error';
+  hasNoteForCurrentDefense: boolean;
 };
 
-async function mockBackend(page: Page, defenses: typeof DEFENSES) {
+async function mockBackend(page: Page, defenses: typeof DEFENSES, seededNotes: { defense_play_id: string; note: string }[] = []) {
   await page.addInitScript(({ user, storageKey }) => {
     localStorage.setItem(storageKey, JSON.stringify({
       access_token: 'test-access-token', refresh_token: 'test-refresh-token',
@@ -70,6 +74,17 @@ async function mockBackend(page: Page, defenses: typeof DEFENSES) {
     const url = route.request().url();
     const body = url.includes('type=eq.defense') ? JSON.stringify(defenses) : JSON.stringify(OFFENSE);
     return route.fulfill({ status: 200, contentType: 'application/json', body });
+  });
+
+  // matchup_notes: GET returns the seeded deck of notes; any write (upsert/
+  // delete) is just acknowledged — the UI updates its own local map from the
+  // response of the action that triggered it, not a refetch.
+  await page.route('**/rest/v1/matchup_notes**', (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(seededNotes) });
+    }
+    return route.fulfill({ status: 201, contentType: 'application/json', body: '[]' });
   });
 }
 
@@ -150,4 +165,46 @@ test('with no saved defenses, the offense still renders and prompts to create on
   expect(state.offenseIcons.map((i) => i.letter)).toEqual(['Q', 'C', 'X', 'Y', 'Z']);
   expect(state.defenseIcons).toEqual([]);
   await expect(page.getByRole('link', { name: /create a defense/i })).toBeVisible();
+});
+
+test('B-36: per-matchup coaching notes load, edit, save, and stay scoped per defense', async ({ page }) => {
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+
+  // Cover 2 Zone (def-1, first in the deck) already has a note; Man Blitz
+  // (def-2) doesn't.
+  await mockBackend(page, DEFENSES, [{ defense_play_id: 'def-1', note: 'Seeded note for Cover 2' }]);
+  await openVs(page);
+
+  const initial = await vsState(page);
+  expect(initial.defenseId).toBe('def-1');
+  expect(initial.hasNoteForCurrentDefense).toBe(true);
+
+  // Closed by default; opening loads the existing note into the draft.
+  expect(initial.notesOpen).toBe(false);
+  await page.getByRole('button', { name: /notes/i }).click();
+  expect((await vsState(page)).notesOpen).toBe(true);
+  await expect(page.locator('#matchup-note-textarea')).toHaveValue('Seeded note for Cover 2');
+
+  // Edit and save (blur triggers the save, same as clicking the Save button).
+  await page.locator('#matchup-note-textarea').fill('vs Cover 2, hit the flat');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+  expect((await vsState(page)).noteDraft).toBe('vs Cover 2, hit the flat');
+
+  // Switching to the other defense shows its own (empty) note, not a leak
+  // from the one just edited.
+  await page.getByRole('button', { name: 'Next defense' }).click();
+  await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
+  const onSecond = await vsState(page);
+  expect(onSecond.hasNoteForCurrentDefense).toBe(false);
+  expect(onSecond.noteDraft).toBe('');
+  await expect(page.locator('#matchup-note-textarea')).toHaveValue('');
+
+  // Switching back shows the edit that was just saved.
+  await page.getByRole('button', { name: 'Previous defense' }).click();
+  await expect(page.locator('#matchup-note-textarea')).toHaveValue('vs Cover 2, hit the flat');
+  expect((await vsState(page)).hasNoteForCurrentDefense).toBe(true);
+
+  expect(errors, 'no uncaught page errors').toEqual([]);
 });


### PR DESCRIPTION
## What changed

The first of BACKLOG **B-36**'s deferred "Vs. Defense" follow-ups: a coach can now attach a personal note to one offense×defense pairing on `/vs?play=<id>` (e.g. "vs Cover 2, hit the flat").

- New "Notes" button in the `/vs` header toggles a small panel with a textarea (badge dot shown when a note exists for the defense currently on screen).
- `matchup_notes` table, keyed `(user_id, offense_play_id, defense_play_id)` rather than tied to either play's ownership — the offense being viewed can be someone else's public play, but the note always belongs to the viewer. RLS: owner-only, mirroring the `custom_formations`/`play_votes` pattern.
- All notes for the offense load in one query alongside the defensive deck; switching defenses swaps the textarea to that pairing's note (or empty) client-side, no refetch. Saving (blur or the Save button) upserts, or deletes the row if cleared to empty.
- Notes load best-effort: a fetch failure (e.g. the migration hasn't been run yet) is logged and the rest of the view still works normally.

### Bug fix found along the way

Writing the smoke test for the Previous/Next defense *buttons* (every prior `/vs` test only used the arrow-key shortcut) turned up a real pre-existing bug: the cookie consent banner (`fixed bottom-0`, z-50) was never excluded from `/vs`, only `/designer`, so on a fresh session it sat directly on top of `/vs`'s own fixed-bottom footer controls and silently ate the clicks. Extended the existing `/designer` exclusion on `ConsentBanner`, `Footer`, and `FeedbackButton` to also cover `/vs` — same "full-screen tool with its own fixed controls" reasoning already documented for the designer.

## ⚠ requires SQL run

`supabase/matchup_notes.sql` — new table, additive, idempotent (`CREATE TABLE IF NOT EXISTS`, `DROP POLICY/TRIGGER IF EXISTS` before create). `supabase/SCHEMA.md` updated in this PR to match, marked "not yet applied" until run.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint src/components/vs/VsDefenseView.tsx tests/smoke/vs-defense.spec.ts` — 0 errors, only the 2 pre-existing `no-explicit-any` warnings on the unrelated `window as any` test-bridge lines.
- `npm run build` — succeeds.
- Full Playwright smoke suite: **123/123 passed**, including 4 in `vs-defense.spec.ts` (1 new test for the notes flow, 3 pre-existing unaffected). Run against a throwaway placeholder `.env` and the container's pre-installed Chromium via a temporary, uncommitted `launchOptions.executablePath` in `playwright.config.ts` (same recurring pinned-Playwright-vs-preinstalled-browser mismatch noted in prior nightly PRs for B-33/B-34) — reverted before committing, not part of this diff.

## Not done (out of scope for this PR)

Per B-36's remaining priority order: matchup PNG/PDF export, quiz/reveal mode, and community defenses in the deck — all still open in `BACKLOG.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0111RQxAgLxCXwDJrW4g2TXF)_