### PR TITLE
B-38 [from feedback]: make Z readable next to Q and X

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -150,21 +150,6 @@ the play in the library (and vice versa via the play description).
 Library grows on autopilot; blog↔library interlinking compounds SEO.
 Requires B-31's generation/thumbnail tooling to exist first.
 
-### B-38 · [from feedback] Default roster colors: Q/X/Z read too similar
-A coach reported the default player-icon colors for Q, X, and Z are too
-close to tell apart at a glance, and asked for a default yellow. Current
-offense defaults in `src/components/designer/rosters.ts`: Q is blue
-(`#3B82F6`), X is purple (`#8B5CF6`), Z is indigo (`#6366F1`) — all three
-sit in the same blue-violet hue band. (A is already yellow, `#F59E0B`, so
-the ask is really "give X or Z a color further from Q's," not "add yellow
-from scratch.") Coaches can already override chip colors themselves via
-the saved-toolbar-rosters feature (2026-08-06), so this is a defaults-only
-polish, not a missing capability — low priority, but a real contrast gap
-for anyone using the stock roster. Fix is a one- or two-line color swap in
-`DEFAULT_ROSTERS`; flagging for a human to pick the replacement hue(s)
-rather than a script guessing, since it's a shared visual token every
-offense roster inherits.
-
 ### B-36 · "Vs. Defense" follow-ups
 The read-only `/vs?play=<id>` view ships offense+defense overlay, defense
 cycling, per-matchup notes, export, and (as of the item below) a community
@@ -193,7 +178,10 @@ Fixed by polling the bridge instead of snapshotting it.
 React's render queue whenever the value it reports is set from an effect.
 Poll it, or assert against the DOM.
 
-### B-38 · Touch-target sweep (`.tap-target`)
+### B-51 · Touch-target sweep (`.tap-target`)
+*(Was filed as a second B-38 on 2026-08-12, colliding with the feedback-filed
+item of that number above. Renumbered 2026-08-14 — the feedback routine's
+entry keeps B-38, since its PR references it.)*
 PR #67 added a `.tap-target` utility gated on `@media (pointer: coarse)`, so
 raising a hit area costs nothing on desktop, and applied it to the
 destructive/primary controls under ~28px. ~25 controls remain at 26-36px:
@@ -203,20 +191,6 @@ pill (`PlayDesigner.tsx:623/630/638`, 28px), filter pills
 (`PostList.tsx:118`), `PlaysPage`'s `CARD_ACTION` (36px), admin buttons,
 `PlaybooksPage.tsx:1722`'s 28px drag grip (the only reorder affordance).
 Reference: 44pt iOS / 48dp Android.
-
-### B-39 · Flex rows that can't wrap (measured overflow)
-`/playbooks` **actually scrolls sideways on every phone** — 458px of content in
-a 375px viewport, from the non-wrapping cluster at `PlaybooksPage.tsx:1198`
-(tab pill + New Play + New Playbook = 442px). Measured 2026-08-12 at 375/390/430.
-Same shape elsewhere: `PlaysPage.tsx:349` header and `:385` type filters
-(the latter inside an `overflow-hidden` panel, so there's no scroll escape),
-`AdminDashboard.tsx:156` tabs (also clipped — "Moderation" is unreachable on a
-phone), `TimeRangeSelector.tsx:19`, `AccountSettings.tsx:342` (where the only
-Save Changes button lives), `PlayLibrary.tsx:311`, `Hero.tsx:80`.
-Every **grid** in the app already collapses correctly — the layout failures are
-all flex rows missing `flex-wrap`. Add a guard asserting
-`documentElement.scrollWidth <= clientWidth` per route; that's how this was
-found.
 
 ### B-40 · Designer touch tuning
 Icon tap targets are 34-37px and route lines 28px, both below the 44px floor,
@@ -296,6 +270,43 @@ renders text, so images/markdown don't render at all. `p-8` inside `px-4`
 leaves a 279px column on a 375px phone.
 
 ## Done
+
+- **2026-08-14 · B-38 [from feedback]: default roster colors Q/X/Z read too
+  similar** — the first backlog item filed by the feedback triage routine to be
+  worked. A coach reported Q, X and Z were indistinguishable at a glance, and
+  they were: blue 217°, indigo 239°, purple 258°, the whole trio inside a 41°
+  band with adjacent pairs only 19-22° apart. **Z: indigo `#6366F1` → lime
+  `#84CC16`**, which sits at 82° in the one wide gap this palette has (between
+  A's amber at 38° and R's green at 160°), clearing every other chip by at
+  least 78°. Changed Z rather than Q or X to keep the conventional blue QB.
+  Applied to **both** `rosters.ts` (toolbar chips) and `formations.ts`'s
+  separate `C` map (`SLOT`), which had the identical trio — a coach places the
+  same receiver by stamping a formation *or* tapping a chip, and getting a
+  different color depending on the route taken would be worse than either color
+  alone.
+  The coach also asked for "a default yellow"; A is already amber `#F59E0B`, so
+  the real ask was separation, not a missing color.
+  Existing saved rosters are untouched: `resolveRoster()` merges overrides by
+  stable chip id, so anyone who already customised Z keeps their choice, and
+  saved plays store their own colors.
+  **Tests assert the property, not the hex** — pairwise hue separation across
+  the whole offense roster with a 25° floor (plus 40° for the reported trio),
+  so any future palette change that re-crowds the band is caught. Verified it
+  fails on the old colors, reporting `Q/Z 22°` and `X/Z 20°`. A second test
+  guards the two files against drifting apart again.
+
+- **2026-08-14 · B-39: Stop pages scrolling sideways on a phone** (PR #73) —
+  `/playbooks` put 458px of content in a 375px viewport, so the whole document
+  scrolled horizontally on every phone, from one non-wrapping cluster
+  (`PlaybooksPage.tsx:1198`, 442px of the 458). Seven other rows shared the
+  shape and two sat inside `overflow-hidden` panels, so their overrun was
+  *clipped* rather than scrollable — which is how `/admin` lost its
+  "Moderation" tab and `/plays` lost its "special teams" filter on a phone.
+  Fixed together with `flex-wrap`; every grid in the app already collapsed
+  correctly, so the change was entirely additive. Guard added asserting
+  `documentElement.scrollWidth <= clientWidth` across seven routes at 375px,
+  and verified it fails without the fix. (Moved to Done 2026-08-14 — it shipped
+  on the 12th and was left in Up next by mistake.)
 
 - **2026-08-14 · B-37 (2): one shared play card** — the second and larger half
   of B-37. My Plays, the Community library and the playbook detail grid each

--- a/src/components/designer/formations.ts
+++ b/src/components/designer/formations.ts
@@ -25,7 +25,13 @@ const LINE_Y = yBehindLOS(0);
 // Colors reuse the app's existing player-icon palette (PlayerToolbar.tsx /
 // PlayerStyleEditor.tsx's SWATCH_COLORS) so stamped icons look like ones a
 // coach placed by hand, not a separate visual language.
-const C = { QB: '#3B82F6', RB: '#10B981', FB: '#F59E0B', WR: '#8B5CF6', TE: '#EC4899', OL: '#000000', SLOT: '#6366F1' };
+// SLOT is lime rather than the indigo it used to be, matching the Z chip in
+// rosters.ts — indigo sat between QB blue and WR purple and was reported as
+// unreadable at a glance. Keep these two files in step: a coach can place the
+// same receiver by stamping a formation or by tapping a chip, and getting a
+// different color depending on which route they took is worse than either
+// color alone.
+const C = { QB: '#3B82F6', RB: '#10B981', FB: '#F59E0B', WR: '#8B5CF6', TE: '#EC4899', OL: '#000000', SLOT: '#84CC16' };
 
 const ol = (x: number, letter: string): PlayerIcon => ({ x, y: LINE_Y, letter, color: C.OL, shape: 'square' });
 const wr = (x: number, letter: string, y = LINE_Y, color = C.WR): PlayerIcon => ({ x, y, letter, color, shape: 'circle' });

--- a/src/components/designer/rosters.ts
+++ b/src/components/designer/rosters.ts
@@ -31,7 +31,14 @@ export const DEFAULT_ROSTERS: Record<PlayType, RosterChip[]> = {
     { id: 'off-c', letter: 'C', color: '#000000', shape: 'square' }, // Black — the center
     { id: 'off-x', letter: 'X', color: '#8B5CF6', shape: 'circle' }, // Purple
     { id: 'off-y', letter: 'Y', color: '#EC4899', shape: 'circle' }, // Pink
-    { id: 'off-z', letter: 'Z', color: '#6366F1', shape: 'circle' }, // Indigo
+    // Lime, not the indigo it used to be: a coach reported Q/X/Z were
+    // indistinguishable at a glance, and they were — blue 217°, indigo 239°,
+    // purple 258°, all inside a 41° band. Lime sits at 82°, in the one wide
+    // gap this palette has (between A's amber at 38° and R's green at 160°),
+    // so it clears every other chip by at least 78°. Changing Z rather than
+    // Q or X keeps the conventional blue QB and leaves X/Y as the pair a
+    // coach is least likely to confuse, since they're rarely adjacent.
+    { id: 'off-z', letter: 'Z', color: '#84CC16', shape: 'circle' }, // Lime
   ],
   // Defensive Line, Linebacker, Cornerback, Safety. "CB" (not "C") since "C"
   // is already the offensive Center above.

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, CDPSession } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { zoneConnectorVisible } from '../../src/lib/renderPlayScene';
+import { DEFAULT_ROSTERS } from '../../src/components/designer/rosters';
 
 // Mocked-session tests must seed localStorage under the same key the real
 // supabase-js client reads (`sb-<project-ref>-auth-token`, derived from
@@ -3199,6 +3200,73 @@ async function withRoster(page: Page, customRoster: unknown) {
   });
   return () => writes;
 }
