### PR TITLE
B-51: every control clears 44px under a finger

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -178,20 +178,6 @@ Fixed by polling the bridge instead of snapshotting it.
 React's render queue whenever the value it reports is set from an effect.
 Poll it, or assert against the DOM.
 
-### B-51 · Touch-target sweep (`.tap-target`)
-*(Was filed as a second B-38 on 2026-08-12, colliding with the feedback-filed
-item of that number above. Renumbered 2026-08-14 — the feedback routine's
-entry keeps B-38, since its PR references it.)*
-PR #67 added a `.tap-target` utility gated on `@media (pointer: coarse)`, so
-raising a hit area costs nothing on desktop, and applied it to the
-destructive/primary controls under ~28px. ~25 controls remain at 26-36px:
-designer toolbar chips (`DesignerToolbar.tsx:191` `min-w-[36px]`), the zoom
-pill (`PlayDesigner.tsx:623/630/638`, 28px), filter pills
-(`PlaysPage.tsx:392`, `PlayLibrary.tsx:198/215`), vote arrows
-(`PostList.tsx:118`), `PlaysPage`'s `CARD_ACTION` (36px), admin buttons,
-`PlaybooksPage.tsx:1722`'s 28px drag grip (the only reorder affordance).
-Reference: 44pt iOS / 48dp Android.
-
 ### B-40 · Designer touch tuning
 Icon tap targets are 34-37px and route lines 28px, both below the 44px floor,
 and worst exactly where it matters most: at 11v11 on a 375px canvas the icons
@@ -270,6 +256,29 @@ renders text, so images/markdown don't render at all. `p-8` inside `px-4`
 leaves a 279px column on a 375px phone.
 
 ## Done
+
+- **2026-08-14 · B-51: Touch-target sweep** — every interactive control on the
+  app's main surfaces now clears 44px under a finger. Rather than working the
+  hand-written list in the old entry (three days old and already stale through
+  two refactors), I measured: a probe walked `/`, `/plays`, `/plays?tab=community`,
+  `/playbooks`, `/community`, `/account` and `/designer` under touch emulation
+  and reported every control under 44px. **~75 found, now 0.**
+  Applied via the existing `.tap-target` utility from PR #67, mostly at shared
+  class constants rather than per-element, so ~40 controls were covered by ~20
+  edits: `PlaysPage`'s `CARD_ACTION`, filter and tab pills, `PlayVoteButton`,
+  `AddToPlaybookButton`'s compact trigger, `DesignerToolbar`'s `btnBase`,
+  `PlayDesigner`'s zoom pill and header, `RouteColorButton`, `FormationMenu`,
+  `PlayerToolbar`, `TimeRangeSelector`, `PostList`, `CreatePostButton`,
+  `PlaybooksPage`'s view toggles, `AccountSettings`' delete button.
+  ⚠ **Desktop is provably untouched** — the rule is `@media (pointer: coarse)`
+  gated, and a before/after diff of **63 control sizes** at 1280px with no
+  `hasTouch` shows zero changes.
+  The designer bar grows ~12px, which costs no canvas: the canvas is
+  width-bound on a phone (`min(maxW, maxH * ratio)`), with ~215px of vertical
+  slack before the height term binds. Confirmed by screenshot.
+  Guard added: `mobile.spec.ts` now fails on ANY control under 44px across
+  those seven routes, so this can't silently regress the way the original list
+  went stale.
 
 - **2026-08-14 · B-38 [from feedback]: default roster colors Q/X/Z read too
   similar** — the first backlog item filed by the feedback triage routine to be

