### PR TITLE
Set every default formation a yard back off the ball

### DIFF
--- a/src/components/designer/formations.ts
+++ b/src/components/designer/formations.ts
@@ -5,20 +5,30 @@ import type { PlayMetadata } from '../../types/play';
 // Formation templates (B-24): curated starting positions coaches can stamp
 // onto the canvas instead of hand-placing every icon. Coordinates are
 // authored relative to the line of scrimmage using the same math Canvas.tsx
-// uses to render it (yFromYards), so a template lines up on the LOS exactly
-// like a hand-placed icon would.
-const yBehindLOS = (yardsBehindLOS: number) =>
-  (FIELD_YARDS_ABOVE_LOS + yardsBehindLOS) / TOTAL_FIELD_YARDS;
+// uses to render it (yFromYards), so a template lands on the field exactly
+// where a hand-placed icon would.
+//
+// Every icon then sits one yard further back than its authored alignment
+// (2026-08-11): the front line starts a yard off the ball instead of straddling
+// it, and everything behind shifts with it, so relative spacing is unchanged.
+// Applied here rather than in each template so the numbers below stay readable
+// as plain yards behind the LOS. This only affects newly stamped formations —
+// plays already saved keep the coordinates they were saved with.
+const TEMPLATE_SETBACK_YARDS = 1;
 
-const LOS = yBehindLOS(0);
+const yBehindLOS = (yardsBehindLOS: number) =>
+  (FIELD_YARDS_ABOVE_LOS + yardsBehindLOS + TEMPLATE_SETBACK_YARDS) / TOTAL_FIELD_YARDS;
+
+/** The front line — on the ball, plus the shared setback above. */
+const LINE_Y = yBehindLOS(0);
 
 // Colors reuse the app's existing player-icon palette (PlayerToolbar.tsx /
 // PlayerStyleEditor.tsx's SWATCH_COLORS) so stamped icons look like ones a
 // coach placed by hand, not a separate visual language.
 const C = { QB: '#3B82F6', RB: '#10B981', FB: '#F59E0B', WR: '#8B5CF6', TE: '#EC4899', OL: '#000000', SLOT: '#6366F1' };
 