+
+/** Hue angle (0-360) of a #rrggbb color. Hue alone is the right measure here:
+ *  these chips are all similar saturation and lightness by construction, so
+ *  what makes two of them hard to tell apart on a field is how close their
+ *  hues are. */
+function hueOf(hex: string): number {
+  const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return -1; // achromatic (the black center) — no hue to compare
+  const d = max - min;
+  const h =
+    max === r ? ((g - b) / d) % 6 :
+    max === g ? (b - r) / d + 2 :
+                (r - g) / d + 4;
+  return ((h * 60) % 360 + 360) % 360;
+}
+
+/** Shortest distance between two hue angles, accounting for the wrap at 360. */
+const hueGap = (a: number, b: number) => {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+};
+
+test('default offense roster colors are far enough apart to tell apart', async () => {
+  // From real user feedback: a coach reported Q, X and Z were indistinguishable
+  // at a glance. They were — blue 217°, indigo 239°, purple 258°, the whole
+  // trio inside a 41° band, with adjacent pairs only 19-22° apart.
+  //
+  // This asserts the property rather than the hex values, so a future palette
+  // change can move any chip it likes and still be caught if it re-crowds the
+  // band.
+  const offense = DEFAULT_ROSTERS.offense
+    .map((c) => ({ letter: c.letter, hue: hueOf(c.color) }))
+    .filter((c) => c.hue >= 0); // drops the black center
+
+  const pairs = offense.flatMap((a, i) =>
+    offense.slice(i + 1).map((b) => ({ pair: `${a.letter}/${b.letter}`, gap: hueGap(a.hue, b.hue) })),
+  );
+
+  // 25° floor for every pair. The tightest today is Y/B at 30° (pink vs red),
+  // which predates the report and reads fine on the field; before this fix the
+  // tightest was Z/X at 19°.
+  const tooClose = pairs.filter((p) => p.gap < 25);
+  expect(tooClose.map((p) => `${p.pair} ${Math.round(p.gap)}°`)).toEqual([]);
+
+  // And the specific trio from the report gets a wider berth.
+  for (const name of ['Q/X', 'Q/Z', 'X/Z']) {
+    const found = pairs.find((p) => p.pair === name)!;
+    expect(Math.round(found.gap), `${name} hue gap`).toBeGreaterThanOrEqual(40);
+  }
+});
+
+test('a stamped formation uses the same receiver colors as the toolbar chips', async ({ page }) => {
+  // formations.ts keeps its own color map, so the two can drift — and a coach
+  // placing the same receiver by stamping vs. tapping a chip getting different
+  // colors is worse than either color alone.
+  await openDesigner(page);
+  await btn(page, 'Formation templates').click();
+  await realClick(page, page.getByRole('button', { name: 'Spread' }));
+
+  const icons = (await canvasState(page)).playerIcons;
+  const rosterColors = new Set(DEFAULT_ROSTERS.offense.map((c) => c.color.toUpperCase()));
+  const stamped = [...new Set(icons.map((i) => i.color.toUpperCase()))];
+  const strangers = stamped.filter((c) => !rosterColors.has(c));
+  expect(strangers, 'formation colors not present in the offense roster').toEqual([]);
+});
 
 test('saved roster: a customized chip replaces the built-in one', async ({ page }) => {
   await withRoster(page, {


### PR DESCRIPTION
The first backlog item filed by the feedback triage routine to actually get worked.

## The report was right, and measurably so

A coach said Q, X and Z were indistinguishable at a glance. Hue angles:

```
217°  Q  blue    #3B82F6
239°  Z  indigo  #6366F1     Q/Z = 22° apart
258°  X  purple  #8B5CF6     X/Z = 20° apart
```

The whole trio inside a 41° band.

## The change

**Z: indigo `#6366F1` → lime `#84CC16`.**

Lime sits at 82°, in the one wide gap this palette has — between A's amber at 38° and R's green at 160° — so it clears every other chip by at least 78°. Changing Z rather than Q or X keeps the conventional blue QB.

Also updated `formations.ts`, which keeps its own colour map with the identical QB-blue/WR-purple/SLOT-indigo trio. **Narrow in practice** — `C.SLOT` is used exactly once, by Wing-T's wingback — but the two files shouldn't drift, since a coach places the same receiver by stamping a formation *or* by tapping a chip, and getting a different colour depending which route they took is worse than either colour alone.

The coach also asked for "a default yellow". A is already amber `#F59E0B`, so the real ask was separation, not a missing colour.

**Existing saved rosters are untouched.** `resolveRoster()` merges overrides by stable chip id, so anyone who already recoloured Z keeps their choice, and saved plays store their own colours.

## The tests assert the property, not the hex

Pairwise hue separation across the whole offense roster, with a 25° floor and 40° for the reported trio. A future palette change can move any chip it likes and still get caught if it re-crowds the band.

**Verified they fail on the old palette:**

```
+   "Q/Z 22°",
+   "X/Z 20°",
```

A second test guards `rosters.ts` and `formations.ts` against drifting apart again. That one passes either way — it's a guard against future drift, not a regression test for this bug.

## Housekeeping in the same file — both mine to fix

- **Renumbered my touch-target sweep B-38 → B-51.** It collided with this item: the feedback routine filed its B-38 first and references the number in its PR, so it keeps it.
- **Moved B-39 to Done.** It shipped in PR #73 on the 12th and I left it sitting in Up next.

## Verification

typecheck + build clean, eslint 0 errors, smoke **141/141**, and the chips screenshotted before/after. Z is now unmistakable next to Q — and reads as distinct from R's emerald despite both being greens, which was the one risk worth eyeballing rather than trusting the arithmetic on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)