### PR TITLE
B-37 (2): one shared play card

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -172,21 +172,6 @@ deck fallback. Still deferred:
 1. **Quiz/reveal mode** — hide the answer, show a random defense, reveal the
    read. Blocked on there being no "correct read" data on a play at all.
 
-### B-37 · Consolidate the four duplicate play-card implementations
-Surfaced while fixing the My Plays card overflow (PR for that is card-only by
-choice). There is no shared play card: My Plays (`plays/PlaysPage.tsx`),
-Community (`plays/PlayLibrary.tsx`), and the playbook detail grid *and* list
-views (`playbooks/PlaybooksPage.tsx`) each hand-roll their own, which is why
-they drifted apart on shell, thumbnail aspect ratio, and button styling in the
-first place.
-⚠ Not a mechanical extraction: the Community filter smoke test asserts
-`.grid > div.bg-board-light` structurally, so it must be re-pointed at a
-`data-testid` in the same change. The dead-code deletion half of this item
-(unimported `designer/PlayCard.tsx`, `AddToPlaybookModal.tsx`,
-`PlaybookSelectionModal.tsx`, `PlaybookSelector.tsx`, `CreatePlaybookModal.tsx`)
-is done (see Done below) — what's left is the actual shared-component
-extraction and re-pointing the four call sites at it.
-
 ### B-50 · ~~/vs matchup notes leak between defenses~~ — RESOLVED, was a flaky test
 Filed 2026-08-12 as a data-loss bug. **That diagnosis was wrong**, and the
 correction is worth keeping: `vs-defense.spec.ts:170` failed ~4 runs in 6, but
@@ -312,6 +297,37 @@ leaves a 279px column on a 375px phone.
 
 ## Done
 
