### PR TITLE
Fix the flaky /vs notes test — and correct the bug report it produced

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -196,23 +196,26 @@ reachable from nowhere else).
 `data-testid` in the same change. Multi-PR; do the dead-code deletion first as
 its own low-risk PR.
 
-### B-50 · ⚠ BUG: /vs matchup notes leak between defenses (fix first)
-**Highest priority item in this list.** Found while verifying the mobile work
-on 2026-08-12; shipped in the nightly PR #62, whose description claimed
-123/123. On clean `main` (0a235f6) `vs-defense.spec.ts:170` fails **4 runs in
-6**:
-```
-Expected: ""
-Received: "vs Cover 2, hit the flat"     // vs-defense.spec.ts:201
-```
-Switching to a second defense leaves the *previous* defense's text in
-`#matchup-note-textarea` while `hasNoteForCurrentDefense` correctly reports
-`false`. It reads as a race between the blur-save and the defense swap in
-`VsDefenseView.tsx`. Not cosmetic: the panel saves on blur, so a stale draft
-left in the box can write one defense's note onto another — user data loss.
-Reproduce with
-`npx playwright test tests/smoke/vs-defense.spec.ts --grep "per-matchup" --repeat-each=6 --workers=1`.
-A passing single run means nothing here; always use `--repeat-each`.
+### B-50 · ~~/vs matchup notes leak between defenses~~ — RESOLVED, was a flaky test
+Filed 2026-08-12 as a data-loss bug. **That diagnosis was wrong**, and the
+correction is worth keeping: `vs-defense.spec.ts:170` failed ~4 runs in 6, but
+the product was behaving correctly the whole time.
+
+Switching defenses takes two renders — the first commits the new defense (so
+the label and `hasNoteForCurrentDefense` are already right), and the effect
+that re-syncs the draft schedules the second. A **single** read of the
+`__PBP_VS_TEST__` bridge can land between them and see the previous defense's
+draft. The DOM assertion on the next line auto-retried and always passed,
+which is the tell.
+
+Verified by capturing the actual writes: typing against one defense and
+immediately switching writes exactly one row, targeting the defense that was
+on screen when the text was typed. Zero writes to the other.
+Fixed by polling the bridge instead of snapshotting it.
+
+**The reusable lesson:** a one-shot read of a debug bridge is a race against
+React's render queue whenever the value it reports is set from an effect.
+Poll it, or assert against the DOM.
 
 ### B-38 · Touch-target sweep (`.tap-target`)
 PR #67 added a `.tap-target` utility gated on `@media (pointer: coarse)`, so

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -196,9 +196,16 @@ test('B-36: per-matchup coaching notes load, edit, save, and stay scoped per def
   // from the one just edited.
   await page.getByRole('button', { name: 'Next defense' }).click();
   await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
-  const onSecond = await vsState(page);
-  expect(onSecond.hasNoteForCurrentDefense).toBe(false);
-  expect(onSecond.noteDraft).toBe('');
+  // Poll rather than read once. Switching defenses takes two renders: the
+  // first commits the new defense (so the label and hasNoteForCurrentDefense
+  // are already correct), and the effect that re-syncs the draft schedules the
+  // second. A single snapshot of the bridge can land between them and see the
+  // previous defense's draft — a stale read of a debug surface, not a leak.
+  // (Verified: typing against one defense and immediately switching writes
+  // exactly one row, and it targets the defense that was on screen when the
+  // text was typed.)
+  await expect.poll(async () => (await vsState(page)).noteDraft).toBe('');
+  expect((await vsState(page)).hasNoteForCurrentDefense).toBe(false);
   await expect(page.locator('#matchup-note-textarea')).toHaveValue('');
 
   // Switching back shows the edit that was just saved.


### PR DESCRIPTION
**This corrects a bad call I made in #69.** I filed **B-50** as a data-loss bug — that switching defenses could write one defense's note onto another. It isn't. The product was behaving correctly the whole time.

## What was actually happening

Switching defenses takes two renders. The first commits the new defense, so the label and `hasNoteForCurrentDefense` are already correct; the effect that re-syncs the draft schedules the second. A **single** read of the `__PBP_VS_TEST__` bridge can land between them and report the previous defense's draft.

The tell was sitting in the test the whole time: the DOM assertion on the very next line (`toHaveValue('')`) auto-retries, and always passed.

## How I checked, rather than reasoning about it

Captured the actual writes: typed a note against defense 1, immediately switched to defense 2 without saving, and inspected every non-GET request to `matchup_notes`.

```
WRITES TARGETING def-2: []
defense_play_id: "def-1"        ← the defense that was on screen when it was typed
```

Exactly one row, correct target, zero writes against the other defense. Three runs, identical.

Also confirmed the arrow-key shortcut can't produce the leak either — `VsDefenseView.tsx:297` already ignores keydown from `TEXTAREA`.

## The fix

Poll the bridge instead of snapshotting it. **10/10** where it was **2-in-6** before. Full suite **133/133**.

B-50 stays in `BACKLOG.md` as a resolved entry rather than being deleted, because the trap generalizes: a one-shot read of a debug bridge races React's render queue whenever the value it reports is set from an effect. Poll it, or assert against the DOM.

So the nightly PR #62's "123/123" was honest — it was the test that was wrong, not the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)