### PR TITLE
B-39: stop pages scrolling sideways on a phone

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -79,7 +79,7 @@ export function Hero() {
                 </p>
                 <div className="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
                   {user ? (
-                    <div className="flex gap-4">
+                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                       <Link to="/plays" className="flex items-center justify-center px-8 py-3 border border-transparent text-base font-bold rounded-md text-white bg-primary hover:bg-primary-dark md:py-4 md:text-lg md:px-10">
                         View Plays
                       </Link>
@@ -88,7 +88,7 @@ export function Hero() {
                       </Link>
                     </div>
                   ) : (
-                    <div className="flex gap-4">
+                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                       <Link
                         to="/designer"
                         className="flex items-center justify-center px-8 py-3 border border-transparent text-base font-bold rounded-md text-white bg-primary hover:bg-primary-dark md:py-4 md:text-lg md:px-10"

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -153,7 +153,10 @@ export function AdminDashboard() {
               <h1 className="text-2xl font-bold text-chalk">Admin Dashboard</h1>
             </div>
 
-            <div className="mt-4 flex gap-4">
+            {/* Wrap rather than scroll: the enclosing panel is overflow-hidden,
+                so an unwrapped 4-tab row put "Moderation" out of reach on a
+                phone entirely. */}
+            <div className="mt-4 flex flex-wrap gap-2 sm:gap-4">
               <button
                 onClick={() => setActiveTab('users')}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${

--- a/src/components/auth/AccountSettings.tsx
+++ b/src/components/auth/AccountSettings.tsx
@@ -339,8 +339,11 @@ export default function AccountSettings() {
     <div className="min-h-screen bg-board py-12">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-board-light rounded-xl shadow-lg border border-chalk/10 overflow-hidden">
-          <div className="px-6 py-4 border-b border-chalk/10 flex justify-between items-center">
-            <div className="flex items-center gap-3">
+          {/* Save Changes lives only in this header, so it must never be
+              crushed — a founding member with unsaved edits put ~450px of
+              content in a 295px row. */}
+          <div className="px-6 py-4 border-b border-chalk/10 flex flex-wrap justify-between items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <h2 className="text-2xl font-bold text-chalk">Account Settings</h2>
               {isFoundingMember && (
                 <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/40 text-primary text-xs font-semibold">

--- a/src/components/community/TimeRangeSelector.tsx
+++ b/src/components/community/TimeRangeSelector.tsx
@@ -17,8 +17,8 @@ const timeRanges: { value: TimeRange; label: string }[] = [
 
 export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
   return (
-    <div className="flex items-center gap-2 bg-board rounded-lg border border-chalk/20 p-1">
-      <Clock className="h-4 w-4 text-chalk/50 ml-2" />
+    <div className="flex flex-wrap items-center gap-1.5 bg-board rounded-lg border border-chalk/20 p-1">
+      <Clock className="h-4 w-4 text-chalk/50 ml-2 shrink-0" />
       {timeRanges.map((range) => (
         <button
           key={range.value}

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -1195,7 +1195,10 @@ export function PlaybooksPage() {
                   : 'Organize and manage your football plays'}
               </p>
             </div>
-            <div className="flex items-center gap-4">
+            {/* Measured 2026-08-12: unwrapped, this cluster was 442px inside a
+                375px viewport and pushed the whole document to 458px, so every
+                page on /playbooks scrolled sideways on a phone. */}
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4">
               <div className="flex items-center gap-1 border border-chalk/15 rounded-lg p-1">
                 <button
                   onClick={() => setSearchParams({}, { replace: true })}

--- a/src/components/plays/PlayLibrary.tsx
+++ b/src/components/plays/PlayLibrary.tsx
@@ -308,7 +308,7 @@ export function PlayLibrary() {
                   {play.author?.username ? `by ${play.author.username}` : ''}
                   {gameFormatLabel(play) ? ` · ${gameFormatLabel(play)}` : ''}
                 </p>
-                <div className="mt-auto flex items-center justify-between gap-2">
+                <div className="mt-auto flex flex-wrap items-center justify-between gap-2">
                   <PlayVoteButton
                     playId={play.id}
                     upvotes={play.upvotes ?? 0}

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -345,8 +345,10 @@ export function PlaysPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-board-light rounded-xl border border-chalk/10 overflow-hidden">
           <div className="px-6 py-4 border-b border-chalk/10">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
+            {/* flex-wrap throughout: the panel is overflow-hidden, so a row
+                that outgrows it is clipped rather than scrollable. */}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-3 sm:gap-4">
                 <h1 className="text-2xl font-bold text-chalk flex items-center gap-2">
                   <Book className="h-6 w-6 text-primary" />
                   Plays
@@ -382,9 +384,9 @@ export function PlaysPage() {
             </div>
 
             {tab === 'mine' && (
-            <div className="mt-4 flex items-center gap-2">
-              <Filter className="h-4 w-4 text-chalk/50" />
-              <div className="flex gap-2">
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <Filter className="h-4 w-4 text-chalk/50 shrink-0" />
+              <div className="flex flex-wrap gap-2">
                 {(['all', 'offense', 'defense', 'special_teams'] as const).map((type) => (
                   <button
                     key={type}

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+
+// supabase-js reads its session from localStorage under a key derived from
+// VITE_SUPABASE_URL — same seeding trick as designer.spec.ts.
+const SUPABASE_URL = readFileSync('.env', 'utf-8').match(/^VITE_SUPABASE_URL=(.+)$/m)?.[1].trim() ?? '';
+const AUTH_STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split('.')[0]}-auth-token`;
 
 /**
  * Mobile shell regressions. These are the bugs a normal smoke test cannot see:
@@ -137,6 +143,55 @@ test('Escape closes the mobile nav menu', async ({ page }) => {
   await expect(page.locator('#mobile-menu')).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(page.locator('#mobile-menu')).toHaveCount(0);
+});
+
+test('no page scrolls sideways at phone width', async ({ page }) => {
+  // /playbooks used to put 458px of content in a 375px viewport — a whole
+  // document that scrolled horizontally — from one non-wrapping button
+  // cluster. Nothing caught it because every individual element was "visible".
+  // Asserting document width is the cheap guard that would have.
+  const userJson = {
+    id: '22222222-2222-2222-2222-222222222222',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 't', refresh_token: 'r',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  await page.route('**/auth/v1/user**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/admin_users**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/subscriptions**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'founding' }) }));
+  await page.route('**/rest/v1/user_preferences**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/playbooks**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([
+      { id: 'pb-1', name: 'Game Plan', description: '', created_at: '2025-09-01T00:00:00Z', user_id: userJson.id, playbook_plays: [{ count: 1 }] },
+    ]) }));
+  await page.route('**/rest/v1/plays**', (r) => {
+    if (r.request().method() === 'HEAD') {
+      return r.fulfill({ status: 200, headers: { 'content-range': '*/1', 'access-control-expose-headers': 'content-range' }, body: '' });
+    }
+    return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([
+      { id: 'play-a', name: 'Trips Right Zip Motion Y Corner', type: 'offense', thumbnail: null, is_public: true, upvotes: 5, user_id: userJson.id, metadata: { formation: 'Trips', gameType: '7v7' } },
+    ]) });
+  });
+
+  for (const route of ['/', '/plays', '/plays?tab=community', '/playbooks', '/account', '/community', '/blog']) {
+    await page.goto(route);
+    await page.waitForTimeout(350);
+    const { scrollW, clientW } = await page.evaluate(() => ({
+      scrollW: document.documentElement.scrollWidth,
+      clientW: document.documentElement.clientWidth,
+    }));
+    expect(scrollW, `${route} scrolls horizontally at ${clientW}px`).toBeLessThanOrEqual(clientW + 1);
+  }
 });
 
 test('navigating to a new route scrolls back to the top', async ({ page }) => {


### PR DESCRIPTION
`/playbooks` put **458px of content in a 375px viewport** — the whole document scrolled horizontally on every phone — from a single non-wrapping cluster holding the tab pill, New Play and New Playbook (442px of that 458).

Measured at 375/390/430 while verifying the mobile PRs, and confirmed pre-existing by re-measuring with that branch's changes stashed.

## Why all eight together

Seven other rows share the shape, and **two sit inside `overflow-hidden` panels**, so their overrun was *clipped* rather than merely scrollable. That's how `/admin` lost its "Moderation" tab entirely on a phone, and how the type filters on `/plays` lost "special teams". Fixing one and leaving seven would have been arbitrary.

| File | Row |
|---|---|
| `PlaysPage` | header + type filters (clipped) |
| `PlaybooksPage` | the measured 442px cluster |
| `AdminDashboard` | 4-tab row (clipped) |
| `AccountSettings` | header — Save Changes lives only there |
| `TimeRangeSelector` | 5 labelled buttons in one bordered row |
| `PlayLibrary` | card footer |
| `Hero` | CTA pair, now stacks below `sm` |

Every **grid** in the app already collapsed correctly — the failures were all flex rows missing `flex-wrap`. So this is entirely additive: no breakpoint changes, no component restructuring.

## The guard

```js
expect(scrollW).toBeLessThanOrEqual(clientW + 1)   // 7 routes @ 375px
```

**I verified it actually fails without the fix** — stashed `src/`, watched it report `/playbooks scrolls horizontally at 375px`, restored. A guard that can't fail isn't one, and this is the third time this week a test in this repo has looked like it proved something it didn't.

Nothing existing caught this because every individual element was perfectly "visible" — the page around them was just wider than the phone.

## Verification

- `npm run typecheck`, `npm run build` — clean
- `npm run smoke` — **137/137**
- Screenshotted `/`, `/plays`, `/playbooks`, `/account` at 375 — `/playbooks` now fits exactly, tabs on one line and buttons wrapping below

⚠ `npx eslint` on the touched files reports **1 error**: an unused `Upload` import in `AccountSettings.tsx`. It's present on unmodified `main` and is not from this change — left alone rather than bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)