### PR TITLE
[nightly] B-36 (3): Community defenses in the /vs deck

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -167,13 +167,10 @@ offense roster inherits.
 
 ### B-36 · "Vs. Defense" follow-ups
 The read-only `/vs?play=<id>` view ships offense+defense overlay, defense
-cycling, per-matchup notes, and (as of the item below) export. Still
-deferred, in rough priority order:
+cycling, per-matchup notes, export, and (as of the item below) a community
+deck fallback. Still deferred:
 1. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
    read. Blocked on there being no "correct read" data on a play at all.
-2. **Community defenses in the deck** — currently the deck is the coach's own
-   defensive plays only, so a coach with none gets an empty state pointing at
-   the designer. Offering public defenses would seed it.
 
 ### B-37 · Consolidate the four duplicate play-card implementations
 Surfaced while fixing the My Plays card overflow (PR for that is card-only by
@@ -316,6 +313,42 @@ renders text, so images/markdown don't render at all. `p-8` inside `px-4`
 leaves a 279px column on a 375px phone.
 
 ## Done
+
+- **2026-08-13 · B-36 (3): Community defenses in the `/vs` deck** — a coach
+  with no saved defensive plays used to hit a dead end on `/vs?play=<id>`: an
+  empty state pointing only at the designer. The deck now falls back to
+  public community defensive plays (`plays` where `is_public=true` and
+  `type='defense'`, ordered by upvotes, capped at 25) whenever the coach's
+  own deck is empty — fetched up front in the same `Promise.all` as the
+  other page queries (best-effort: a failed fetch just leaves the existing
+  empty state, same treatment as the matchup-notes query) so there's no
+  extra round trip in the common case where a coach already has their own
+  defenses and the fallback goes unused. Community entries are tagged
+  `isCommunity` and get a small "Community" badge next to the defense name,
+  plus a banner above the deck controls pointing back at the designer to
+  create a real one. Coaching notes work unchanged against a community
+  defense — `matchup_notes` was already keyed by `(user_id, offense_play_id,
+  defense_play_id)` rather than ownership, the same reasoning that already
+  lets it work against someone else's public offense. **Note:** with zero
+  public defensive plays live in production today (B-31's defensive content
+  is still a private draft awaiting Jeremy's publish review), this fallback
+  is currently a no-op in prod — it activates automatically once any
+  defensive play gets published, no further change needed.
+  **Verification:** `npx tsc --noEmit` clean; `npx eslint` on touched files
+  shows only the two pre-existing `no-explicit-any` warnings on the unrelated
+  test-bridge lines (no new errors); `npm run build` succeeds. 2 new smoke
+  tests in `tests/smoke/vs-defense.spec.ts` cover the fallback itself
+  (community deck loads, is labeled, cycles correctly, malformed rows are
+  still dropped) and that a coach's own defenses take priority over the
+  community deck when they have any. Full Playwright smoke suite (139
+  tests, including the 2 new ones) run against a throwaway placeholder
+  `.env` and the container's pre-installed Chromium binary via
+  `PBP_CHROMIUM_PATH` (same recurring environment mismatch noted in prior
+  entries; neither is part of this commit): 138/139 passed — the one
+  failure, `mobile.spec.ts` "no page scrolls sideways at phone width", is a
+  30s navigation timeout on `/plays?tab=community` confirmed unrelated:
+  reproduces identically with this change's commits stashed out, against
+  unmodified `main`.
 
 - **2026-08-12 · B-36 (2): Export the matchup** — a coach can now export
   what's on `/vs?play=<id>` instead of only viewing it: a new "Export"

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -30,7 +30,16 @@ type PlayRow = {
   canvas_data: string | null;
 };
 
-type DefenseEntry = { id: string; name: string; description: string | null; gameType?: string; scene: SceneLayer };
+type DefenseEntry = {
+  id: string;
+  name: string;
+  description: string | null;
+  gameType?: string;
+  scene: SceneLayer;
+  /** True when this entry came from the public community deck fallback
+   *  (B-36 follow-up #2) rather than the coach's own saved defenses. */
+  isCommunity?: boolean;
+};
 
 const EMPTY_SCENE: SceneLayer = { paths: [], playerIcons: [], zones: [], textBoxes: [] };
 
@@ -75,6 +84,7 @@ export function VsDefenseView() {
   const [offensePlay, setOffensePlay] = useState<PlayRow | null>(null);
   const [offenseScene, setOffenseScene] = useState<SceneLayer>(EMPTY_SCENE);
   const [defenses, setDefenses] = useState<DefenseEntry[]>([]);
+  const [usingCommunityDeck, setUsingCommunityDeck] = useState(false);
   const [index, setIndex] = useState(0);
   const [showDefense, setShowDefense] = useState(true);
   const [canvasSize, setCanvasSize] = useState({ width: 640, height: 480 });
@@ -115,9 +125,12 @@ export function VsDefenseView() {
         setUserId(user.id);
 
         // The offense may be someone else's public play (RLS allows reading
-        // those), but the defensive deck — and any coaching notes — are
-        // always the signed-in coach's own.
-        const [offenseRes, defenseRes, notesRes] = await Promise.all([
+        // those), and coaching notes are always the signed-in coach's own.
+        // The defensive deck is normally the coach's own too — the community
+        // query below only gets used as a fallback when that's empty (B-36
+        // follow-up #2), fetched up front alongside everything else so
+        // there's no extra round trip in the common case where it goes unused.
+        const [offenseRes, defenseRes, notesRes, communityDefenseRes] = await Promise.all([
           supabase
             .from('plays')
             .select('id, name, type, description, metadata, canvas_data')
@@ -134,10 +147,23 @@ export function VsDefenseView() {
             .select('defense_play_id, note')
             .eq('user_id', user.id)
             .eq('offense_play_id', playId),
+          supabase
+            .from('plays')
+            .select('id, name, description, metadata, canvas_data')
+            .eq('is_public', true)
+            .eq('type', 'defense')
+            .order('upvotes', { ascending: false })
+            .limit(25),
         ]);
         if (cancelled) return;
         if (offenseRes.error) throw offenseRes.error;
         if (defenseRes.error) throw defenseRes.error;
+        // Best-effort like notes below: a coach with their own saved defenses
+        // never needs this query to succeed, so a failure here shouldn't
+        // block the page.
+        if (communityDefenseRes.error) {
+          console.error('Community defense load error:', communityDefenseRes.error);
+        }
         // Notes are a nice-to-have on top of the core view — a failed fetch
         // (e.g. the migration hasn't been run yet) shouldn't block the page.
         if (notesRes.error) {
@@ -158,7 +184,13 @@ export function VsDefenseView() {
         // play is excluded: metadata.gameType is optional and missing on older
         // rows, so filtering on it could silently empty the deck.
         const offFormat = offRow.metadata?.gameType;
-        const deck: DefenseEntry[] = ((defenseRes.data ?? []) as PlayRow[])
+        const sortDeck = (rows: DefenseEntry[]) => rows.sort((a, b) => {
+          const aMatch = offFormat && a.gameType === offFormat ? 0 : 1;
+          const bMatch = offFormat && b.gameType === offFormat ? 0 : 1;
+          return aMatch - bMatch || a.name.localeCompare(b.name);
+        });
+
+        const ownDeck: DefenseEntry[] = sortDeck(((defenseRes.data ?? []) as PlayRow[])
           .map((row): DefenseEntry | null => {
             const scene = parseScene(row.canvas_data);
             if (!scene) return null;
@@ -170,16 +202,38 @@ export function VsDefenseView() {
               scene,
             };
           })
-          .filter((d): d is DefenseEntry => d !== null)
-          .sort((a, b) => {
-            const aMatch = offFormat && a.gameType === offFormat ? 0 : 1;
-            const bMatch = offFormat && b.gameType === offFormat ? 0 : 1;
-            return aMatch - bMatch || a.name.localeCompare(b.name);
-          });
+          .filter((d): d is DefenseEntry => d !== null));
+
+        // Empty state fallback: a coach with no saved defenses of their own
+        // gets the public community deck instead of a dead end pointing only
+        // at the designer.
+        let deck = ownDeck;
+        let usingCommunity = false;
+        if (ownDeck.length === 0) {
+          const communityDeck: DefenseEntry[] = sortDeck(((communityDefenseRes.data ?? []) as PlayRow[])
+            .map((row): DefenseEntry | null => {
+              const scene = parseScene(row.canvas_data);
+              if (!scene) return null;
+              return {
+                id: row.id,
+                name: row.name || 'Untitled Defense',
+                description: row.description,
+                gameType: row.metadata?.gameType,
+                scene,
+                isCommunity: true,
+              };
+            })
+            .filter((d): d is DefenseEntry => d !== null));
+          if (communityDeck.length > 0) {
+            deck = communityDeck;
+            usingCommunity = true;
+          }
+        }
 
         setOffensePlay(offRow);
         setOffenseScene(offScene);
         setDefenses(deck);
+        setUsingCommunityDeck(usingCommunity);
         // Honour ?d= on first load / refresh so a specific matchup is linkable.
         const startAt = deck.findIndex((d) => d.id === defenseParam);
         setIndex(startAt >= 0 ? startAt : 0);
@@ -341,10 +395,15 @@ export function VsDefenseView() {
         noteDraft,
         noteSaveState,
         hasNoteForCurrentDefense: currentDefense ? currentDefense.id in notes : false,
+        usingCommunityDeck,
+        isCommunityDefense: currentDefense?.isCommunity ?? false,
       }),
     };
     return () => { delete (window as any).__PBP_VS_TEST__; };
-  }, [offenseScene, visibleDefenseScene, currentDefense, defenses.length, index, showDefense, notesOpen, noteDraft, noteSaveState, notes]);
+  }, [
+    offenseScene, visibleDefenseScene, currentDefense, defenses.length, index, showDefense,
+    notesOpen, noteDraft, noteSaveState, notes, usingCommunityDeck,
+  ]);
 
   const ariaLabel = useMemo(() => {
     const off = offensePlay?.name ?? 'Play';
@@ -493,7 +552,14 @@ export function VsDefenseView() {
             </Link>
           </div>
         ) : (
-          <div className="flex items-center gap-2 sm:gap-3 max-w-4xl mx-auto">
+          <div className="max-w-4xl mx-auto">
+            {usingCommunityDeck && (
+              <div className="mb-2 flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 text-center text-xs text-chalk/60 bg-board rounded-lg px-3 py-1.5 border border-chalk/10">
+                <span>You haven&apos;t saved any defenses yet — showing community defenses instead.</span>
+                <Link to="/designer" className="text-primary hover:underline shrink-0">Create your own</Link>
+              </div>
+            )}
+            <div className="flex items-center gap-2 sm:gap-3">
             <button
               onClick={() => step(-1)}
               disabled={defenses.length < 2}
@@ -509,6 +575,11 @@ export function VsDefenseView() {
                   the coach cycles, since the canvas itself can't. */}
               <div id="vs-defense-label" aria-live="polite" className="truncate">
                 <span className="text-chalk font-medium">{currentDefense?.name}</span>
+                {currentDefense?.isCommunity && (
+                  <span className="ml-2 text-xs text-primary border border-primary/40 rounded px-1.5 py-0.5">
+                    Community
+                  </span>
+                )}
                 {currentDefense?.gameType && (
                   <span className="ml-2 text-xs text-chalk/50 border border-chalk/20 rounded px-1.5 py-0.5">
                     {currentDefense.gameType}
@@ -546,6 +617,7 @@ export function VsDefenseView() {
             >
               <ChevronRight className="h-5 w-5" />
             </button>
+            </div>
           </div>
         )}
       </footer>

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -55,9 +55,16 @@ type VsState = {
   noteDraft: string;
   noteSaveState: 'idle' | 'saving' | 'saved' | 'error';
   hasNoteForCurrentDefense: boolean;
+  usingCommunityDeck: boolean;
+  isCommunityDefense: boolean;
 };
 
-async function mockBackend(page: Page, defenses: typeof DEFENSES, seededNotes: { defense_play_id: string; note: string }[] = []) {
+async function mockBackend(
+  page: Page,
+  defenses: typeof DEFENSES,
+  seededNotes: { defense_play_id: string; note: string }[] = [],
+  communityDefenses: typeof DEFENSES = [],
+) {
   await page.addInitScript(({ user, storageKey }) => {
     localStorage.setItem(storageKey, JSON.stringify({
       access_token: 'test-access-token', refresh_token: 'test-refresh-token',
@@ -68,11 +75,21 @@ async function mockBackend(page: Page, defenses: typeof DEFENSES, seededNotes: {
   await page.route('**/auth/v1/user**', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(USER) }));
 
-  // Both play queries hit /rest/v1/plays — the offense fetch is a .single()
-  // keyed by id, the deck fetch filters type=eq.defense.
+  // Three play queries hit /rest/v1/plays — the offense fetch is a .single()
+  // keyed by id, the coach's own deck filters type=eq.defense+user_id, and
+  // the community fallback deck (B-36 follow-up #2) filters
+  // type=eq.defense+is_public=eq.true. Order matters: check the more specific
+  // is_public filter before the generic type=eq.defense one, since both match it.
   await page.route('**/rest/v1/plays**', (route) => {
     const url = route.request().url();
-    const body = url.includes('type=eq.defense') ? JSON.stringify(defenses) : JSON.stringify(OFFENSE);
+    let body: string;
+    if (url.includes('is_public=eq.true')) {
+      body = JSON.stringify(communityDefenses);
+    } else if (url.includes('type=eq.defense')) {
+      body = JSON.stringify(defenses);
+    } else {
+      body = JSON.stringify(OFFENSE);
+    }
     return route.fulfill({ status: 200, contentType: 'application/json', body });
   });
 
@@ -156,7 +173,7 @@ test('?d= restores a specific matchup on reload', async ({ page }) => {
   await expect(page).toHaveURL(/d=def-1/);
 });
 
-test('with no saved defenses, the offense still renders and prompts to create one', async ({ page }) => {
+test('with no saved defenses and none in the community, the offense still renders and prompts to create one', async ({ page }) => {
   await mockBackend(page, []);
   await openVs(page);
 
@@ -164,7 +181,46 @@ test('with no saved defenses, the offense still renders and prompts to create on
   expect(state.deckLength).toBe(0);
   expect(state.offenseIcons.map((i) => i.letter)).toEqual(['Q', 'C', 'X', 'Y', 'Z']);
   expect(state.defenseIcons).toEqual([]);
+  expect(state.usingCommunityDeck).toBe(false);
   await expect(page.getByRole('link', { name: /create a defense/i })).toBeVisible();
+});
+
+test('B-36 (3): falls back to community defenses when the coach has none of their own', async ({ page }) => {
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+
+  await mockBackend(page, [], [], DEFENSES);
+  await openVs(page);
+
+  const state = await vsState(page);
+  // Same two well-formed rows as the "own deck" tests survive; the malformed
+  // third is dropped the same way.
+  expect(state.deckLength).toBe(2);
+  expect(state.usingCommunityDeck).toBe(true);
+  expect(state.isCommunityDefense).toBe(true);
+  expect(state.defenseIcons.map((i) => i.letter)).toEqual(['D', 'CB', 'CB', 'S', 'S']);
+  await expect(page.getByText(/showing community defenses/i)).toBeVisible();
+  await expect(page.locator('#vs-defense-label').getByText('Community', { exact: true })).toBeVisible();
+  // The "create your own" empty-state prompt is gone — deck isn't empty.
+  await expect(page.getByRole('link', { name: /create a defense/i })).toHaveCount(0);
+
+  // Cycling still works against the community deck.
+  await page.keyboard.press('ArrowRight');
+  await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
+  expect((await vsState(page)).isCommunityDefense).toBe(true);
+
+  expect(errors, 'no uncaught page errors').toEqual([]);
+});
+
+test('B-36 (3): the coach\'s own defenses take priority over the community fallback', async ({ page }) => {
+  await mockBackend(page, [DEFENSES[0]], [], DEFENSES);
+  await openVs(page);
+
+  const state = await vsState(page);
+  expect(state.deckLength).toBe(1);
+  expect(state.usingCommunityDeck).toBe(false);
+  expect(state.isCommunityDefense).toBe(false);
+  await expect(page.getByText(/showing community defenses/i)).toHaveCount(0);
 });
 
 test('B-36: per-matchup coaching notes load, edit, save, and stay scoped per defense', async ({ page }) => {


### PR DESCRIPTION
## What changed

`/vs?play=<id>` (the read-only "vs. defense" teaching view) previously showed a coach only their own saved defensive plays, and a coach with none hit a dead end: an empty state pointing only at the designer. This closes the remaining unblocked follow-up on B-36 ("Community defenses in the deck" — the other follow-up, quiz/reveal mode, stays blocked on there being no "correct read" data on a play).

The deck now falls back to public community defensive plays (`plays` where `is_public=true` and `type='defense'`, ordered by upvotes, capped at 25) whenever the coach's own deck is empty. Behavior:
- The community query is fetched up front, in the same `Promise.all()` as the offense/own-deck/notes queries, so there's no extra round trip in the common case (a coach with their own defenses) where it goes unused.
- It's best-effort, same as the existing matchup-notes query — a failed fetch just leaves the existing "create a defense" empty state rather than blocking the page.
- Community entries are tagged `isCommunity` and get a small "Community" badge next to the defense name in the header, plus a banner above the deck controls linking back to the designer.
- Per-matchup coaching notes work unchanged against a community defense — `matchup_notes` is keyed by `(user_id, offense_play_id, defense_play_id)` rather than ownership, the same reasoning that already lets notes work against someone else's public *offense*.

**Note on current effect:** there are zero public defensive plays live in production today — B-31's defensive library content is still a private draft awaiting Jeremy's publish review. So this fallback is currently a no-op in prod; it activates automatically the moment any defensive play gets published, no further change needed.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint src/components/vs/VsDefenseView.tsx tests/smoke/vs-defense.spec.ts` — 0 errors, only the 2 pre-existing `no-explicit-any` warnings on the test-bridge lines (documented in CLAUDE.md as expected).
- `npm run build` — succeeds.
- 2 new smoke tests in `tests/smoke/vs-defense.spec.ts`:
  - the community-deck fallback loads, is labeled, cycles correctly, and still drops malformed rows the same way the own-deck path does
  - a coach's own defenses take priority over the community deck when they have any
- Full Playwright smoke suite: **138/139 passed**, run against a throwaway placeholder `.env` and the container's pre-installed Chromium binary via `PBP_CHROMIUM_PATH` (neither is part of this commit — same recurring environment mismatch noted in prior nightly PRs, see CLAUDE.md). The one failure — `mobile.spec.ts` "no page scrolls sideways at phone width", a 30s navigation timeout on `/plays?tab=community` — is confirmed **unrelated**: it reproduces identically with this change's commits stashed out, against unmodified `main`.

## Backlog

`BACKLOG.md` updated: B-36's community-defenses sub-item removed from "Up next" (only the blocked quiz-mode sub-item remains there) and a new Done entry added with today's date.

No SQL changes, no billing/auth code touched.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PRLzvPNDoAubyFgBVwRhR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRLzvPNDoAubyFgBVwRhR1)_