### PR TITLE
[nightly] B-36 (2): export the /vs matchup as PNG or PDF

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -345,8 +345,16 @@ leaves a 279px column on a 375px phone.
   placeholder `.env` and the container's pre-installed Chromium binary via a
   temporary `launchOptions.executablePath` in `playwright.config.ts` (same
   recurring environment mismatch noted in B-33/B-34/B-36(1) — reverted after
-  the run, not part of this commit); see the PR description for the full-suite
-  result.
+  the run, not part of this commit): 110/136 passed on the single full
+  concurrent run; the other 26 (spread across `designer.spec.ts`,
+  `mobile.spec.ts`, and this change's own `vs-defense.spec.ts`) all passed
+  when re-run individually or in their own file, so the concurrent-run
+  failures were container resource contention over a 14.7-minute, 2-worker
+  run, not real regressions — 8 of the 26 were `vs-defense.spec.ts` tests
+  that hit `ENOENT: .env` because the placeholder file was deleted mid-run
+  by this same verification pass, not a code issue either. See the PR
+  description for the isolated re-run confirming all touched/adjacent files
+  pass.
 
 - **2026-08-10 · B-36 (1): Per-matchup coaching notes** — the first of B-36's
   deferred follow-ups: a coach can now attach a personal note to one

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -167,15 +167,11 @@ offense roster inherits.
 
 ### B-36 · "Vs. Defense" follow-ups
 The read-only `/vs?play=<id>` view ships offense+defense overlay, defense
-cycling, and (as of the item below) per-matchup notes. Still deferred, in
-rough priority order:
-1. **Export the matchup** — a PNG/PDF of the overlaid diagram, and a
-   "whole deck vs this play" sheet. `renderOverlayScene()` already renders to
-   any offscreen context, so this is mostly an ExportModal variant. Likely a
-   Pro gate (viewing stays free).
-2. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
+cycling, per-matchup notes, and (as of the item below) export. Still
+deferred, in rough priority order:
+1. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
    read. Blocked on there being no "correct read" data on a play at all.
-3. **Community defenses in the deck** — currently the deck is the coach's own
+2. **Community defenses in the deck** — currently the deck is the coach's own
    defensive plays only, so a coach with none gets an empty state pointing at
    the designer. Offering public defenses would seed it.
 
@@ -317,6 +313,40 @@ renders text, so images/markdown don't render at all. `p-8` inside `px-4`
 leaves a 279px column on a 375px phone.
 
 ## Done
+
+- **2026-08-12 · B-36 (2): Export the matchup** — a coach can now export
+  what's on `/vs?play=<id>` instead of only viewing it: a new "Export"
+  button in the header opens `VsExportModal.tsx`, offering a PNG download or
+  a print/Save-as-PDF of the current matchup (offense + whichever defense is
+  on screen, honoring the same show/hide toggle as the live view — hiding
+  the defense before exporting produces an offense-only diagram), plus,
+  whenever the coach has more than zero saved defenses, a "print full deck"
+  option that puts the offense against every defense in the deck on its own
+  page (one PDF for the whole binder of looks). Both render through
+  `renderOverlayScene()` at the same fixed `EXPORT_WIDTH`/`EXPORT_HEIGHT`
+  resolution as the designer's own `exportImage()`, so quality matches every
+  other export surface in the app. Gated behind Pro (viewing/cycling stays
+  free, per the item's own note) — status is queried directly off
+  `subscriptions` via the already-resolved `userId` (not `useEntitlement()`,
+  per the B-4 gotrue-deadlock note: this view already runs its own
+  `auth.getUser()` call). Play/defense names are HTML-escaped before being
+  interpolated into the generated print document (existing `escapeHtml()`
+  from `userPreferences.ts`) — the print window is opened via
+  `document.write()` on untrusted user-entered names, so this isn't optional.
+  **Verification:** `npx tsc --noEmit` clean; `npx eslint` on touched files
+  shows only the two pre-existing `no-explicit-any` warnings on the unrelated
+  test-bridge lines (no new errors); `npm run build` succeeds. 3 new smoke
+  tests in `tests/smoke/vs-defense.spec.ts` cover the Pro gate (free account
+  sees the upgrade prompt, no export modal), a Pro account downloading the
+  current matchup (asserts the actual browser download event and its
+  filename) and seeing the whole-deck option, and that the whole-deck option
+  is absent when the coach has no saved defenses — all 7 tests in that file
+  pass. Full Playwright smoke suite (136 tests) run against a throwaway
+  placeholder `.env` and the container's pre-installed Chromium binary via a
+  temporary `launchOptions.executablePath` in `playwright.config.ts` (same
+  recurring environment mismatch noted in B-33/B-34/B-36(1) — reverted after
+  the run, not part of this commit); see the PR description for the full-suite
+  result.
 
 - **2026-08-10 · B-36 (1): Per-matchup coaching notes** — the first of B-36's
   deferred follow-ups: a coach can now attach a personal note to one

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Eye, EyeOff, Home, Shield, StickyNote, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Eye, EyeOff, Home, Shield, StickyNote, X } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { usePageMeta } from '../../lib/seo';
 import { renderOverlayScene, EXPORT_WIDTH, EXPORT_HEIGHT, type SceneLayer } from '../../lib/renderPlayScene';
+import { rowIsPro } from '../../lib/entitlements';
 import { Logo } from '../Logo';
+import { UpgradePrompt } from '../UpgradePrompt';
+import { VsExportModal } from './VsExportModal';
 
 // ---------------------------------------------
 // Read-only "vs. defense" view: one offensive play with a defensive play drawn
@@ -81,6 +84,14 @@ export function VsDefenseView() {
   const [notesOpen, setNotesOpen] = useState(false);
   const [noteDraft, setNoteDraft] = useState('');
   const [noteSaveState, setNoteSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  // Export (B-36 follow-up #1) — Pro-gated, queried directly off `userId`
+  // rather than via useEntitlement(), whose own auth.getUser() call can
+  // deadlock gotrue-js's session lock alongside this view's own (see the B-4
+  // note in entitlements.ts).
+  const [isPro, setIsPro] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [showUpgrade, setShowUpgrade] = useState(false);
 
   const currentDefense = defenses[index] ?? null;
 
@@ -186,6 +197,19 @@ export function VsDefenseView() {
     // and re-running the fetch on every arrow press would refetch the deck.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playId, navigate]);
+
+  // ── Resolve Pro status for the export gate ───────────────────
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    supabase
+      .from('subscriptions')
+      .select('plan, current_period_end')
+      .eq('user_id', userId)
+      .maybeSingle()
+      .then(({ data }) => { if (!cancelled) setIsPro(rowIsPro(data)); });
+    return () => { cancelled = true; };
+  }, [userId]);
 
   // ── Keep ?d= pointed at the visible defense ─────────────────
   useEffect(() => {
@@ -377,6 +401,14 @@ export function VsDefenseView() {
           <span className="hidden sm:inline">{showDefense ? 'Hide defense' : 'Show defense'}</span>
         </button>
         <button
+          onClick={() => { if (isPro) setExportOpen(true); else setShowUpgrade(true); }}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors"
+          title="Export this matchup"
+        >
+          <Download className="h-4 w-4" />
+          <span className="hidden sm:inline">Export</span>
+        </button>
+        <button
           onClick={() => setNotesOpen((v) => !v)}
           disabled={!currentDefense}
           className="relative flex items-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
@@ -517,6 +549,22 @@ export function VsDefenseView() {
           </div>
         )}
       </footer>
+
+      <VsExportModal
+        isOpen={exportOpen}
+        onClose={() => setExportOpen(false)}
+        offenseName={offensePlay.name}
+        offenseScene={offenseScene}
+        currentDefense={currentDefense}
+        currentDefenseVisible={showDefense}
+        deck={defenses}
+      />
+      <UpgradePrompt
+        isOpen={showUpgrade}
+        onClose={() => setShowUpgrade(false)}
+        feature="Matchup export"
+        description="Exporting a matchup as a PNG or PDF is part of Playbuilder Pro ($39/yr). Viewing and cycling defenses stays free."
+      />
     </div>
   );
 }

--- a/src/components/vs/VsExportModal.tsx
+++ b/src/components/vs/VsExportModal.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { X, Download, Printer, Layers } from 'lucide-react';
+import { renderOverlayScene, EXPORT_WIDTH, EXPORT_HEIGHT, type SceneLayer } from '../../lib/renderPlayScene';
+import { paperPageSize, escapeHtml } from '../../lib/userPreferences';
+
+// ---------------------------------------------
+// Export options for the read-only "vs. defense" view (B-36 follow-up #1):
+// a PNG or printable PDF of whatever matchup is currently on screen, plus a
+// multi-page PDF of the offense against every defense in the coach's deck.
+// Reuses renderOverlayScene() (already offscreen-context-agnostic) at the
+// same EXPORT_WIDTH/EXPORT_HEIGHT fixed resolution as the designer's own
+// exportImage(), so output matches the print quality of every other export
+// surface in the app.
+// ---------------------------------------------
+
+type ExportDeckEntry = { id: string; name: string; scene: SceneLayer };
+
+interface VsExportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  offenseName: string;
+  offenseScene: SceneLayer;
+  /** The defense currently on screen, honoring the same show/hide toggle as
+   *  the live view — null when hidden or the deck is empty. */
+  currentDefense: ExportDeckEntry | null;
+  currentDefenseVisible: boolean;
+  /** Full deck, for the "whole deck" sheet — independent of the show/hide
+   *  toggle, since the point of that sheet is to cover every look. */
+  deck: ExportDeckEntry[];
+}
+
+function sceneToDataURL(offense: SceneLayer, defense: SceneLayer | null): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = EXPORT_WIDTH;
+  canvas.height = EXPORT_HEIGHT;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+  renderOverlayScene(ctx, EXPORT_WIDTH, EXPORT_HEIGHT, offense, defense);
+  return canvas.toDataURL('image/png');
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'play';
+}
+
+function downloadDataURL(dataURL: string, filename: string) {
+  const a = document.createElement('a');
+  a.href = dataURL;
+  a.download = filename;
+  a.click();
+}
+
+function matchupPageHTML(dataURL: string, offenseName: string, defenseName: string | null): string {
+  return `
+    <div class="matchup-page">
+      <div class="matchup-header">
+        <div class="matchup-title">${escapeHtml(offenseName)}</div>
+        ${defenseName ? `<div class="matchup-subtitle">vs. ${escapeHtml(defenseName)}</div>` : ''}
+      </div>
+      <div class="matchup-image"><img src="${dataURL}" alt="" /></div>
+    </div>`;
+}
+
+function buildPrintHTML(pagesHTML: string, docTitle: string): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(docTitle)}</title>
+  <style>
+    @page { size: ${paperPageSize('letter')}; margin: 0.5in; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: Arial, sans-serif; color: #000; background: white; }
+    .matchup-page {
+      min-height: 9.5in;
+      display: flex;
+      flex-direction: column;
+      page-break-inside: avoid;
+      page-break-after: always;
+    }
+    .matchup-page:last-child { page-break-after: auto; }
+    .matchup-header {
+      text-align: center;
+      margin-bottom: 20px;
+      padding-bottom: 12px;
+      border-bottom: 2px solid #2563eb;
+    }
+    .matchup-title {
+      font-size: 22pt;
+      font-weight: bold;
+      color: #1e40af;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    .matchup-subtitle { font-size: 13pt; color: #64748b; margin-top: 4px; }
+    .matchup-image { flex: 1; display: flex; align-items: center; justify-content: center; }
+    .matchup-image img {
+      max-width: 100%;
+      max-height: 100%;
+      border: 2px solid #e5e7eb;
+      border-radius: 8px;
+    }
+    @media print {
+      body { -webkit-print-color-adjust: exact !important; }
+      .matchup-page { page-break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>${pagesHTML}</body>
+</html>`;
+}
+
+function openPrintWindow(html: string) {
+  const printWindow = window.open('', '_blank', 'width=800,height=600');
+  if (!printWindow) {
+    alert('Popup blocked. Please allow popups for this site and try again.');
+    return;
+  }
+  printWindow.document.open();
+  printWindow.document.write(html);
+  printWindow.document.close();
+  printWindow.onload = () => {
+    setTimeout(() => {
+      printWindow.focus();
+      printWindow.print();
+    }, 500);
+  };
+}
+
+export function VsExportModal({
+  isOpen,
+  onClose,
+  offenseName,
+  offenseScene,
+  currentDefense,
+  currentDefenseVisible,
+  deck,
+}: VsExportModalProps) {
+  if (!isOpen) return null;
+
+  const activeDefenseScene = currentDefenseVisible ? currentDefense?.scene ?? null : null;
+  const activeDefenseName = currentDefenseVisible ? currentDefense?.name ?? null : null;
+
+  const handleDownloadPNG = () => {
+    const dataURL = sceneToDataURL(offenseScene, activeDefenseScene);
+    if (!dataURL) return;
+    const suffix = activeDefenseName ? `-vs-${slugify(activeDefenseName)}` : '';
+    downloadDataURL(dataURL, `${slugify(offenseName)}${suffix}.png`);
+  };
+
+  const handlePrintMatchup = () => {
+    const dataURL = sceneToDataURL(offenseScene, activeDefenseScene);
+    if (!dataURL) return;
+    openPrintWindow(buildPrintHTML(matchupPageHTML(dataURL, offenseName, activeDefenseName), offenseName));
+  };
+
+  const handlePrintDeck = () => {
+    const pagesHTML = deck
+      .map((d) => matchupPageHTML(sceneToDataURL(offenseScene, d.scene), offenseName, d.name))
+      .join('');
+    openPrintWindow(buildPrintHTML(pagesHTML, `${offenseName} — Full Deck`));
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 text-center">
+        <div className="fixed inset-0 bg-black bg-opacity-75" onClick={onClose} />
+        <div className="inline-block w-full max-w-sm overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
+            <h3 className="text-xl font-bold text-chalk">Export Matchup</h3>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="tap-target flex items-center justify-center text-chalk/70 hover:text-chalk transition-colors"
+            >
+              <X className="w-6 h-6" />
+            </button>
+          </div>
+          <div className="p-6 space-y-5">
+            <div>
+              <p className="text-xs font-semibold text-chalk/50 uppercase tracking-wide mb-2">This matchup</p>
+              <div className="space-y-2">
+                <button
+                  onClick={handleDownloadPNG}
+                  className="w-full flex items-center gap-3 px-4 py-3 bg-board hover:bg-board-light border border-chalk/10 rounded-lg text-chalk transition-colors"
+                >
+                  <Download className="h-5 w-5 text-primary shrink-0" />
+                  <span className="text-sm font-medium">Download PNG</span>
+                </button>
+                <button
+                  onClick={handlePrintMatchup}
+                  className="w-full flex items-center gap-3 px-4 py-3 bg-board hover:bg-board-light border border-chalk/10 rounded-lg text-chalk transition-colors"
+                >
+                  <Printer className="h-5 w-5 text-primary shrink-0" />
+                  <span className="text-sm font-medium">Print / Save as PDF</span>
+                </button>
+              </div>
+            </div>
+            {deck.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-chalk/50 uppercase tracking-wide mb-2">
+                  Whole deck ({deck.length} defense{deck.length === 1 ? '' : 's'})
+                </p>
+                <button
+                  onClick={handlePrintDeck}
+                  className="w-full flex items-center gap-3 px-4 py-3 bg-board hover:bg-board-light border border-chalk/10 rounded-lg text-chalk transition-colors"
+                >
+                  <Layers className="h-5 w-5 text-primary shrink-0" />
+                  <span className="text-sm font-medium">Print full deck vs. this play</span>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -208,3 +208,56 @@ test('B-36: per-matchup coaching notes load, edit, save, and stay scoped per def
 
   expect(errors, 'no uncaught page errors').toEqual([]);
 });
+
+test('B-36 (1): export is Pro-gated — free accounts see the upgrade prompt', async ({ page }) => {
+  await mockBackend(page, DEFENSES);
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(null) }));
+  await openVs(page);
+
+  await page.getByRole('button', { name: /^export$/i }).click();
+  await expect(page.getByText('Matchup export is a Pro feature')).toBeVisible();
+  await expect(page.getByText('Export Matchup')).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Maybe later' }).click();
+  await expect(page.getByText('Matchup export is a Pro feature')).toHaveCount(0);
+});
+
+test('B-36 (1): Pro accounts can download the current matchup and print the whole deck', async ({ page }) => {
+  await mockBackend(page, DEFENSES);
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ plan: 'pro', current_period_end: null }),
+    }));
+  await openVs(page);
+
+  await page.getByRole('button', { name: /^export$/i }).click();
+  await expect(page.getByText('Export Matchup')).toBeVisible();
+  await expect(page.getByText('Whole deck (2 defenses)')).toBeVisible();
+
+  // Download PNG renders offense + the defense currently on screen (Cover 2
+  // Zone, first in the sorted deck) to a fixed-resolution offscreen canvas
+  // and triggers a native download rather than a popup.
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download PNG' }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe('smash-concept-vs-cover-2-zone.png');
+});
+
+test('B-36 (1): export modal has no "whole deck" section when the deck is empty', async ({ page }) => {
+  await mockBackend(page, []);
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ plan: 'pro', current_period_end: null }),
+    }));
+  await openVs(page);
+
+  await page.getByRole('button', { name: /^export$/i }).click();
+  await expect(page.getByText('Export Matchup')).toBeVisible();
+  await expect(page.getByText('This matchup')).toBeVisible();
+  await expect(page.getByText(/Whole deck/)).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed

Adds a Pro-gated **Export** button to the read-only `/vs?play=<id>` view (B-36 follow-up #1 from `BACKLOG.md`'s "Up next" list). Clicking it opens `VsExportModal.tsx`, offering:

- **Download PNG** — the current matchup (offense + whichever defense is on screen, honoring the same show/hide toggle as the live view — hiding the defense before exporting produces an offense-only diagram).
- **Print / Save as PDF** — same matchup, as a printable document.
- **Print full deck vs. this play** — shown whenever the coach has at least one saved defense; puts the offense against every defense in the deck on its own page, one PDF for the whole binder of looks.

All three render through the existing `renderOverlayScene()` at the same fixed `EXPORT_WIDTH`/`EXPORT_HEIGHT` resolution the designer's own `exportImage()` uses, so output quality matches every other export surface in the app.

**Pro gate:** exporting is Pro-only (viewing/cycling stays free, per the item's own note in the backlog). Status is queried directly off the `subscriptions` table via the `userId` this view already resolves — not `useEntitlement()`, since that hook's own `auth.getUser()` call can deadlock gotrue-js's session lock alongside this view's own auth call (the B-4 note in `entitlements.ts`).

**Security note:** play/defense names are HTML-escaped (existing `escapeHtml()` from `userPreferences.ts`) before being interpolated into the generated print document — that document is written via `document.write()` on a popup window using untrusted, user-entered play names, so escaping isn't optional.

`BACKLOG.md`: moved this item out of B-36's "Up next" follow-up list into Done, renumbered the two remaining follow-ups (quiz/reveal mode, community defenses in the deck).

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on touched files — 0 errors; 2 pre-existing `no-explicit-any` warnings on the unrelated dev-test-bridge lines (same as the B-36(1) precedent), no new warnings.
- `npm run build` — succeeds.
- **New smoke tests** (`tests/smoke/vs-defense.spec.ts`, 3 added, 7 total in the file): free account clicking Export sees the upgrade prompt (no export modal); Pro account sees the export modal with the whole-deck option and can actually trigger a PNG download (asserted via the real browser download event + filename); the whole-deck option is absent when the coach has zero saved defenses. All 7 pass, both standalone and re-run after the full suite.
- **Full Playwright smoke suite (136 tests):** run against a throwaway placeholder `.env` and the container's pre-installed Chromium binary via a temporary `launchOptions.executablePath` override in `playwright.config.ts` (same recurring browser-revision mismatch noted in prior nightly PRs — reverted after the run, not part of this commit). The single concurrent run reported **110/136 passed, 26 failed** (`designer.spec.ts`'s Community Forum + routes tests, all of `mobile.spec.ts`, and this change's own `vs-defense.spec.ts`). I re-ran every failing file/test in isolation afterward and **all of them passed**:
  - `mobile.spec.ts` — 7/7 passed standalone.
  - `designer.spec.ts -g "Community Forum|routes:"` — 24/24 passed standalone.
  - `vs-defense.spec.ts` — 7/7 passed standalone (these 8 failures — one test counted twice across sub-cases — were actually `ENOENT: .env` errors, because I deleted the placeholder `.env` mid-run while the full-suite run was still using it; not a code issue).

  Conclusion: the concurrent-run failures were container resource contention over a 14.7-minute, 2-worker run against 136 tests, not real regressions from this change. I did not touch any file involved in the Community Forum, route-dragging, or mobile-nav tests.

## Not done (out of scope for this item)

The other two deferred B-36 follow-ups — quiz/reveal mode and community defenses in the deck — remain in `BACKLOG.md`'s "Up next", unchanged by this PR.

---

Note: while picking up tonight's item, I found PR #70 (open, not a `nightly/*` branch) had already resolved **B-50** — it corrected a flaky-test misdiagnosis rather than a real data-loss bug — so I skipped past it and B-18/B-21/B-20/B-8/B-12 (all human-only), B-28 (needs human design approval), B-29b (on hold), B-31 (awaiting human review), B-32 (depends on B-31 and a scheduled-agent prompt not in this repo), and the `[from feedback]` B-38 roster-colors item (explicitly flagged for a human to pick the replacement hue) to land on this one.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqyVntMeB3fDsVq7QKeQ1Y)_