### PR TITLE
mobile: fix what's unreachable or broken on a phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,13 @@
          only after the visitor accepts the cookie consent banner (BACKLOG B-19). -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover is required for env(safe-area-inset-*) to resolve to
+         anything but 0. Without it the designer's bottom-toolbar padding and the
+         consent banner's buttons sit under the iPhone home indicator. Note the
+         `8px` fallbacks in those rules only apply where env() is UNSUPPORTED —
+         they do not save you when it returns 0. No maximum-scale/user-scalable:
+         pinch zoom stays available. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Playbuilder Pro — Youth &amp; Flag Football Play Designer</title>
     <meta name="description" content="Playbuilder Pro is the play designer for youth and flag football coaches — from 5v5 flag to 11v11. Draw routes on a real field, build playbooks, and print game-day sheets." />
     <meta property="og:site_name" content="Playbuilder Pro" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,23 @@ function RecoveryRedirect() {
   return null;
 }
 
+/**
+ * React Router keeps the window's scroll position across navigations, so
+ * jumping from the bottom of a long list to another page lands mid-page. Most
+ * noticeable on a phone, where every page is long. Skips hash links, which
+ * want to scroll to their own anchor.
+ */
+function ScrollToTop() {
+  const { pathname, hash } = useLocation();
+
+  useEffect(() => {
+    if (hash) return;
+    window.scrollTo(0, 0);
+  }, [pathname, hash]);
+
+  return null;
+}
+
 function App() {
   useEffect(() => {
     initAnalyticsFromStoredConsent();
@@ -94,6 +111,7 @@ function App() {
   return (
     <Router>
       <RecoveryRedirect />
+      <ScrollToTop />
       <div className="min-h-screen bg-board flex flex-col">
         <Navbar />
         <div className="flex-1">

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -26,7 +26,7 @@ export function ConsentBanner() {
   };
 
   return (
-    <div className="fixed bottom-0 inset-x-0 z-50 bg-board-light border-t border-chalk/10 shadow-lg">
+    <div className="fixed bottom-0 inset-x-0 z-40 bg-board-light border-t border-chalk/10 shadow-lg pb-[env(safe-area-inset-bottom)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col sm:flex-row items-center gap-4">
         <p className="text-sm text-chalk/80 flex-1">
           We use Google Analytics to understand how coaches use Playbuilder Pro. See our{' '}
@@ -35,13 +35,13 @@ export function ConsentBanner() {
         <div className="flex items-center gap-3 shrink-0">
           <button
             onClick={() => choose('denied')}
-            className="px-4 py-2 text-sm rounded-md text-chalk/70 hover:text-chalk border border-chalk/20 transition-colors"
+            className="tap-target px-4 py-2 text-sm rounded-md text-chalk/70 hover:text-chalk border border-chalk/20 transition-colors"
           >
             Decline
           </button>
           <button
             onClick={() => choose('granted')}
-            className="px-4 py-2 text-sm rounded-md bg-primary hover:bg-primary-dark text-white transition-colors"
+            className="tap-target px-4 py-2 text-sm rounded-md bg-primary hover:bg-primary-dark text-white transition-colors"
           >
             Accept
           </button>

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, X, LogIn } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { getSafeErrorMessage } from '../lib/errors';
+import { getStoredConsent, onConsentChange } from '../lib/analytics';
 
 type FeedbackType = 'bug' | 'feature' | 'general';
 
@@ -69,7 +70,21 @@ export function FeedbackButton() {
 
   // The Play Designer and Vs. Defense view cover the full screen; the
   // floating button would overlap their own fixed-position controls.
-  const hidden = location.pathname === '/designer' || location.pathname === '/vs';
+  // startsWith, matching Footer and ConsentBanner — with `===` a trailing
+  // slash floats this button over the designer's own bottom toolbar.
+  const hidden =
+    location.pathname.startsWith('/designer') || location.pathname.startsWith('/vs');
+
+  // The consent banner is a bottom-anchored bar that stacks to ~130px on a
+  // phone, which is exactly where this button sits. Lift above it while the
+  // choice is unresolved, and drop back down the moment it's made.
+  const [consentPending, setConsentPending] = useState(() => getStoredConsent() === null);
+  useEffect(() => onConsentChange(() => setConsentPending(false)), []);
+
+  // Clears both the banner and the iPhone home indicator.
+  const bottomOffset = consentPending
+    ? 'bottom-[9.5rem] sm:bottom-24'
+    : 'bottom-[calc(1rem+env(safe-area-inset-bottom))]';
 
   // getSession() reads the locally stored session — no network round trip on
   // every page load for signed-out visitors. The authoritative getUser() check
@@ -173,8 +188,9 @@ export function FeedbackButton() {
     return (
       <button
         onClick={openPanel}
-        className="fixed bottom-4 right-4 z-40 bg-primary hover:bg-primary-dark text-white rounded-full p-3 shadow-lg transition-colors"
+        className={`fixed ${bottomOffset} right-4 z-50 bg-primary hover:bg-primary-dark text-white rounded-full p-3 shadow-lg transition-all`}
         title="Give Feedback"
+        aria-label="Give Feedback"
       >
         <MessageSquare className="h-6 w-6" />
       </button>
@@ -187,7 +203,7 @@ export function FeedbackButton() {
     <div
       role="dialog"
       aria-label="Give Feedback"
-      className="fixed bottom-4 right-4 z-40 w-96 max-w-[calc(100vw-2rem)] bg-board-light rounded-lg shadow-xl border border-chalk/10"
+      className={`fixed ${bottomOffset} right-4 z-50 w-96 max-w-[calc(100vw-2rem)] max-h-[80vh] overflow-y-auto bg-board-light rounded-lg shadow-xl border border-chalk/10`}
     >
       <div className="flex items-center justify-between px-4 py-3 border-b border-chalk/10">
         <h3 className="text-lg font-semibold text-chalk">Give Feedback</h3>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Menu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import { Logo, Wordmark } from './Logo';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import type { User } from '@supabase/supabase-js';
@@ -26,6 +26,22 @@ export function Navbar() {
 
     return () => subscription.unsubscribe();
   }, []);
+
+  // Every menu item calls setIsMenuOpen(false) on click, but navigation that
+  // doesn't originate inside the menu — browser back, a UserMenu item, a deep
+  // link — used to leave it hanging open over the new page.
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsMenuOpen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isMenuOpen]);
 
   const isActive = (path: string) => {
     if (path === '/') {
@@ -88,22 +104,25 @@ export function Navbar() {
             {user && <UserMenu user={user} showName={false} />}
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
-              className="inline-flex items-center justify-center p-2 rounded-md text-chalk/70 hover:text-chalk hover:bg-board-light focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
+              aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-menu"
+              className="tap-target inline-flex items-center justify-center p-2 rounded-md text-chalk/70 hover:text-chalk hover:bg-board-light focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
             >
-              <Menu className="h-6 w-6" />
+              {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </button>
           </div>
         </div>
       </div>
 
       {isMenuOpen && (
-        <div className="sm:hidden bg-board-light">
+        <div id="mobile-menu" className="sm:hidden bg-board-light">
           <div className="pt-2 pb-3 space-y-1">
             {navItems.map(({ path, label }) => (
               <Link
                 key={path}
                 to={path}
-                className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
+                className={`tap-target flex items-center pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                   isActive(path)
                     ? 'bg-board text-primary border-primary'
                     : 'border-transparent text-chalk/70 hover:text-chalk hover:bg-board'

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -25,7 +25,7 @@ export function UpgradePrompt({ isOpen, onClose, feature, description }: Upgrade
               <Lock className="h-5 w-5 text-primary shrink-0" />
               <h3 className="text-lg font-bold text-chalk">{feature} is a Pro feature</h3>
             </div>
-            <button onClick={onClose} className="text-chalk/70 hover:text-chalk transition-colors shrink-0">
+            <button onClick={onClose} aria-label="Close" className="tap-target flex items-center justify-center text-chalk/70 hover:text-chalk transition-colors shrink-0">
               <X className="w-5 h-5" />
             </button>
           </div>

--- a/src/components/community/CommentThread.tsx
+++ b/src/components/community/CommentThread.tsx
@@ -165,7 +165,7 @@ export function CommentThread({ postId, currentUserId, onCommentsChanged }: Comm
                       <button
                         onClick={() => handleDelete(comment.id)}
                         title="Delete Comment"
-                        className="ml-auto p-1 text-chalk/40 hover:text-red-400 rounded transition-colors"
+                        className="tap-target ml-auto flex items-center justify-center p-1 text-chalk/40 hover:text-red-400 rounded transition-colors"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>

--- a/src/components/community/PostFormModal.tsx
+++ b/src/components/community/PostFormModal.tsx
@@ -94,7 +94,8 @@ export function PostFormModal({ isOpen, onClose, onSaved, post }: PostFormModalP
             <h3 className="text-2xl font-bold text-chalk">{isEditing ? 'Edit Post' : 'Create Post'}</h3>
             <button
               onClick={onClose}
-              className="text-chalk/70 hover:text-chalk transition-colors"
+              aria-label="Close"
+              className="tap-target flex items-center justify-center text-chalk/70 hover:text-chalk transition-colors"
             >
               <X className="w-6 h-6" />
             </button>

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1600,6 +1600,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           onPointerLeave={handlePointerUp}
+          // iOS fires pointercancel (never pointerup) when the system takes
+          // over a gesture — an edge swipe, an incoming notification. Without
+          // this the pointer id is never removed from activePointersRef, so
+          // the NEXT single touch is misread as the second finger of a pinch
+          // and drawing stays dead until the component remounts.
+          onPointerCancel={handlePointerUp}
           onDragOver={handleDragOver}
           onDrop={handleDrop}
           className="block bg-white touch-none"

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -1515,10 +1515,15 @@ export function PlaybooksPage() {
                                 <Play className="h-8 w-8" />
                               </div>
                             )}
-                            <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+                            {/* touch-always-visible: on a phone there is no
+                                hover, so without it Edit/Vs/Remove simply do
+                                not exist here — and this grid is the default
+                                layout. See the @media (hover: none) rule in
+                                index.css. */}
+                            <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 touch-always-visible transition-opacity flex items-center justify-center gap-2">
                               <button
                                 onClick={() => handleEditPlay(play.id)}
-                                className="px-3 py-2 bg-white text-black rounded-lg text-sm font-medium"
+                                className="tap-target px-3 py-2 bg-white text-black rounded-lg text-sm font-medium"
                               >
                                 Edit Play
                               </button>
@@ -1529,7 +1534,7 @@ export function PlaybooksPage() {
                                 <Link
                                   to={`/vs?play=${play.id}`}
                                   title="View this play against your defensive plays"
-                                  className="p-2 bg-white text-black hover:bg-chalk rounded-lg transition-colors"
+                                  className="tap-target flex items-center justify-center p-2 bg-white text-black hover:bg-chalk rounded-lg transition-colors"
                                 >
                                   <Shield className="h-4 w-4" />
                                 </Link>
@@ -1537,7 +1542,7 @@ export function PlaybooksPage() {
                               <button
                                 onClick={() => removePlayFromPlaybook(play)}
                                 title="Remove from this playbook"
-                                className="p-2 bg-white text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                                className="tap-target flex items-center justify-center p-2 bg-white text-red-500 hover:bg-red-50 rounded-lg transition-colors"
                               >
                                 <Trash2 className="h-4 w-4" />
                               </button>
@@ -1616,7 +1621,8 @@ export function PlaybooksPage() {
                   <h3 className="text-lg font-bold text-chalk">Create New Playbook</h3>
                   <button
                     onClick={() => setShowCreateModal(false)}
-                    className="text-chalk/70 hover:text-chalk transition-colors"
+                    aria-label="Close"
+                    className="tap-target flex items-center justify-center text-2xl leading-none text-chalk/70 hover:text-chalk transition-colors"
                   >
                     ×
                   </button>

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -400,7 +400,7 @@ export function VsDefenseView() {
             </span>
             <button
               onClick={() => setNotesOpen(false)}
-              className="p-1 text-chalk/50 hover:text-chalk rounded"
+              className="tap-target flex items-center justify-center p-1 text-chalk/50 hover:text-chalk rounded"
               aria-label="Close notes"
             >
               <X className="h-4 w-4" />
@@ -425,7 +425,7 @@ export function VsDefenseView() {
             <button
               onClick={saveNote}
               disabled={noteSaveState === 'saving'}
-              className="px-3 py-1 text-xs bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors disabled:opacity-50"
+              className="tap-target px-3 py-1 text-xs bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors disabled:opacity-50"
             >
               Save
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,51 @@ body {
   background-color: #101D2E;
 }
 
+/* ── Touch input ────────────────────────────────────────────────────────────
+   Everything here is gated on `pointer: coarse` — a finger, not a mouse — so
+   desktop density is untouched. Keyed on the input device rather than a width
+   breakpoint because a 1280px touchscreen still needs finger-sized targets and
+   a 600px desktop window does not. */
+@media (pointer: coarse) {
+  /* iOS Safari zooms the whole page when a focused control's font-size is
+     under 16px, and never zooms back out. That's ~10 controls across the app
+     (comment box, admin filters, /vs notes); the worst are inside /designer
+     and /vs, which are `fixed inset-0` — zooming detaches their chrome from
+     the visual viewport. One rule beats editing every call site, and the
+     visual size stays as designed everywhere else.
+
+     !important is load-bearing: these are element selectors and Tailwind's
+     `.text-sm` is a class, so it wins on specificity no matter what order the
+     rules appear in. Safe to clamp — no input, select or textarea in the app
+     asks for a font larger than 16px, so this only ever raises. */
+  input,
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
+
+  /* Fitts' Law floor. Applied opt-in rather than to every button, so it can
+     be added where a control is genuinely too small without inflating the
+     layouts that are already fine. Pair with the existing padding — this only
+     raises the hit area, it doesn't restyle the control. */
+  .tap-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+
+/* An action revealed by `group-hover` does not exist on a touch device — there
+   is no hover state to enter and no click fallback. Add this alongside the
+   hover classes so the overlay is simply always visible where hover is
+   unavailable, rather than gating real actions behind a gesture that can't
+   happen. Keyed on `hover: none` (not `pointer: coarse`) because the question
+   is specifically whether hovering works. */
+@media (hover: none) {
+  .touch-always-visible {
+    opacity: 1;
+  }
+}
+
 /* Route "draw-in": used on the hero's decorative SVG doodles so the routes
    appear to be drawn on load, echoing "Draw the play." Set --draw-length to
    the path's actual length (via getTotalLength()) for an accurate trace. */

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -32,6 +32,23 @@ export function getStoredConsent(): ConsentChoice | null {
   }
 }
 
+/**
+ * Consent isn't only an analytics question — the banner is a ~130px fixed bar on
+ * mobile, so anything else anchored to the bottom of the viewport has to know
+ * whether it's currently on screen. Subscribers are notified on every choice so
+ * they can move out of the way (and back) without polling localStorage.
+ */
+type ConsentListener = (choice: ConsentChoice) => void;
+const consentListeners = new Set<ConsentListener>();
+
+/** Subscribe to consent changes. Returns an unsubscribe function. */
+export function onConsentChange(listener: ConsentListener): () => void {
+  consentListeners.add(listener);
+  return () => {
+    consentListeners.delete(listener);
+  };
+}
+
 /** Persists the visitor's choice and loads GA immediately if they granted it. */
 export function storeConsent(choice: ConsentChoice): void {
   try {
@@ -40,6 +57,7 @@ export function storeConsent(choice: ConsentChoice): void {
     // Storage blocked — honor the choice for this page view even if it can't persist.
   }
   if (choice === 'granted') loadGoogleAnalytics();
+  consentListeners.forEach((listener) => listener(choice));
 }
 
 let gaLoaded = false;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2581,6 +2581,31 @@ test('PlaybooksPage: Grid view is the default and unaffected by the List view fe
   await expect(page.locator('button[title="Grid view"]')).toHaveAttribute('aria-pressed', 'true');
 });
 
+test.describe('touch device', () => {
+  // hasTouch is the only thing that makes `hover: none` evaluate true —
+  // setViewportSize doesn't, and CDP Emulation.setEmulatedMedia ignores the
+  // hover/pointer features entirely. Without it this test passes vacuously.
+  test.use({ viewport: { width: 375, height: 667 }, hasTouch: true });
+
+  test('PlaybooksPage: Grid view play actions are reachable without hover', async ({ page }) => {
+    // Regression: Edit Play / Vs / Remove lived in an `opacity-0
+    // group-hover:opacity-100` overlay with no click fallback, and Grid is the
+    // default layout — so on a phone those three actions did not exist at all.
+    await mockPlaybookWithPlays(page, [{ id: 'play-a', name: 'Play A', order_position: 10 }]);
+
+    await expect(page.locator('button[title="Grid view"]')).toHaveAttribute('aria-pressed', 'true');
+
+    const edit = page.getByRole('button', { name: 'Edit Play' });
+    await expect(edit).toBeVisible();
+    // Visible isn't enough — a 0-opacity element still reports visible to
+    // getComputedStyle-free checks. Assert the overlay is actually painted.
+    const opacity = await edit.evaluate((el) => getComputedStyle(el.parentElement!).opacity);
+    expect(opacity).toBe('1');
+
+    await expect(page.getByTitle('Remove from this playbook')).toBeVisible();
+  });
+});
+
 test('PlaybooksPage: dragging a play in List view reorders it and writes a two-phase PATCH', async ({ page }) => {
   const patchCalls = await mockPlaybookWithPlays(page, [
     { id: 'play-a', name: 'Play A', order_position: 10 },

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Mobile shell regressions. These are the bugs a normal smoke test cannot see:
+ * an element buried under a fixed overlay still passes `toBeVisible()`, and a
+ * `@media (pointer: coarse)` rule never activates under Playwright's default
+ * desktop emulation — so a fix keyed on it would appear tested while actually
+ * being inert.
+ */
+
+/**
+ * `hasTouch` is what makes `pointer: coarse` / `hover: none` evaluate true —
+ * and it is the ONLY thing that does. `setViewportSize` alone leaves the page
+ * on a fine pointer, and CDP `Emulation.setEmulatedMedia` silently ignores the
+ * `pointer`/`hover` features (verified: it reports false for both). Without
+ * this every coarse-pointer fix below would look tested while being inert, so
+ * each test asserts a real consequence rather than trusting the emulation.
+ */
+test.use({ viewport: { width: 375, height: 667 }, hasTouch: true });
+
+test('the touch media queries are actually active in this suite', async ({ page }) => {
+  await page.goto('/');
+  expect(
+    await page.evaluate(() => ({
+      coarse: matchMedia('(pointer: coarse)').matches,
+      noHover: matchMedia('(hover: none)').matches,
+    })),
+  ).toEqual({ coarse: true, noHover: true });
+});
+
+test('the feedback button is tappable, not buried under the cookie banner', async ({ page }) => {
+  // Regression: the banner is `fixed bottom-0 z-50` and stacks to ~130px on a
+  // phone; the FAB was `fixed bottom-4 right-4 z-40` — entirely inside the
+  // banner's footprint at a LOWER z-index, so every first-time mobile visitor
+  // had no way to reach it. toBeVisible() passes for an occluded element,
+  // which is exactly why this shipped: only hit-testing catches it.
+  await page.goto('/');
+
+  const banner = page.getByText('We use Google Analytics');
+  await expect(banner).toBeVisible();
+
+  const fab = page.getByRole('button', { name: 'Give Feedback' });
+  await expect(fab).toBeVisible();
+
+  const box = (await fab.boundingBox())!;
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // Whatever the browser would deliver the tap to must be the button itself.
+  const hitsFab = await page.evaluate(
+    ([x, y]) => {
+      const el = document.elementFromPoint(x as number, y as number);
+      return Boolean(el?.closest('button[aria-label="Give Feedback"]'));
+    },
+    [cx, cy],
+  );
+  expect(hitsFab, 'the cookie banner is covering the feedback button').toBe(true);
+
+  // And it actually opens.
+  await fab.click();
+  await expect(page.getByRole('dialog', { name: 'Give Feedback' })).toBeVisible();
+});
+
+test('dismissing the cookie banner drops the feedback button back down', async ({ page }) => {
+  // The offset is driven by a consent subscription rather than a one-shot
+  // localStorage read, so the button has to move without a reload.
+  await page.goto('/');
+
+  const fab = page.getByRole('button', { name: 'Give Feedback' });
+  const raised = (await fab.boundingBox())!;
+
+  await page.getByRole('button', { name: 'Decline' }).click();
+  await expect(page.getByText('We use Google Analytics')).toHaveCount(0);
+
+  await expect
+    .poll(async () => (await fab.boundingBox())!.y, { message: 'FAB should move back down' })
+    .toBeGreaterThan(raised.y);
+});
+
+test('touch devices get 16px form controls so iOS does not zoom the page', async ({ page }) => {
+  // iOS Safari zooms the whole page when a focused control is under 16px and
+  // never zooms back out. The Community tab's formation <select> is `text-sm`
+  // (14px) and is one of ~10 such controls; a single coarse-pointer rule in
+  // index.css covers all of them.
+
+  // The formation <select> only renders once some play carries a formation,
+  // so the fixture needs one.
+  await page.route('**/rest/v1/plays**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{
+        id: 'pub-1', name: 'Trips Right', type: 'offense', thumbnail: null,
+        is_public: true, upvotes: 3, user_id: 'someone-else',
+        metadata: { formation: 'Trips', gameType: '7v7' },
+      }]),
+    }));
+
+  await page.goto('/plays?tab=community');
+  const select = page.locator('select').first();
+  await expect(select).toBeVisible();
+
+  const fontSize = await select.evaluate((el) => getComputedStyle(el).fontSize);
+  expect(fontSize).toBe('16px');
+});
+
+test('the mobile nav toggle is labelled, reports state, and closes on navigation', async ({ page }) => {
+  await page.goto('/');
+
+  const toggle = page.getByRole('button', { name: 'Open menu' });
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+  const box = (await toggle.boundingBox())!;
+  expect(box.width, 'toggle width').toBeGreaterThanOrEqual(44);
+  expect(box.height, 'toggle height').toBeGreaterThanOrEqual(44);
+
+  await toggle.click();
+  await expect(page.getByRole('button', { name: 'Close menu' })).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+
+  // Navigating from inside the menu closes it...
+  await page.locator('#mobile-menu').getByRole('link', { name: 'Blog' }).click();
+  await expect(page.locator('#mobile-menu')).toHaveCount(0);
+
+  // ...and so does browser-back, which previously left it hanging open over
+  // the new page because nothing watched location.pathname.
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+  await page.goBack();
+  await expect(page.locator('#mobile-menu')).toHaveCount(0);
+});
+
+test('Escape closes the mobile nav menu', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#mobile-menu')).toHaveCount(0);
+});
+
+test('navigating to a new route scrolls back to the top', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => window.scrollTo(0, 600));
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await page.locator('#mobile-menu').getByRole('link', { name: 'Blog' }).click();
+
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+});


### PR DESCRIPTION
First of two PRs from a full mobile review of the site. This one is **only things that are broken**, not things that could be nicer — those are filed as backlog items in a follow-up.

Context: coaches use this on a phone on the sideline, and `Features.tsx:6-9` advertises **"Draw a play on your phone."** The designer canvas genuinely backs that up — pinch-zoom, multi-touch hygiene, forgiving hit tests, all tested. The shell around it did not.

## The headline: the feedback button was completely buried

`ConsentBanner.tsx:29` is `fixed bottom-0 z-50` and stacks to ~130px tall on a phone. `FeedbackButton.tsx:176` was `fixed bottom-4 right-4 z-40` — **entirely inside the banner's footprint, at a lower z-index**. Every first-time mobile visitor had no way to reach it, and the open panel's Submit button was covered too.

It now sits above the banner and drops back down when consent is answered, driven by a subscription added to `analytics.ts` rather than a one-shot localStorage read that couldn't invalidate.

## The rest

- **`viewport-fit=cover`** — without it `env(safe-area-inset-*)` resolves to `0`, so `PlayDesigner.tsx:648`'s bottom-toolbar padding was dead code and the banner's buttons sat in the home-indicator strip. Worth knowing: the `8px` fallback in those rules only applies where `env()` is *unsupported*; it does not save you when it returns 0.
- **iOS zoom on focus** — Safari zooms the page whenever a focused control is under 16px, and never zooms back. Ten controls qualified (`CommentThread.tsx:190`, `VsDefenseView.tsx:417`, five in `FeedbackManagement.tsx`, …). One `@media (pointer: coarse)` rule fixes all of them. `!important` is load-bearing there — Tailwind's `.text-sm` is a class and beats an element selector regardless of source order. Safe to clamp: nothing in the app asks for an input larger than 16px.
- **Hover-gated actions** — `PlaybooksPage.tsx:1518` hid **Edit Play, Vs and Remove** behind `group-hover:opacity-100` with no click fallback, and grid is the default layout. On touch those three actions did not exist.
- **Canvas wedged after an interrupted touch** — no `onPointerCancel`. iOS fires it instead of `pointerup` when the system takes a gesture, so a stale entry stayed in `activePointersRef` and the *next* single touch was misread as the second finger of a pinch. Drawing stayed dead until remount.
- **Nav menu** — no `aria-label`/`aria-expanded`, never became an X, 40px target, and stayed open on browser-back because nothing watched `location.pathname`.
- **Route exclusion** — `FeedbackButton.tsx:72` used `===` where `Footer` and `ConsentBanner` use `startsWith`, so a trailing slash floated the FAB over the designer's own toolbar.
- **`ScrollToTop`** — React Router keeps scroll position across navigations.
- **`.tap-target`** — new coarse-pointer-only utility, so **desktop density is completely untouched**. Applied here only to destructive/primary controls under ~28px (the 22px comment delete, the 16px modal `×`). The full sweep is backlog.

## Verification

- `npm run typecheck`, `npm run build` — clean
- `npx eslint` on all 14 touched files — **0 errors** (24 warnings, all pre-existing)
- `npm run smoke` — **132/132**, including 8 new

**The test setup is the important part here.** `hasTouch` is the *only* thing that makes `pointer: coarse` and `hover: none` evaluate true — `setViewportSize` doesn't, and CDP `Emulation.setEmulatedMedia` silently ignores those two features (I verified: it reports `false` for both). Without that, every coarse-pointer fix in this PR would have looked tested while being completely inert. `mobile.spec.ts` therefore asserts the emulation itself before anything else.

The buried-FAB test hit-tests with `document.elementFromPoint` rather than `toBeVisible()`, because **an occluded element still passes `toBeVisible()`** — which is precisely how this shipped.

Also screenshotted at **375×667 / 390×844 / 430×932** across `/`, `/plays`, `/playbooks`, `/designer`, `/account`.

## Found, not fixed here

That screenshot pass turned up a **pre-existing** bug I deliberately left for **B-39**: `/playbooks` scrolls horizontally at every phone width — 458px of content in a 375px viewport, from the non-wrapping button cluster at `PlaybooksPage.tsx:1198`. Confirmed pre-existing by re-running the check with this branch's changes stashed. It's one of eight non-wrapping flex rows; fixing one and leaving seven would be arbitrary, so they go together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)