### PR TITLE
designer: give the mobile toolbar its labels back

### DIFF
--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -190,12 +190,32 @@ export function DesignerToolbar({
     : `${btnBase} justify-center px-2.5 py-2 gap-1.5 text-xs font-medium`;
   const iconOnly = `${btnBase} justify-center p-2 min-w-[36px]`;
   const divider = vertical ? 'h-px w-full bg-chalk/15 my-1 shrink-0' : 'w-px h-5 bg-chalk/15 shrink-0 mx-0.5';
-  const label = vertical ? 'whitespace-nowrap' : 'hidden sm:inline whitespace-nowrap';
+  // `hidden sm:inline` used to be the horizontal branch, which hid every label
+  // unconditionally: the horizontal orientation is ONLY rendered below sm (see
+  // PlayDesigner's `sm:hidden` bottom bar), so the label could never appear on
+  // the one surface it applied to. That left a phone showing ~13 unlabeled
+  // 32px icons, several near-identical (two Eraser glyphs, Circle vs
+  // CircleOff). Labels cost horizontal scrolling, which the edge-fade on the
+  // row now advertises.
+  const label = 'whitespace-nowrap';
+
+  // The horizontal rows scroll with `scrollbar-hide`, so without this there is
+  // nothing at all telling a coach more tools exist past the right edge — the
+  // row just looks like it ends. A fade over the last few pixels reads as
+  // "continues"; pointer-events-none so it never eats a tap on the chip under
+  // it.
+  const scrollRow = 'relative flex items-center gap-1 overflow-x-auto scrollbar-hide';
+  const edgeFade = (
+    <div
+      aria-hidden
+      className="pointer-events-none sticky right-0 shrink-0 -ml-6 h-9 w-6 bg-gradient-to-l from-board-light to-transparent"
+    />
+  );
 
   return (
     <div className={`flex flex-col w-full ${vertical ? 'gap-2' : 'gap-1'}`}>
       {/* Tools: a column of labeled rows (sidebar) or one scrollable row (bar) */}
-      <div className={vertical ? 'flex flex-col items-stretch gap-0.5' : 'flex items-center gap-1 overflow-x-auto scrollbar-hide pb-0.5'}>
+      <div className={vertical ? 'flex flex-col items-stretch gap-0.5' : `${scrollRow} pb-0.5`}>
 
         {/* Select */}
         <button
@@ -356,23 +376,31 @@ export function DesignerToolbar({
 
           <div className="w-px h-5 bg-chalk/15 shrink-0 mx-0.5" />
 
-          {/* Clear routes */}
-          <button onClick={onClearRoutes} title="Clear Routes" className={`${iconOnly} text-yellow-400 hover:bg-yellow-400/10`}>
+          {/* Clear routes / Clear all — same Eraser glyph, adjacent, and one of
+              them is destructive, so these two in particular must stay
+              labelled wherever they're shown. */}
+          <button
+            onClick={onClearRoutes}
+            title="Clear Routes"
+            className={`${vertical ? iconOnly : `${btnBase} justify-center px-2.5 py-2 gap-1 text-xs`} text-yellow-400 hover:bg-yellow-400/10`}
+          >
             <Eraser className="h-4 w-4" />
+            {!vertical && <span className={label}>Routes</span>}
           </button>
 
           {/* Clear all */}
           <button onClick={onClear} title="Clear All" className={`${btnBase} justify-center px-2.5 py-2 gap-1 text-xs text-red-400 hover:bg-red-400/10`}>
             <Eraser className="h-4 w-4" />
-            <span className="hidden sm:inline whitespace-nowrap">All</span>
+            <span className={label}>All</span>
           </button>
         </div>
+        {!vertical && edgeFade}
       </div>
 
       {vertical && <div className={divider} />}
 
       {/* Play type + player icons: wrapped grid (sidebar) or scrollable row (bar) */}
-      <div className={vertical ? 'flex flex-col gap-2' : 'flex items-center gap-1 overflow-x-auto scrollbar-hide'}>
+      <div className={vertical ? 'flex flex-col gap-2' : scrollRow}>
         {/* Offense / Defense / Special Teams — decided once per play, locked once it has content */}
         <div
           className={`flex items-center rounded-md border border-chalk/15 overflow-hidden shrink-0 ${vertical ? 'w-full' : ''} ${playTypeLocked ? 'opacity-50' : ''}`}
@@ -400,6 +428,7 @@ export function DesignerToolbar({
           onRosterChange={onRosterChange}
           wrap={vertical}
         />
+        {!vertical && edgeFade}
       </div>
 
       {/* Active mode label */}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -780,6 +780,34 @@ test('formation menu opens fully on screen from the mobile bottom toolbar', asyn
   expect((await canvasState(page)).playerIcons).toHaveLength(11);
 });
 
+test('mobile toolbar: tools are labelled, and every one is reachable by scrolling', async ({ page }) => {
+  // The label class used to be `hidden sm:inline` in the horizontal
+  // orientation — which is the ONLY orientation rendered below sm — so every
+  // label was hidden on the one surface it applied to. A phone got ~13
+  // unlabeled 32px icons, including two identical Eraser glyphs where one
+  // clears routes and the other clears the whole play.
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openDesigner(page);
+
+  const bar = page.locator('div.sm\\:hidden').filter({ has: page.locator('button[title="Clear All"]') }).first();
+  // Zone / Remove Zone are defense-only, so they're not in this offense list.
+  for (const text of ['Text', 'Straight', 'Route', 'Remove Route', 'Routes', 'All']) {
+    await expect(bar.getByText(text, { exact: true }).first()).toBeVisible();
+  }
+
+  // The destructive pair must be distinguishable, not two bare erasers.
+  await expect(bar.locator('button[title="Clear Routes"]')).toContainText('Routes');
+  await expect(bar.locator('button[title="Clear All"]')).toContainText('All');
+
+  // Wider chips mean more scrolling, so the row must still deliver every tool.
+  // realClick uses true screen coordinates and refuses to auto-scroll, so a
+  // chip stranded off-screen fails here rather than silently "passing".
+  const formation = page.locator('button[title="Formation templates"]:visible');
+  await formation.scrollIntoViewIfNeeded();
+  await realClick(page, formation);
+  await expect(page.locator('div.fixed.z-40')).toBeVisible();
+});
+
 test('formation templates: game-format picker in the menu offers 5v5/6v6/7v7/11v11 sets', async ({ page }) => {
   await openDesigner(page);
 


### PR DESCRIPTION
Second of two PRs from the mobile review. `DesignerToolbar.tsx:193`:

```js
const label = vertical ? 'whitespace-nowrap' : 'hidden sm:inline whitespace-nowrap';
```

The horizontal orientation is the **only** one rendered below `sm` — it *is* the mobile bottom bar (`PlayDesigner.tsx:647`, `sm:hidden`). So `hidden sm:inline` hid every label unconditionally on the one surface it applied to.

A phone got ~13 unlabeled 32px icons in a scroll strip with no scroll affordance, several near-identical: `Circle` vs `CircleOff`, and **two identical `Eraser` glyphs** where one clears the routes and the other clears the whole play.

## Change

- Labels render in both orientations.
- Clear Routes / Clear All get theirs spelled out ("Routes" / "All") regardless of orientation — they're the adjacent identical-glyph pair, and one is destructive.
- Both scrollable rows get a sticky edge-fade so it's visible that the row continues. `pointer-events-none` so it never eats a tap, and painted in the bar's own `board-light` so chips fade into the chrome instead of being sliced off.

Wider chips mean more horizontal scrolling. That's the accepted trade — the fade is what makes it discoverable. Select/Snap/Undo/Redo stay icon-only; those glyphs are unambiguous and `DesignerToolbar.tsx:254-261` documents a previous, deliberate effort to keep this row short.

## Verification

- `npm run typecheck`, `npm run build` — clean
- `npx eslint` on both files — 0 errors (6 warnings, pre-existing)
- New test asserts the labels render **and** that the Formation trigger is still reachable now that the row is wider — via the existing `realClick` helper, which uses true screen coordinates and refuses Playwright's auto-scroll-into-view, so a chip stranded off-screen fails instead of silently passing.
- Screenshotted at 375 and 390, scrolled to both ends. Confirmed the fade actually paints (24×36, `sticky`, at the row edge) rather than assuming it did.

## ⚠ One pre-existing failure, not from this PR

`npm run smoke` is **124 passed / 1 failed**. The failure is **B-36: per-matchup coaching notes** (`vs-defense.spec.ts:170`), from the nightly PR #62 that merged yesterday:

```
Expected: ""
Received: "vs Cover 2, hit the flat"    // vs-defense.spec.ts:201
```

Switching to a second defense leaves the previous defense's draft in the textarea while reporting `hasNoteForCurrentDefense: false`.

Confirmed **not** caused by this branch: it fails **4 runs in 6 on clean `main` (0a235f6)** with these changes stashed. This branch touches only `DesignerToolbar`, which `/vs` doesn't use. Reporting separately — worth attention, since a stale draft that then saves on blur could write one defense's note onto another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)