+- **2026-08-14 · B-37 (2): one shared play card** — the second and larger half
+  of B-37. My Plays, the Community library and the playbook detail grid each
+  hand-rolled their own card; they now all render `plays/PlayCard.tsx`, which
+  owns the parts that should never differ (shell, thumbnail frame and its empty
+  state, body padding) and takes everything below the title as children,
+  because the actions genuinely do differ per surface. Net **-222 lines** across
+  the three call sites before counting the new component.
+  The playbook **list** view is deliberately not a consumer: it's a compact
+  drag-to-reorder row, not a card, and routing it through here would mean a
+  variant sharing nothing but a name.
+  Three drifts closed by consolidating, each previously invisible: the playbook
+  grid used `object-cover`, so it **cropped** play diagrams and cut routes off
+  at the frame edge (now `object-contain` like the others); its empty-state icon
+  was `text-chalk/30` on a white ground, i.e. nearly invisible; and its meta row
+  now sits at the card bottom, so cards with and without a description align.
+  ⚠ **Deleted `generateFallbackThumbnail` + `ThumbnailImage` (~166 lines) from
+  PlaysPage** rather than promoting them. They read `canvasData.icons` and
+  `path.path`, but v4 saves `playerIcons` and paths with `points` — so for every
+  modern play the "fallback" drew an **empty field with no players or routes**,
+  at absolute pixel coordinates that don't match the normalized ones stored
+  today. My Plays now shows the same honest play-icon placeholder as everywhere
+  else. Only ever reachable for rows with no stored thumbnail, since the
+  designer always writes one on save.
+  Re-pointed the Community filter smoke test from `.grid > div.bg-board-light`
+  to `getByTestId('play-card')` — it was a filter test coupled to the card's
+  background colour and grid nesting.
+  **Verification:** typecheck and build clean, eslint 0 errors on all touched
+  files, smoke **139/139**, and all three surfaces screenshotted before/after at
+  1280 and 375 to confirm the refactor is visually a no-op apart from the three
+  drifts noted above.
+
 - **2026-08-14 · B-37 (1): Delete dead play-card code** — the low-risk first
   half of B-37: removed five files confirmed unimported anywhere in the repo
   (checked by grepping every `.tsx`/`.ts` file for import statements, not just
@@ -321,10 +337,10 @@ leaves a 279px column on a 375px phone.
   `designer/PlaybookSelector.tsx`, and `designer/CreatePlaybookModal.tsx`
   (only reachable through the two Playbook*Modal/Selector files being deleted
   alongside it, so it goes too). No behavior change — the remaining scope
-  (extracting one shared play-card component and re-pointing the four
-  hand-rolled implementations at it, including re-pointing the Community
-  filter smoke test off its current structural `.grid > div.bg-board-light`
-  selector) is unstarted and stays in Up next under B-37.
+  (extracting one shared play-card component and re-pointing the hand-rolled
+  implementations at it, including re-pointing the Community filter smoke test
+  off its structural `.grid > div.bg-board-light` selector) was done the same
+  day; see B-37 (2) above.
   **Verification:** `npx tsc --noEmit` clean; `npm run build` succeeds. Full
   Playwright smoke suite run against a throwaway placeholder `.env` and the
   container's pre-installed Chromium binary via `PBP_CHROMIUM_PATH` (same

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -29,6 +29,7 @@ import { getSafeErrorMessage } from '../../lib/errors';
 import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { UsageWarningBanner } from '../UsageWarningBanner';
+import { PlayCard } from '../plays/PlayCard';
 import { getUserPreferences, paperPageSize, teamBrandHTML, type UserPreferences } from '../../lib/userPreferences';
 import { usePageMeta } from '../../lib/seo';
 import { PlaybookPackLibrary } from './PlaybookPackLibrary';
@@ -1499,30 +1500,16 @@ export function PlaybooksPage() {
                   ) : playsLayout === 'grid' ? (
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
                       {playsInPlaybook.map((play) => (
-                        <div
+                        <PlayCard
                           key={play.id}
-                          className="bg-board rounded-lg border border-chalk/10 overflow-hidden hover:border-chalk/20 transition-colors group"
-                        >
-                          {/* Play Thumbnail */}
-                          <div className="aspect-video bg-white border-b border-chalk/10 relative">
-                            {play.thumbnail ? (
-                              <img
-                                src={play.thumbnail}
-                                alt={play.name}
-                                className="w-full h-full object-cover"
-                                loading="lazy"
-                                decoding="async"
-                              />
-                            ) : (
-                              <div className="w-full h-full flex items-center justify-center text-chalk/30">
-                                <Play className="h-8 w-8" />
-                              </div>
-                            )}
-                            {/* touch-always-visible: on a phone there is no
-                                hover, so without it Edit/Vs/Remove simply do
-                                not exist here — and this grid is the default
-                                layout. See the @media (hover: none) rule in
-                                index.css. */}
+                          play={play}
+                          tone="inPanel"
+                          overlay={
+                            /* touch-always-visible: on a phone there is no
+                               hover, so without it Edit/Vs/Remove simply do
+                               not exist here — and this grid is the default
+                               layout. See the @media (hover: none) rule in
+                               index.css. */
                             <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 touch-always-visible transition-opacity flex items-center justify-center gap-2">
                               <button
                                 onClick={() => handleEditPlay(play.id)}
@@ -1550,24 +1537,21 @@ export function PlaybooksPage() {
                                 <Trash2 className="h-4 w-4" />
                               </button>
                             </div>
+                          }
+                        >
+                          <h3 className="font-medium text-chalk mb-1 line-clamp-1">
+                            {play.name}
+                          </h3>
+                          {play.description && (
+                            <p className="text-sm text-chalk/70 line-clamp-2 mb-2">
+                              {play.description}
+                            </p>
+                          )}
+                          <div className="mt-auto flex items-center justify-between text-xs text-chalk/50">
+                            <span className="capitalize">{play.type}</span>
+                            <span>{new Date(play.created_at).toLocaleDateString()}</span>
                           </div>
-
-                          {/* Play Info */}
-                          <div className="p-4">
-                            <h3 className="font-medium text-chalk mb-1 line-clamp-1">
-                              {play.name}
-                            </h3>
-                            {play.description && (
-                              <p className="text-sm text-chalk/70 line-clamp-2 mb-2">
-                                {play.description}
-                              </p>
-                            )}
-                            <div className="flex items-center justify-between text-xs text-chalk/50">
-                              <span className="capitalize">{play.type}</span>
-                              <span>{new Date(play.created_at).toLocaleDateString()}</span>
-                            </div>
-                          </div>
-                        </div>
+                        </PlayCard>
                       ))}
                     </div>
                   ) : (

--- a/src/components/plays/PlayCard.tsx
+++ b/src/components/plays/PlayCard.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Play as PlayIcon } from 'lucide-react';
+
+/**
+ * The one play card (B-37). My Plays, the Community library and the playbook
+ * detail grid each hand-rolled their own before this, which is exactly why
+ * they drifted apart on shell, thumbnail fit and button styling — and why the
+ * My Plays card was the only one whose action row outgrew it.
+ *
+ * The card owns the parts that should never differ: the shell, the thumbnail
+ * frame and its empty state, and the body padding. Everything below the title
+ * is passed in as children, because the actions genuinely do differ per
+ * surface (copy vs. delete vs. remove-from-playbook) and pretending otherwise
+ * would just move the duplication into a pile of boolean props.
+ *
+ * The playbook *list* view is deliberately not a consumer: it's a compact
+ * drag-to-reorder row, not a card, and forcing it through here would mean a
+ * variant that shares nothing but a name.
+ */
+
+export type PlayCardPlay = {
+  id: string;
+  name: string;
+  type: string;
+  thumbnail?: string | null;
+};
+
+type PlayCardProps = {
+  play: PlayCardPlay;
+  /** Where the thumbnail navigates. Omit to render it as a plain frame. */
+  href?: string;
+  /** Painted over the thumbnail — the playbook grid's hover actions. */
+  overlay?: React.ReactNode;
+  /**
+   * Cards on the page background sit on `board-light`; cards nested inside an
+   * already-light panel sit on `board` so they don't disappear into it.
+   */
+  tone?: 'onBoard' | 'inPanel';
+  /**
+   * `false` where the card contains an absolutely-positioned child that has to
+   * escape it — My Plays' add-to-playbook dropdown is clipped out of existence
+   * by `overflow-hidden` on the shell.
+   */
+  clip?: boolean;
+  children?: React.ReactNode;
+};
+
+export function PlayCard({
+  play,
+  href,
+  overlay,
+  tone = 'onBoard',
+  clip = true,
+  children,
+}: PlayCardProps) {
+  const shell = [
+    'group relative flex flex-col rounded-lg border transition-colors',
+    tone === 'onBoard'
+      ? 'bg-board-light border-chalk/10 hover:border-primary/30'
+      : 'bg-board border-chalk/10 hover:border-chalk/20',
+    clip ? 'overflow-hidden' : '',
+  ].join(' ');
+
+  // White ground: stored thumbnails are exported on white, so anything else
+  // shows as a border around the image.
+  const frame = `relative block aspect-video bg-white border-b border-chalk/10 ${clip ? '' : 'rounded-t-lg overflow-hidden'}`;
+
+  const thumbnail = play.thumbnail ? (
+    <img
+      src={play.thumbnail}
+      alt={play.name}
+      className="w-full h-full object-contain"
+      loading="lazy"
+      decoding="async"
+    />
+  ) : (
+    // object-contain, never object-cover: cropping a play diagram cuts routes
+    // off at the edge of the frame.
+    <div className="w-full h-full flex items-center justify-center text-board/30">
+      <PlayIcon className="h-8 w-8" />
+    </div>
+  );
+
+  return (
+    <div data-testid="play-card" className={shell}>
+      {href ? (
+        <Link to={href} className={frame}>
+          {thumbnail}
+          {overlay}
+        </Link>
+      ) : (
+        <div className={frame}>
+          {thumbnail}
+          {overlay}
+        </div>
+      )}
+      <div className="p-4 flex-1 flex flex-col">{children}</div>
+    </div>
+  );
+}
+
+/** Play name + type pill on one line. Truncates rather than wrapping, so a
+ *  long name can't desynchronise card heights across a grid row. */
+export function PlayCardTitle({ name, type }: { name: string; type: string }) {
+  return (
+    <div className="flex items-start justify-between gap-2 mb-1">
+      <h3 className="min-w-0 truncate font-bold text-chalk group-hover:text-primary transition-colors">
+        {name}
+      </h3>
+      <span className="px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs capitalize shrink-0">
+        {type.replace('_', ' ')}
+      </span>
+    </div>
+  );
+}

--- a/src/components/plays/PlayLibrary.tsx
+++ b/src/components/plays/PlayLibrary.tsx
@@ -4,6 +4,7 @@ import { Copy, Check, Play as PlayIcon, Search, Filter, Wand2 } from 'lucide-rea
 import { supabase } from '../../lib/supabase';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { PlayVoteButton } from './PlayVoteButton';
+import { PlayCard, PlayCardTitle } from './PlayCard';
 import { UpgradePrompt } from '../UpgradePrompt';
 
 type PublicPlay = {
@@ -278,32 +279,9 @@ export function PlayLibrary() {
       ) : (
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((play) => (
-            <div
-              key={play.id}
-              className="bg-board-light rounded-lg border border-chalk/10 hover:border-primary/30 transition-colors overflow-hidden flex flex-col"
-            >
-              <div className="aspect-video bg-white border-b border-chalk/10">
-                {play.thumbnail ? (
-                  <img
-                    src={play.thumbnail}
-                    alt={play.name}
-                    className="w-full h-full object-contain"
-                    loading="lazy"
-                    decoding="async"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-board/30">
-                    <PlayIcon className="h-8 w-8" />
-                  </div>
-                )}
-              </div>
-              <div className="p-4 flex-1 flex flex-col">
-                <div className="flex items-start justify-between gap-2 mb-1">
-                  <h3 className="font-bold text-chalk">{play.name}</h3>
-                  <span className="px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs capitalize shrink-0">
-                    {play.type.replace('_', ' ')}
-                  </span>
-                </div>
+            <PlayCard key={play.id} play={play}>
+              <>
+                <PlayCardTitle name={play.name} type={play.type} />
                 <p className="text-xs text-chalk/50 mb-3">
                   {play.author?.username ? `by ${play.author.username}` : ''}
                   {gameFormatLabel(play) ? ` · ${gameFormatLabel(play)}` : ''}
@@ -346,8 +324,8 @@ export function PlayLibrary() {
                     )}
                   </div>
                 </div>
-              </div>
-            </div>
+              </>
+            </PlayCard>
           ))}
         </div>
       )}

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { AddToPlaybookButton } from './AddToPlaybookButton'; // Adjust path as needed
 import { PlayVoteButton } from './PlayVoteButton';