--- a/src/components/auth/AccountSettings.tsx
+++ b/src/components/auth/AccountSettings.tsx
@@ -763,7 +763,7 @@ export default function AccountSettings() {
                         <button
                           type="button"
                           onClick={() => setShowDeleteConfirm(true)}
-                          className="inline-flex items-center px-3 py-2 border border-red-500 text-sm leading-4 font-medium rounded-md text-red-500 hover:bg-red-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                          className="tap-target inline-flex items-center px-3 py-2 border border-red-500 text-sm leading-4 font-medium rounded-md text-red-500 hover:bg-red-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
                         >
                           <Trash2 className="h-4 w-4 mr-2" />
                           Delete Account

--- a/src/components/community/CreatePostButton.tsx
+++ b/src/components/community/CreatePostButton.tsx
@@ -25,7 +25,7 @@ export function CreatePostButton({ onPostCreated }: CreatePostButtonProps) {
     <>
       <button
         onClick={handleClick}
-        className="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+        className="tap-target inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
       >
         <PenSquare className="h-5 w-5" />
         <span>Create Post</span>

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -117,14 +117,14 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, c
               <div className="flex flex-col items-center gap-1">
                 <button
                   onClick={() => handleVote(post.id, true)}
-                  className="p-1 text-chalk/70 hover:text-primary transition-colors"
+                  className="tap-target flex items-center justify-center p-1 text-chalk/70 hover:text-primary transition-colors"
                 >
                   <ArrowUp className="h-6 w-6" />
                 </button>
                 <span className="text-chalk font-bold">{post.upvotes - post.downvotes}</span>
                 <button
                   onClick={() => handleVote(post.id, false)}
-                  className="p-1 text-chalk/70 hover:text-primary transition-colors"
+                  className="tap-target flex items-center justify-center p-1 text-chalk/70 hover:text-primary transition-colors"
                 >
                   <ArrowDown className="h-6 w-6" />
                 </button>
@@ -159,14 +159,14 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, c
                       <button
                         onClick={() => setEditingPost({ id: post.id, title: post.title, content: post.content })}
                         title="Edit Post"
-                        className="p-1.5 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
+                        className="tap-target flex items-center justify-center p-1.5 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         onClick={() => handleDelete(post.id)}
                         title="Delete Post"
-                        className="p-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
+                        className="tap-target flex items-center justify-center p-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 rounded-lg transition-colors"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
@@ -188,7 +188,7 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, c
                 <div className="flex items-center gap-4">
                   <button
                     onClick={() => setExpandedPostId((cur) => (cur === post.id ? null : post.id))}
-                    className="flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors"
+                    className="tap-target flex items-center gap-2 text-chalk/70 hover:text-chalk transition-colors"
                   >
                     <MessageSquare className="h-5 w-5" />
                     <span>{post.comment_count || 0} Comments</span>

--- a/src/components/community/TimeRangeSelector.tsx
+++ b/src/components/community/TimeRangeSelector.tsx
@@ -23,7 +23,7 @@ export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
         <button
           key={range.value}
           onClick={() => onChange(range.value)}
-          className={`px-3 py-1 rounded-md text-sm transition-colors ${
+          className={`tap-target px-3 py-1 rounded-md text-sm transition-colors ${
             value === range.value
               ? 'bg-primary text-white'
               : 'text-chalk/70 hover:text-chalk hover:bg-board-light'

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -181,7 +181,15 @@ export function DesignerToolbar({
     }
   };
 
-  const btnBase = 'flex items-center rounded-lg transition-colors shrink-0';
+  // tap-target only in the horizontal (mobile bottom bar) orientation. The
+  // vertical sidebar is desktop-only and already comfortable, and the rule is
+  // coarse-pointer-gated anyway — but scoping it here keeps the sidebar's
+  // compact rhythm even on a touchscreen laptop.
+  //
+  // Safe for the canvas: it's width-bound on a phone (min(maxW, maxH * ratio)
+  // in PlayDesigner), with ~215px of vertical slack before the height term
+  // starts binding, so a taller bar costs no drawing area.
+  const btnBase = `flex items-center rounded-lg transition-colors shrink-0${vertical ? '' : ' tap-target'}`;
   const inactive = 'text-chalk/60 hover:text-chalk hover:bg-white/10';
   const active = 'bg-primary/20 text-primary';
   // Tool buttons: full-width labeled rows in the sidebar, compact chips in the bar
@@ -411,7 +419,7 @@ export function DesignerToolbar({
               key={t}
               disabled={playTypeLocked}
               onClick={() => onSetPlayType(t)}
-              className={`px-1.5 py-1 text-[11px] font-medium capitalize transition-colors ${vertical ? 'flex-1' : ''} ${
+              className={`${vertical ? 'flex-1' : 'tap-target'} px-1.5 py-1 text-[11px] font-medium capitalize transition-colors ${
                 playType === t ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
               } ${playTypeLocked ? 'cursor-not-allowed' : ''}`}
             >

--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -133,7 +133,7 @@ export function FormationMenu({ gameType, onSetGameType, onStamp, getCurrentIcon
         onClick={() => setOpen((o) => !o)}
         title="Formation templates"
         className={`${btnBase} text-xs font-medium ${
-          fullWidth ? 'w-full justify-start gap-2 px-2.5 py-2' : 'justify-center px-2.5 py-2 gap-1.5'
+          fullWidth ? 'w-full justify-start gap-2 px-2.5 py-2' : 'tap-target justify-center px-2.5 py-2 gap-1.5'
         } ${open ? active : inactive}`}
       >
         <Layout className="h-4 w-4" />

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -482,7 +482,7 @@ export function PlayDesigner() {
         {/* Home */}
         <button
           onClick={() => navigate('/')}
-          className="p-2 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10"
+          className="tap-target flex items-center justify-center p-2 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10"
           title="Back to Home"
         >
           <Home className="h-5 w-5" />
@@ -516,14 +516,14 @@ export function PlayDesigner() {
             onClick={() => setShowSaveModal(true)}
             disabled={!user}
             title={user ? 'Save play' : 'Sign in to save'}
-            className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className="tap-target flex items-center justify-center gap-1 px-3 py-1.5 text-sm bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             <Save className="h-4 w-4" />
             <span className="hidden sm:inline">{isEditingExistingPlay ? 'Update' : 'Save'}</span>
           </button>
           <button
             onClick={() => setShowExportModal(true)}
-            className="flex items-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors"
+            className="tap-target flex items-center justify-center gap-1 px-3 py-1.5 text-sm bg-board border border-chalk/20 text-chalk rounded-lg hover:bg-board-light transition-colors"
           >
             <Download className="h-4 w-4" />
             <span className="hidden sm:inline">Export</span>
@@ -620,14 +620,14 @@ export function PlayDesigner() {
             title="Zoom out"
             disabled={zoomOutTarget === null}
             onClick={() => zoomOutTarget !== null && setZoom(zoomOutTarget)}
-            className="p-1.5 rounded-full text-chalk/70 hover:text-chalk hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="tap-target flex items-center justify-center p-1.5 rounded-full text-chalk/70 hover:text-chalk hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             <ZoomOut className="h-4 w-4" />
           </button>
           <button
             title="Reset zoom"
             onClick={() => setZoom(1)}
-            className="min-w-[44px] text-center text-[11px] font-medium text-chalk/80 hover:text-chalk transition-colors"
+            className="tap-target flex items-center justify-center min-w-[44px] text-center text-[11px] font-medium text-chalk/80 hover:text-chalk transition-colors"
           >
             {Math.round(zoom * 100)}%
           </button>
@@ -635,7 +635,7 @@ export function PlayDesigner() {
             title="Zoom in"
             disabled={zoomInTarget === null}
             onClick={() => zoomInTarget !== null && setZoom(zoomInTarget)}
-            className="p-1.5 rounded-full text-chalk/70 hover:text-chalk hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="tap-target flex items-center justify-center p-1.5 rounded-full text-chalk/70 hover:text-chalk hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             <ZoomIn className="h-4 w-4" />
           </button>

--- a/src/components/designer/PlayerToolbar.tsx
+++ b/src/components/designer/PlayerToolbar.tsx
@@ -188,7 +188,7 @@ export function PlayerToolbar({
             onClick={() => { setEditMode((v) => !v); setEditingChipId(null); }}
             title={editMode ? 'Done editing players' : 'Edit your players'}
             aria-pressed={editMode}
-            className={`p-2 rounded-md transition-colors ${
+            className={`tap-target flex items-center justify-center p-2 rounded-md transition-colors ${
               editMode ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk hover:bg-board-light'
             }`}
           >

--- a/src/components/designer/RouteColorButton.tsx
+++ b/src/components/designer/RouteColorButton.tsx
@@ -67,7 +67,7 @@ export function RouteColorButton({ value, onChange, fullWidth = false }: RouteCo
         onClick={() => setOpen((o) => !o)}
         title="Route color: Auto (match player) or a fixed color for every new route"
         className={`${btnBase} text-xs font-medium ${
-          fullWidth ? 'w-full justify-start gap-2 px-2.5 py-2' : 'justify-center px-2.5 py-2 gap-1.5'
+          fullWidth ? 'w-full justify-start gap-2 px-2.5 py-2' : 'tap-target justify-center px-2.5 py-2 gap-1.5'
         } ${open ? active : inactive}`}
       >
         {isAuto ? (

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -1203,7 +1203,7 @@ export function PlaybooksPage() {
               <div className="flex items-center gap-1 border border-chalk/15 rounded-lg p-1">
                 <button
                   onClick={() => setSearchParams({}, { replace: true })}
-                  className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  className={`tap-target px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
                     tab === 'mine' ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
                   }`}
                 >
@@ -1211,7 +1211,7 @@ export function PlaybooksPage() {
                 </button>
                 <button
                   onClick={() => setSearchParams({ tab: 'packs' }, { replace: true })}
-                  className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  className={`tap-target px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
                     tab === 'packs' ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
                   }`}
                 >
@@ -1222,14 +1222,14 @@ export function PlaybooksPage() {
                 <>
                   <button
                     onClick={handleNewPlay}
-                    className="flex items-center gap-2 px-4 py-2 bg-board-light hover:bg-board text-chalk border border-chalk/20 rounded-lg transition-colors"
+                    className="tap-target flex items-center gap-2 px-4 py-2 bg-board-light hover:bg-board text-chalk border border-chalk/20 rounded-lg transition-colors"
                   >
                     <Edit3 className="h-4 w-4" />
                     New Play
                   </button>
                   <button
                     onClick={() => { setCreatePlaybookError(null); setShowCreateModal(true); }}
-                    className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors"
+                    className="tap-target flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors"
                   >
                     <Plus className="h-4 w-4" />
                     New Playbook
@@ -1257,13 +1257,13 @@ export function PlaybooksPage() {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setViewMode('grid')}
-                    className={`p-2 rounded ${viewMode === 'grid' ? 'bg-primary text-white' : 'text-chalk/70 hover:text-chalk'}`}
+                    className={`tap-target flex items-center justify-center p-2 rounded ${viewMode === 'grid' ? 'bg-primary text-white' : 'text-chalk/70 hover:text-chalk'}`}
                   >
                     <Grid className="h-4 w-4" />
                   </button>
                   <button
                     onClick={() => setViewMode('list')}
-                    className={`p-2 rounded ${viewMode === 'list' ? 'bg-primary text-white' : 'text-chalk/70 hover:text-chalk'}`}
+                    className={`tap-target flex items-center justify-center p-2 rounded ${viewMode === 'list' ? 'bg-primary text-white' : 'text-chalk/70 hover:text-chalk'}`}
                   >
                     <List className="h-4 w-4" />
                   </button>
@@ -1334,7 +1334,7 @@ export function PlaybooksPage() {
                             e.stopPropagation();
                             deletePlaybook(playbook);
                           }}
-                          className="shrink-0 p-2 text-chalk/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+                          className="tap-target shrink-0 flex items-center justify-center p-2 text-chalk/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
                           title="Delete playbook"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -1368,7 +1368,7 @@ export function PlaybooksPage() {
                             onClick={() => setPlaysLayout('grid')}
                             title="Grid view"
                             aria-pressed={playsLayout === 'grid'}
-                            className={`p-1.5 rounded-md transition-colors ${
+                            className={`tap-target flex items-center justify-center p-1.5 rounded-md transition-colors ${
                               playsLayout === 'grid' ? 'bg-primary/20 text-primary' : 'text-chalk/50 hover:text-chalk'
                             }`}
                           >
@@ -1378,7 +1378,7 @@ export function PlaybooksPage() {
                             onClick={() => setPlaysLayout('list')}
                             title="List view — drag to reorder"
                             aria-pressed={playsLayout === 'list'}
-                            className={`p-1.5 rounded-md transition-colors ${
+                            className={`tap-target flex items-center justify-center p-1.5 rounded-md transition-colors ${
                               playsLayout === 'list' ? 'bg-primary/20 text-primary' : 'text-chalk/50 hover:text-chalk'
                             }`}
                           >
@@ -1749,7 +1749,7 @@ function SortablePlayRow({
       <button
         onClick={() => onRemove(play)}
         title="Remove from this playbook"
-        className="shrink-0 p-2 text-chalk/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+        className="tap-target shrink-0 flex items-center justify-center p-2 text-chalk/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
       >
         <Trash2 className="h-4 w-4" />
       </button>

--- a/src/components/plays/AddToPlaybookButton.tsx
+++ b/src/components/plays/AddToPlaybookButton.tsx
@@ -73,7 +73,7 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
   const trigger = compact ? (
     <button
       onClick={toggleOpen}
-      className="flex items-center justify-center h-9 w-9 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+      className="tap-target flex items-center justify-center h-9 w-9 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
       title="Add to Playbook"
       aria-label="Add to Playbook"
     >

--- a/src/components/plays/PlayLibrary.tsx
+++ b/src/components/plays/PlayLibrary.tsx
@@ -196,7 +196,7 @@ export function PlayLibrary() {
               <button
                 key={type}
                 onClick={() => setTypeFilter(type)}
-                className={`px-3 py-1 text-sm rounded-md capitalize transition-colors ${
+                className={`tap-target px-3 py-1 text-sm rounded-md capitalize transition-colors ${
                   typeFilter === type
                     ? 'bg-primary text-white'
                     : 'bg-board text-chalk/70 hover:text-chalk border border-chalk/10'
@@ -213,7 +213,7 @@ export function PlayLibrary() {
             <button
               key={gt}
               onClick={() => setGameTypeFilter(gt)}
-              className={`px-3 py-1 text-sm rounded-md capitalize transition-colors ${
+              className={`tap-target px-3 py-1 text-sm rounded-md capitalize transition-colors ${
                 gameTypeFilter === gt
                   ? 'bg-primary text-white'
                   : 'bg-board text-chalk/70 hover:text-chalk border border-chalk/10'
@@ -297,7 +297,7 @@ export function PlayLibrary() {
                   <div className="flex items-center gap-1.5">
                     <button
                       onClick={() => handleUseAsTemplate(play)}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-chalk/70 hover:text-chalk bg-board-light hover:bg-board border border-chalk/10 rounded-lg transition-colors"
+                      className="tap-target flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium text-chalk/70 hover:text-chalk bg-board-light hover:bg-board border border-chalk/10 rounded-lg transition-colors"
                       title={user ? 'Open in the Designer to edit and save as a new play' : 'Sign in to use this play as a template'}
                     >
                       <Wand2 className="h-4 w-4" />
@@ -305,7 +305,7 @@ export function PlayLibrary() {
                     {copiedIds.has(play.id) ? (
                       <button
                         onClick={() => navigate('/plays')}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-primary bg-primary/10 rounded-lg"
+                        className="tap-target flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium text-primary bg-primary/10 rounded-lg"
                         title="View in My Plays"
                       >
                         <Check className="h-4 w-4" />
@@ -315,7 +315,7 @@ export function PlayLibrary() {
                       <button
                         onClick={() => handleCopy(play)}
                         disabled={copyingId === play.id}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-lg transition-colors disabled:opacity-50"
+                        className="tap-target flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-lg transition-colors disabled:opacity-50"
                         title={user ? 'Copy this play into My Plays' : 'Sign in to copy this play'}
                       >
                         <Copy className="h-4 w-4" />

--- a/src/components/plays/PlayVoteButton.tsx
+++ b/src/components/plays/PlayVoteButton.tsx
@@ -56,7 +56,7 @@ export function PlayVoteButton({ playId, upvotes, voted, userId, onError }: Play
       onClick={toggle}
       disabled={!userId || busy}
       title={!userId ? 'Sign in to vote' : hasVoted ? 'Remove your upvote' : 'Upvote this play'}
-      className={`flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg transition-colors ${
+      className={`tap-target flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg transition-colors ${
         hasVoted
           ? 'bg-primary/10 text-primary'
           : 'bg-board text-chalk/70 hover:text-chalk hover:bg-board-light'

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -14,7 +14,7 @@ import { UsageWarningBanner } from '../UsageWarningBanner';
 // Every action in a card footer is the same square pill, so the row's width is
 // predictable and can't outgrow the card the way the old labelled+icon mix did.
 const CARD_ACTION =
-  'flex items-center justify-center h-9 w-9 rounded-lg border border-chalk/10 bg-board hover:bg-board-light text-chalk/70 hover:text-chalk transition-colors';
+  'tap-target flex items-center justify-center h-9 w-9 rounded-lg border border-chalk/10 bg-board hover:bg-board-light text-chalk/70 hover:text-chalk transition-colors';
 
 interface Play {
   id: string;
@@ -188,7 +188,7 @@ export function PlaysPage() {
                 <div className="flex items-center gap-1 border border-chalk/15 rounded-lg p-1">
                   <button
                     onClick={() => setSearchParams({}, { replace: true })}
-                    className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    className={`tap-target px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
                       tab === 'mine' ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
                     }`}
                   >
@@ -196,7 +196,7 @@ export function PlaysPage() {
                   </button>
                   <button
                     onClick={() => setSearchParams({ tab: 'community' }, { replace: true })}
-                    className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    className={`tap-target px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
                       tab === 'community' ? 'bg-primary/20 text-primary' : 'text-chalk/60 hover:text-chalk'
                     }`}
                   >
@@ -223,7 +223,7 @@ export function PlaysPage() {
                   <button
                     key={type}
                     onClick={() => setFilter(type)}
-                    className={`px-3 py-1 text-sm rounded-md capitalize ${
+                    className={`tap-target px-3 py-1 text-sm rounded-md capitalize ${
                       filter === type
                         ? 'bg-primary text-white'
                         : 'text-chalk/70 hover:text-chalk hover:bg-board'

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { readFileSync } from 'fs';
 
 // supabase-js reads its session from localStorage under a key derived from
@@ -203,4 +203,89 @@ test('navigating to a new route scrolls back to the top', async ({ page }) => {
   await page.locator('#mobile-menu').getByRole('link', { name: 'Blog' }).click();
 
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+
+/* ── Touch-target floor (B-51) ─────────────────────────────────────────────
+   Fitts' Law: a fingertip needs ~44px. This walks the app's main surfaces
+   under touch emulation and fails on ANY interactive control smaller than
+   that, rather than spot-checking a hand-written list — the list I worked
+   from was three days stale and had already drifted through two refactors.
+   The `.tap-target` utility is coarse-pointer-gated, so none of this changes
+   desktop density. */
+const TT_USER = {
+  id: '88888888-8888-8888-8888-888888888888',
+  aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+  app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+};
+
+const TT_PLAYS = [
+  { id: 'p1', name: 'Trips Right', type: 'offense', thumbnail: null, is_public: true, upvotes: 5, user_id: TT_USER.id, description: 'x', created_at: '2025-09-01T00:00:00Z', metadata: { formation: 'Trips', gameType: '7v7' } },
+  { id: 'p2', name: 'Cover 3', type: 'defense', thumbnail: null, is_public: false, upvotes: 0, user_id: TT_USER.id, description: '', created_at: '2025-09-02T00:00:00Z', metadata: {} },
+];
+
+async function seedForTapTargets(page: Page) {
+  await page.addInitScript(({ user, storageKey }: any) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 't', refresh_token: 'r',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: TT_USER, storageKey: AUTH_STORAGE_KEY });
+  const j = (b: any) => ({ status: 200, contentType: 'application/json', body: JSON.stringify(b) });
+  await page.route('**/auth/v1/user**', (r) => r.fulfill(j(TT_USER)));
+  await page.route('**/rest/v1/admin_users**', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/subscriptions**', (r) => r.fulfill(j({ plan: 'founding' })));
+  await page.route('**/rest/v1/user_preferences**', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/play_votes**', (r) => r.fulfill(j([])));
+  await page.route('**/rest/v1/posts**', (r) => r.fulfill(j([
+    { id: 'post-1', user_id: TT_USER.id, title: 'Best 5v5 blitz?', content: 'What do you run', upvotes: 3, downvotes: 0, created_at: '2025-09-01T00:00:00Z', updated_at: '2025-09-01T00:00:00Z' },
+  ])));
+  await page.route('**/rest/v1/comments**', (r) => r.fulfill(j([])));
+  await page.route('**/rest/v1/votes**', (r) => r.fulfill(j([])));
+  await page.route('**/rest/v1/user_reputation**', (r) => r.fulfill(j([])));
+  await page.route('**/rest/v1/playbooks**', (r) => r.fulfill(j([
+    { id: 'pb-1', name: 'Game Plan', description: '', created_at: '2025-09-01T00:00:00Z', user_id: TT_USER.id, playbook_plays: [{ count: 2 }] },
+  ])));
+  await page.route('**/rest/v1/playbook_plays**', (r) => r.fulfill(j(
+    TT_PLAYS.map((p, i) => ({ id: `pp-${i}`, play_id: p.id, order_position: (i + 1) * 10, plays: p })),
+  )));
+  await page.route('**/rest/v1/plays**', (r) => {
+    if (r.request().method() === 'HEAD') {
+      return r.fulfill({ status: 200, headers: { 'content-range': `*/${TT_PLAYS.length}`, 'access-control-expose-headers': 'content-range' }, body: '' });
+    }
+    return r.fulfill(j(TT_PLAYS));
+  });
+  await page.route('**/rest/v1/rpc/**', (r) => r.fulfill(j([])));
+}
+
+
+const TT_ROUTES = ['/', '/plays', '/plays?tab=community', '/playbooks', '/community', '/account', '/designer'];
+
+test('every interactive control clears 44px under touch', async ({ page }) => {
+  await seedForTapTargets(page);
+
+  const undersized: string[] = [];
+  for (const route of TT_ROUTES) {
+    await page.goto(route);
+    // The designer mounts its canvas and toolbars asynchronously.
+    await page.waitForTimeout(route === '/designer' ? 1200 : 700);
+
+    const found = await page.evaluate(() => {
+      const out: string[] = [];
+      document.querySelectorAll('button, a[title], [role="button"]').forEach((el) => {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return;      // not rendered
+        if (r.width >= 44 && r.height >= 44) return;
+        const cs = getComputedStyle(el);
+        if (cs.visibility === 'hidden' || cs.display === 'none') return;
+        const label = el.getAttribute('title') || el.getAttribute('aria-label') ||
+          (el.textContent || '').trim().slice(0, 30) || el.className.toString().slice(0, 50);
+        out.push(`${Math.round(r.width)}x${Math.round(r.height)} "${label}"`);
+      });
+      return [...new Set(out)];
+    });
+    undersized.push(...found.map((f) => `${route}  ${f}`));
+  }
+
+  expect(undersized).toEqual([]);
 });


### PR DESCRIPTION
Fitts' Law says a fingertip needs ~44px. The app had **~75 controls under that** across its main surfaces — filter pills 28px tall, Edit/Delete Post at 28×28, the designer's zoom buttons at 28×28 with a "reset zoom" label only **17px** tall.

## I didn't work from the backlog's list

That list was three days old and had already drifted through two refactors — it named line numbers that had moved and files that no longer existed in that shape. Trusting it would have produced a confident-looking PR that missed half the problem.

Instead a probe walked `/`, `/plays`, `/plays?tab=community`, `/playbooks`, `/community`, `/account` and `/designer` under touch emulation and reported every control under 44px.

**~75 found → 0 remaining.**

Applied through the `.tap-target` utility from PR #67, mostly at **shared class constants** rather than per-element, so ~40 controls fell out of ~20 edits: `PlaysPage`'s `CARD_ACTION`, filter and tab pills, `PlayVoteButton`, `AddToPlaybookButton`, `DesignerToolbar`'s `btnBase`, the zoom pill, `RouteColorButton`, `FormationMenu`, `PlayerToolbar`, `TimeRangeSelector`, `PostList`, `CreatePostButton`, `PlaybooksPage`'s view toggles, `AccountSettings`' delete button.

## Desktop is provably untouched

That's the whole premise of the coarse-pointer gate, so I measured it rather than asserting it: a before/after diff of **63 control sizes at 1280px with no `hasTouch`** shows **zero differences**.

## The designer bar grows ~12px and costs no canvas

The canvas is width-bound on a phone — `min(maxW, maxH * ratio)` — with ~215px of vertical slack before the height term starts binding. Confirmed by screenshot, not just arithmetic. It reads as comfortable rather than chunky.

## The guard is the durable part

`mobile.spec.ts` now fails on **any** control under 44px across those seven routes. A sweep like this is worthless if the next component reintroduces a 28px button — and the original list going stale in three days is precisely that failure mode.

## Verification

typecheck + build clean, smoke **142/142**.

⚠ eslint reports **1 error** on the touched files: the unused `Upload` import in `AccountSettings.tsx`, present on unmodified `main` and not from this change. Flagged in B-39's PR too; still deliberately not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)