-const ol = (x: number, letter: string): PlayerIcon => ({ x, y: LOS, letter, color: C.OL, shape: 'square' });
-const wr = (x: number, letter: string, y = LOS, color = C.WR): PlayerIcon => ({ x, y, letter, color, shape: 'circle' });
+const ol = (x: number, letter: string): PlayerIcon => ({ x, y: LINE_Y, letter, color: C.OL, shape: 'square' });
+const wr = (x: number, letter: string, y = LINE_Y, color = C.WR): PlayerIcon => ({ x, y, letter, color, shape: 'circle' });
 
 export type FormationTemplate = {
   id: string;
@@ -42,7 +52,7 @@ const FORMATIONS_11V11: FormationTemplate[] = [
     playType: 'offense',
     icons: [
       ...line11,
-      wr(0.80, 'TE', LOS, C.TE),
+      wr(0.80, 'TE', LINE_Y, C.TE),
       wr(0.10, 'WR'),
       wr(0.90, 'WR'),
       { x: 0.50, y: yBehindLOS(1.5), letter: 'QB', color: C.QB, shape: 'circle' },
@@ -57,7 +67,7 @@ const FORMATIONS_11V11: FormationTemplate[] = [
     playType: 'offense',
     icons: [
       ...line11,
-      wr(0.80, 'TE', LOS, C.TE),
+      wr(0.80, 'TE', LINE_Y, C.TE),
       wr(0.06, 'WR'),
       wr(0.18, 'WR'),
       wr(0.94, 'WR'),
@@ -87,7 +97,7 @@ const FORMATIONS_11V11: FormationTemplate[] = [
     playType: 'offense',
     icons: [
       ...line11,
-      wr(0.80, 'TE', LOS, C.TE),
+      wr(0.80, 'TE', LINE_Y, C.TE),
       { x: 0.86, y: yBehindLOS(1), letter: 'WR', color: C.SLOT, shape: 'circle' }, // wingback, tight off the LOS
       wr(0.10, 'WR'),
       { x: 0.50, y: yBehindLOS(1.5), letter: 'QB', color: C.QB, shape: 'circle' },

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -814,6 +814,41 @@ test('formation templates: game-format picker in the menu offers 5v5/6v6/7v7/11v
   expect(state.playerIcons).toHaveLength(5);
 });
 
+// Every template is offset a yard off the ball (formations.ts
+// TEMPLATE_SETBACK_YARDS) rather than straddling the LOS. The offset is
+// applied in one place for all four formats, so this guards all four.
+test('formation templates: every format stamps a yard behind the LOS, not on it', async ({ page }) => {
+  // The universal field is 17 yards above the LOS and 13 below
+  // (renderPlayScene.ts), so the LOS is at 17/30 in normalized coords.
+  const YARD = 1 / 30;
+  const LOS_Y = 17 / 30;
+
+  await openDesigner(page);
+
+  // deepest = the authored yards-behind-LOS of that template's back-most icon.
+  for (const { format, formation, deepest } of [
+    { format: '11v11', formation: 'I-Formation', deepest: 7 },
+    { format: '7v7', formation: 'Trips', deepest: 4 },
+    { format: '6v6', formation: 'Trips', deepest: 4 },
+    { format: '5v5', formation: 'Trips', deepest: 4 },
+  ] as const) {
+    await btn(page, 'Formation templates').click();
+    if (format !== '11v11') {
+      await realClick(page, page.getByRole('button', { name: format, exact: true }));
+    }
+    await realClick(page, page.getByRole('button', { name: formation, exact: true }));
+
+    const ys = (await canvasState(page)).playerIcons.map((i) => i.y);
+    expect(ys.length, `${format} ${formation} stamped no icons`).toBeGreaterThan(0);
+    // Front line is a yard behind the LOS, not on it.
+    expect(Math.min(...ys), `${format} front line`).toBeCloseTo(LOS_Y + YARD, 5);
+    // The backfield moved by exactly one yard too — the whole formation
+    // shifted, it didn't stretch.
+    expect(Math.max(...ys), `${format} backfield`).toBeCloseTo(LOS_Y + (deepest + 1) * YARD, 5);
+    for (const y of ys) expect(y).toBeLessThan(1);
+  }
+});
+
 // The field is one universal canvas for every game format (2026-07-23,
 // superseding B-29's format-aware hashes), but the format picker still
 // drives formation templates — this guards that switching formats with


### PR DESCRIPTION
Requested: move all player icons in the default formations back (down) by 1 yard, across 5v5, 6v6, 7v7 and 11v11.

## Change

Every template previously placed its front line exactly on the LOS, so those icons straddled the line. All icons now sit one yard further back. The backfield shifts with the line, so **relative spacing inside each formation is unchanged** — the formation moved, it didn't stretch.

Applied as a single `TEMPLATE_SETBACK_YARDS` constant inside `yBehindLOS()` rather than edited into ~40 call sites. That keeps the per-formation numbers readable as plain yards behind the LOS, and leaves one place to adjust if a yard turns out to be too much or too little. The `LOS` constant is renamed `LINE_Y`, since it no longer sits on the line.

**This is not a data migration.** It changes where newly stamped formations land; plays already saved keep the coordinates they were saved with. Nothing about the field geometry (`FIELD_YARDS_ABOVE_LOS` / `BELOW_LOS`) is touched, which is the change that *would* have been one.

Deepest icon is now 8 yards behind the LOS (11v11 I-Formation's RB), well inside the 13 yards the field allows below the line.

## Verification

- `npm run typecheck` — clean
- `npx eslint` on both touched files — 0 errors (6 pre-existing warnings)
- `npm run build` — clean
- `npm run smoke` — **123/123**

The new test stamps a template in each of the four formats and asserts two things: the front line is exactly one yard behind the LOS, **and** the deepest icon moved exactly one yard too. The second assertion is the one that matters — it fails if the formation stretches instead of shifting, which a naive per-icon edit could easily do.

Also checked it by eye, stamping each format in the real designer and confirming the icons sit clear of the line rather than straddling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)