+import { PlayCard, PlayCardTitle } from './PlayCard';
 import { getSafeErrorMessage } from '../../lib/errors';
 import { usePageMeta } from '../../lib/seo';
 import { PlayLibrary } from './PlayLibrary';
@@ -14,9 +15,6 @@ import { UsageWarningBanner } from '../UsageWarningBanner';
 // predictable and can't outgrow the card the way the old labelled+icon mix did.
 const CARD_ACTION =
   'flex items-center justify-center h-9 w-9 rounded-lg border border-chalk/10 bg-board hover:bg-board-light text-chalk/70 hover:text-chalk transition-colors';
-
-const THUMBNAIL_FRAME =
-  'block aspect-video bg-board rounded-t-lg overflow-hidden border-b border-chalk/10';
 
 interface Play {
   id: string;
@@ -33,172 +31,6 @@ interface Play {
     username: string;
     avatar_url?: string;
   };
-}
-
-// Fallback thumbnail generator - only used if no stored thumbnail exists
-function generateFallbackThumbnail(play: Play) {
-  try {
-    const canvasData = JSON.parse(play.canvas_data);
-    const tempCanvas = document.createElement('canvas');
-    const ctx = tempCanvas.getContext('2d');
-
-    if (!ctx) return null;
-
-    // Set canvas size with 4:3 aspect ratio
-    tempCanvas.width = 400;
-    tempCanvas.height = 300;
-
-    // Draw white background
-    ctx.fillStyle = '#FFFFFF';
-    ctx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
-
-    // Calculate field dimensions
-    const yardSpacing = tempCanvas.height / 30;
-    const losY = 20 * yardSpacing;
-    const leftSidelineX = tempCanvas.width * 0.05;
-    const rightSidelineX = tempCanvas.width * 0.95;
-
-    // Draw field lines
-    ctx.beginPath();
-    ctx.strokeStyle = '#1A1A1A';
-    ctx.lineWidth = 2;
-    ctx.globalAlpha = 0.4;
-
-    // Sidelines
-    ctx.moveTo(leftSidelineX, 0);
-    ctx.lineTo(leftSidelineX, tempCanvas.height);
-    ctx.moveTo(rightSidelineX, 0);
-    ctx.lineTo(rightSidelineX, tempCanvas.height);
-    ctx.stroke();
-
-    // Line of scrimmage
-    ctx.beginPath();
-    ctx.strokeStyle = '#60A5FA';
-    ctx.lineWidth = 3;
-    ctx.globalAlpha = 0.7;
-    ctx.moveTo(leftSidelineX, losY);
-    ctx.lineTo(rightSidelineX, losY);
-    ctx.stroke();
-
-    // Draw yard lines
-    ctx.globalAlpha = 0.3;
-    for (let i = 0; i <= 30; i += 5) {
-      if (i === 20) continue; // Skip LOS
-      const y = i * yardSpacing;
-      ctx.beginPath();
-      ctx.strokeStyle = '#1A1A1A';
-      ctx.lineWidth = 2;
-      ctx.moveTo(leftSidelineX, y);
-      ctx.lineTo(rightSidelineX, y);
-      ctx.stroke();
-    }
-
-    ctx.globalAlpha = 1;
-
-    // Draw paths
-    canvasData.paths?.forEach((path: any) => {
-      const p = new Path2D(path.path);
-      ctx.strokeStyle = path.color;
-      ctx.lineWidth = 3;
-      ctx.stroke(p);
-
-      // Draw arrow if exists
-      if (path.arrowFrom && path.arrowTo) {
-        const { x: fromX, y: fromY } = path.arrowFrom;
-        const { x: toX, y: toY } = path.arrowTo;
-
-        const angle = Math.atan2(toY - fromY, toX - fromX);
-        const size = 15;
-
-        ctx.save();
-        ctx.translate(toX, toY);
-        ctx.rotate(angle);
-
-        ctx.beginPath();
-        ctx.moveTo(0, 0);
-        ctx.lineTo(-size, size/2);
-        ctx.lineTo(-size, -size/2);
-        ctx.closePath();
-
-        ctx.fillStyle = path.color;
-        ctx.fill();
-        ctx.restore();
-      }
-    });
-
-    // Draw player icons
-    canvasData.icons?.forEach((icon: any) => {
-      const size = 24;
-      ctx.fillStyle = icon.color;
-
-      if (icon.isSquare) {
-        ctx.fillRect(icon.x - size/2, icon.y - size/2, size, size);
-      } else {
-        ctx.beginPath();
-        ctx.arc(icon.x, icon.y, size/2, 0, Math.PI * 2);
-        ctx.fill();
-      }
-
-      ctx.fillStyle = '#FFFFFF';
-      ctx.font = 'bold 16px Inter';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(icon.letter, icon.x, icon.y);
-    });
-
-    return tempCanvas.toDataURL();
-  } catch (err) {
-    console.error('Error generating fallback thumbnail:', err);
-    return null;
-  }
-}
-
-function getThumbnailSrc(play: Play) {
-  // First, try to use the stored thumbnail
-  if (play.thumbnail && play.thumbnail.startsWith('data:image/')) {
-    return play.thumbnail;
-  }
-
-  // Fallback to generating thumbnail from canvas data
-  return generateFallbackThumbnail(play);
-}
-
-function ThumbnailImage({ play }: { play: Play }) {
-  const [thumbnailSrc, setThumbnailSrc] = useState<string | null>(null);
-  const [imageError, setImageError] = useState(false);
-
-  useEffect(() => {
-    const src = getThumbnailSrc(play);
-    setThumbnailSrc(src);
-    setImageError(false);
-  }, [play]);
-
-  const handleImageError = () => {
-    setImageError(true);
-    // Try fallback thumbnail if stored thumbnail fails
-    if (play.thumbnail && !imageError) {
-      const fallback = generateFallbackThumbnail(play);
-      setThumbnailSrc(fallback);
-    }
-  };
-
-  if (!thumbnailSrc) {
-    return (
-      <div className="w-full h-full bg-board-light flex items-center justify-center">
-        <div className="text-chalk/30 text-sm">No preview</div>
-      </div>
-    );
-  }
-
-  return (
-    <img
-      src={thumbnailSrc}
-      alt={play.name}
-      className="w-full h-full object-contain"
-      onError={handleImageError}
-      loading="lazy"
-    />
-  );
 }
 
 export function PlaysPage() {
@@ -464,41 +296,20 @@ export function PlaysPage() {
                 {/* Visible plays */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                   {visiblePlays.map((play) => (
-                    /* No overflow-hidden on the shell: the add-to-playbook
-                       dropdown is an absolutely-positioned child and would be
-                       clipped by it. The thumbnail clips itself instead. */
-                    <div
+                    // clip={false}: the add-to-playbook dropdown is an
+                    // absolutely-positioned child and overflow-hidden would
+                    // erase it. Signed-out visitors get no edit link — they
+                    // don't own these plays. `from=plays` sends the designer
+                    // back here after an update rather than stranding the coach
+                    // in the designer post-save.
+                    <PlayCard
                       key={play.id}
-                      data-testid="play-card"
-                      className="group relative bg-board-light rounded-lg border border-chalk/10 hover:border-primary/30 transition-colors flex flex-col"
+                      play={play}
+                      clip={false}
+                      href={user ? `/designer?play=${play.id}&from=plays` : undefined}
                     >
-                      {/* Signed-out visitors get the same frame without the
-                          edit link — they don't own these plays. */}
-                      {user ? (
-                        /* from=plays tells the designer to return here after an
-                           update, instead of leaving the coach on the designer
-                           post-save. */
-                        <Link
-                          to={`/designer?play=${play.id}&from=plays`}
-                          className={THUMBNAIL_FRAME}
-                        >
-                          <ThumbnailImage play={play} />
-                        </Link>
-                      ) : (
-                        <div className={THUMBNAIL_FRAME}>
-                          <ThumbnailImage play={play} />
-                        </div>
-                      )}
-
-                      <div className="p-4 flex-1 flex flex-col">
-                        <div className="flex items-start justify-between gap-2 mb-1">
-                          <h3 className="min-w-0 truncate font-bold text-chalk group-hover:text-primary transition-colors">
-                            {play.name}
-                          </h3>
-                          <span className="px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs capitalize shrink-0">
-                            {play.type.replace('_', ' ')}
-                          </span>
-                        </div>
+                      <>
+                        <PlayCardTitle name={play.name} type={play.type} />
 
                         {!user && play.profiles && (
                           <p className="text-xs text-chalk/40">
@@ -578,8 +389,8 @@ export function PlaysPage() {
                             </div>
                           )}
                         </div>
-                      </div>
-                    </div>
+                      </>
+                    </PlayCard>
                   ))}
                 </div>
 

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2111,7 +2111,11 @@ test('Community Play Library: type/game-format/formation filters compose correct
   );
 
   await page.goto('/plays?tab=community');
-  const cards = page.locator('.grid > div.bg-board-light');
+  // Counted by testid, not by shell classes. This used to be
+  // `.grid > div.bg-board-light`, which coupled a filter test to the card's
+  // background colour and grid nesting — restyle the card and this fails for
+  // a reason that has nothing to do with filtering.
+  const cards = page.getByTestId('play-card');
   await expect(cards).toHaveCount(5);
 
   // Type filter alone


### PR DESCRIPTION
The second and larger half of B-37, after the nightly's dead-code deletion in #75.

My Plays, the Community library and the playbook detail grid each hand-rolled their own play card. That's precisely why they drifted apart on shell, thumbnail fit and button styling — and why the My Plays card was the only one whose action row outgrew it and hid the delete button.

## The shape of it

All three now render [`plays/PlayCard.tsx`](src/components/plays/PlayCard.tsx). It owns the parts that should never differ — shell, thumbnail frame and its empty state, body padding — and takes everything below the title as children.

The actions genuinely do differ per surface (copy vs. delete vs. remove-from-playbook). Encoding that in a pile of boolean props would move the duplication rather than remove it, so the card composes instead.

**Net −222 lines** across the three call sites, before counting the new component.

The playbook **list** view is deliberately *not* a consumer. It's a compact drag-to-reorder row, not a card; routing it through here would produce a variant sharing nothing but a name.

## Three drifts closed, all previously invisible

- The playbook grid used `object-cover`, so it **cropped play diagrams** — routes cut off at the frame edge. Now `object-contain` like the others.
- Its empty-state icon was `text-chalk/30` on a **white** ground. Nearly invisible.
- Its meta row now sits at the card bottom, so cards with and without a description line up.

## ⚠ One deletion worth reviewing

I deleted `generateFallbackThumbnail` + `ThumbnailImage` (~166 lines) instead of promoting them to the shared card.

They read `canvasData.icons` and `path.path`. But v4 saves **`playerIcons`**, and paths carry **`points`**. So for every modern play that "fallback" was drawing an empty field — no players, no routes — at absolute pixel coordinates that don't match the normalized 0–1 ones stored today.

My Plays now shows the same honest play-icon placeholder as everywhere else. Worth noting it was only ever reachable for rows with no stored thumbnail, since the designer writes one on every save — so this affects seeded and legacy rows only.

## Test

Re-pointed the Community filter test from `.grid > div.bg-board-light` to `getByTestId('play-card')`, as B-37 called for. A filter test shouldn't fail because the card changed colour or nesting — and it would have kept passing here by luck, since the new shell happens to keep that class.

## Verification

- `npm run typecheck`, `npm run build` — clean
- `npx eslint` on all touched files — **0 errors** (14 warnings, pre-existing)
- `npm run smoke` — **139/139**
- **Before/after screenshots of all three surfaces at 1280 and 375**, captured by stashing `src/` to shoot the baseline. Visually a no-op apart from the three drifts above, which are fixes.

That last check is the one that matters for a refactor whose whole claim is "nothing should change" — the tests can't tell you a card started cropping its thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)