### PR TITLE
test: let the smoke suite's browser binary be set by env, not by hand-edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,22 @@ playbooks, and print/share them. Live at **playbuilderpro.com**.
 - `npm run smoke` — Playwright smoke suite (`tests/smoke/`), drives the real app
   headlessly on its own port (4517). Tests assert on real canvas state via the
   dev-only `window.__PBP_TEST__` bridge in `PlayDesigner.tsx` — no pixel sampling.
+  **If your environment ships its own Chromium** instead of the pinned one
+  Playwright downloads (the cloud agent container does), set
+  `PBP_CHROMIUM_PATH=/path/to/chromium` — don't hand-edit `playwright.config.ts`.
+  Four nightly PRs in a row did that and each reported a pass count from a
+  partly-broken run (one claimed 123/123 over a genuinely flaky test; another
+  reported 110/136 and left 26 failures unexplained — all environmental, since
+  the same commit is 136/136 locally). A verification number nobody can trust is
+  worse than no number.
+  ⚠ **Two ways a green/red result can lie**, both hit in Aug 2026: reading the
+  `__PBP_TEST__`/`__PBP_VS_TEST__` bridge **once** races React's render queue
+  when the value is set from an effect (poll it — see the auto-memory
+  `test-bridge-race.md`); and `toBeVisible()` passes for an element completely
+  covered by a fixed overlay or clipped by an ancestor's `overflow: hidden`
+  (hit-test with `document.elementFromPoint`). Also: `pointer: coarse` /
+  `hover: none` only activate under `test.use({ hasTouch: true })` — a viewport
+  size doesn't do it, and CDP `Emulation.setEmulatedMedia` ignores both.
 - `npm run verify` — typecheck + lint + build + smoke. **⚠ Currently always
   fails at the lint step** on those pre-existing errors, before it ever reaches
   build/smoke. Until that backlog is cleaned up, verify by running

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,21 @@ import { defineConfig } from '@playwright/test';
 // Smoke suite for the flows agents/CI can't eyeball. Runs against the Vite dev
 // server on a dedicated port so it never collides with a manually started
 // `npm run dev` (5173). Invoked via `npm run smoke` / `npm run verify`.
+
+// Environments that ship their own Chromium instead of the pinned one
+// Playwright downloads (the cloud agent container, notably) can point at it
+// here rather than hand-editing this file. That hand-edit is what four nightly
+// PRs in a row did — B-33, B-34, B-36(1), B-36(2) — each reverting it before
+// committing, which left every one of them reporting a pass count that came
+// from a partly-broken run. A verification number nobody can trust is worse
+// than no number, so this makes the override declarative:
+//
+//   PBP_CHROMIUM_PATH=/usr/bin/chromium npm run smoke
+//
+// Unset (every local and CI run today) leaves Playwright's own resolution
+// completely untouched.
+const chromiumPath = process.env.PBP_CHROMIUM_PATH?.trim() || undefined;
+
 export default defineConfig({
   testDir: 'tests/smoke',
   timeout: 30_000,
@@ -13,6 +28,7 @@ export default defineConfig({
     baseURL: 'http://localhost:4517',
     viewport: { width: 1280, height: 900 },
     trace: 'retain-on-failure',
+    ...(chromiumPath ? { launchOptions: { executablePath: chromiumPath } } : {}),
   },
   webServer: {
     command: 'npm run dev -- --port 4517 --strictPort',


### PR DESCRIPTION
Infrastructure for the automated lane, not product work.

## The problem

Four nightly PRs in a row — **B-33, B-34, B-36(1), B-36(2)** — hand-edited `launchOptions.executablePath` in `playwright.config.ts` to reach the container's own Chromium, then reverted it before committing. Each one therefore reported a pass count that came out of a partly-broken run:

- **#62** claimed **123/123** — over a test that was genuinely flaky (2-in-6), fixed in #70
- **#71** reported **110/136** and vouched for 7 tests, leaving 26 unexplained

Both were *honest*. Neither number meant what it looked like. I've now chased each one separately this week, and when a green number can't be trusted and a red one can't either, the suite has stopped doing its job for the nightly routine.

**Those 26 failures were environmental.** The same commit is **136/136** locally, three consecutive runs, plus clean typecheck and build.

## The fix

```sh
PBP_CHROMIUM_PATH=/usr/bin/chromium npm run smoke
```

Unset — every local and CI run today — leaves Playwright's own browser resolution completely untouched.

**Verified both paths**, since an untested escape hatch would be the same class of mistake this is meant to fix: unset → 136/136, explicit valid path → 136/136. A *wrong* path fails immediately and loudly rather than silently falling back to the default browser. (I confirmed that accidentally, by getting the path wrong myself — `chrome-mac` vs `chrome-mac-arm64`.)

The cloud agent environment still needs the variable set; that's the one step this can't do from inside the repo.

## Also

`CLAUDE.md` now records the three ways a smoke result can lie, all hit this month:

- a **one-shot read** of the `__PBP_TEST__` / `__PBP_VS_TEST__` bridge races React's render queue when the value is set from an effect — poll it (this is what produced the false "data-loss bug" in #69, retracted in #70)
- **`toBeVisible()` passes** for an element completely covered by a fixed overlay or clipped by an ancestor's `overflow: hidden` — hit-test with `document.elementFromPoint` (this is how the buried feedback button shipped)
- **`pointer: coarse` / `hover: none`** only activate under `test.use({ hasTouch: true })` — a viewport size doesn't do it, and CDP `Emulation.setEmulatedMedia` ignores both features entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)