### PR TITLE
[nightly] B-41: fix popover dismiss/positioning bugs on phones

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -178,17 +178,6 @@ Fixed by polling the bridge instead of snapshotting it.
 React's render queue whenever the value it reports is set from an effect.
 Poll it, or assert against the DOM.
 
-### B-41 · Popover bugs on phones
-`FormationMenu.tsx:78` and `RouteColorButton.tsx:49` register `scroll` with
-`capture: true`, so scrolling *inside* the popover (it's `max-h-[60vh]
-overflow-y-auto`) closes it; and `resize`→`close` closes it when the Android
-keyboard opens over its own `autoFocus` input, discarding the formation name.
-The three canvas popovers (`Canvas.tsx:1486-1538`) are 260-280px tall against a
-290px phone canvas, so they clamp to cover the very icon being edited, and
-their flip is canvas-relative rather than viewport-relative — it breaks while
-zoomed. `AddToPlaybookButton.tsx:247` is `max-h-80 overflow-hidden` (not
-`-auto`), silently truncating a long playbook list with no way to scroll.
-
 ### B-42 · Admin on mobile
 `AdminDashboard.tsx:242` is the app's only table. It has an `overflow-x-auto`
 wrapper but the `<table>` is `w-full` with no `min-w-*`, so it compresses to
@@ -245,6 +234,57 @@ renders text, so images/markdown don't render at all. `p-8` inside `px-4`
 leaves a 279px column on a 375px phone.
 
 ## Done
+
+- **2026-08-16 · B-41: Popover bugs on phones** — four independent fixes, all
+  in the same family (popovers dismissing or mispositioning themselves):
+  **Scroll-inside-closes-it:** `FormationMenu.tsx` and `RouteColorButton.tsx`
+  register `scroll` on `window` with `capture: true` so a page scroll behind
+  the popover closes it — but scroll events don't bubble, and a capture-phase
+  window listener still sees them fire on their real target, so scrolling
+  *inside* the popover's own `overflow-y-auto` list was indistinguishable
+  from the page scrolling and closed the very list being scrolled. Fixed by
+  checking the event target against a ref on the popover content before
+  treating it as an outside scroll.
+  **Resize-discards-input:** the same components' `resize`→close handler
+  fired when a mobile on-screen keyboard opened over the popover's own input
+  (e.g. the "save formation" name field), silently discarding whatever the
+  coach had just typed. Fixed by skipping the close (repositioning instead)
+  while `document.activeElement` is inside the popover.
+  **Canvas popovers covering the icon they edit:** the three canvas-anchored
+  popovers (icon style, route color, text box — `Canvas.tsx`) clamped and
+  flipped against the canvas's own local coordinate space, not the real
+  viewport. On a phone the canvas renders ~290px tall (it's width-bound, not
+  height-bound — see `PlayDesigner.tsx`'s letterboxing), shorter than the
+  260-280px popovers, so neither the "below" nor "above" branch had room and
+  the fallback clamp landed the popover directly on top of the icon being
+  edited. It also broke while zoomed, since the canvas's local coordinate
+  space balloons past the visible screen at higher zoom levels. Fixed by
+  portaling all three to `<body>` (`position: fixed`) and clamping/flipping
+  against `window.innerWidth`/`innerHeight` via the canvas's real
+  `getBoundingClientRect()`, the same pattern `FormationMenu`/
+  `RouteColorButton` already used for the toolbar popovers.
+  **Playbook list truncation:** `AddToPlaybookButton.tsx`'s dropdown wrapper
+  was `max-h-80 overflow-hidden` (not `-auto`), so content past 320px was
+  clipped instead of scrollable — changed to `overflow-y-auto`.
+  **Verification:** `npx tsc --noEmit` clean; `npx eslint` on the four
+  touched files shows only pre-existing warnings, no new errors/warnings;
+  `npm run build` succeeds. 3 new smoke tests in `tests/smoke/designer.spec.ts`
+  cover the canvas-popover viewport clamp (asserts the popover stays fully
+  on-screen and clear of the icon it's editing, on a viewport sized to
+  reproduce the ~290px-tall canvas), the formation-menu scroll-inside case,
+  and the resize-while-focused case — all three confirmed to fail against the
+  pre-fix code and pass against the fix. Full Playwright smoke suite: 147/148
+  passed on the single concurrent 2-worker run; the one failure
+  (`mobile.spec.ts` "every interactive control clears 44px under touch",
+  a `page.goto` navigation timeout) reproduces the same environmental
+  resource-contention flakiness already documented elsewhere in this file
+  (e.g. B-36 (3)) — confirmed by re-running it alone with `--workers=1`,
+  where it passed. No smoke coverage added for the `AddToPlaybookButton`
+  fix: it's a one-line CSS relaxation (`overflow-hidden` → `overflow-y-auto`,
+  strictly loosens clipping, can't newly hide anything) on a component with
+  no existing test scaffolding (no signed-in-session/playbooks-list mock
+  exists for it yet), so a dedicated test harness felt disproportionate to
+  the risk here — flagging as a gap rather than skipping silently.
 
 - **2026-08-15 · B-40: Designer touch tuning** — the drawing surface's
   tolerances were all mouse-era constants, and every one of them was wrong for

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { PlayerStyleEditor } from './PlayerStyleEditor';
 import { RouteColorEditor } from './RouteColorEditor';
 import { TextBoxEditor } from './TextBoxEditor';
@@ -1548,8 +1549,20 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       } catch { /* ignore */ }
     };
 
+    // ── Shared popover viewport anchor ──────────────────────────────
+    // The three popovers below are portaled to <body> (position:fixed) and
+    // clamp/flip against the real viewport, not the canvas's own width/height.
+    // The canvas's local coordinate space is `canvasSize * zoom` — it shrinks
+    // below the popover's own height on a small phone (a 290px-tall canvas
+    // against a 260px+ popover) and balloons past the visible screen while
+    // zoomed, so clamping against it could still land the popover off-screen
+    // or right on top of the icon being edited instead of beside it.
+    const canvasRect = canvasRef.current?.getBoundingClientRect();
+    const anchorLeft = canvasRect?.left ?? 0;
+    const anchorTop = canvasRect?.top ?? 0;
+
     // ── Icon-edit popover placement ───────────────────────────────
-    // Anchored under the icon, clamped inside the canvas; flips above the
+    // Anchored under the icon, clamped inside the viewport; flips above the
     // icon when there isn't enough room below.
     const editingIcon = editingIconIndex !== null ? playerIcons[editingIconIndex] : null;
     let editorLeft = 0;
@@ -1557,10 +1570,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     if (editingIcon) {
       const POPOVER_W = 230;
       const POPOVER_H = 260;
-      editorLeft = Math.min(Math.max(editingIcon.x * width - POPOVER_W / 2, 8), Math.max(8, width - POPOVER_W - 8));
-      editorTop = editingIcon.y * height + iconRadiusPx + 10;
-      if (editorTop + POPOVER_H > height - 8) {
-        editorTop = Math.max(8, editingIcon.y * height - iconRadiusPx - POPOVER_H - 10);
+      const iconX = anchorLeft + editingIcon.x * width;
+      const iconY = anchorTop + editingIcon.y * height;
+      editorLeft = Math.min(Math.max(iconX - POPOVER_W / 2, 8), Math.max(8, window.innerWidth - POPOVER_W - 8));
+      editorTop = iconY + iconRadiusPx + 10;
+      if (editorTop + POPOVER_H > window.innerHeight - 8) {
+        editorTop = Math.max(8, iconY - iconRadiusPx - POPOVER_H - 10);
       }
     }
 
@@ -1576,10 +1591,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     if (editingRouteColorIcon) {
       const POPOVER_W = 230;
       const POPOVER_H = 190;
-      routeColorEditorLeft = Math.min(Math.max(editingRouteColorIcon.x * width - POPOVER_W / 2, 8), Math.max(8, width - POPOVER_W - 8));
-      routeColorEditorTop = editingRouteColorIcon.y * height + iconRadiusPx + 10;
-      if (routeColorEditorTop + POPOVER_H > height - 8) {
-        routeColorEditorTop = Math.max(8, editingRouteColorIcon.y * height - iconRadiusPx - POPOVER_H - 10);
+      const iconX = anchorLeft + editingRouteColorIcon.x * width;
+      const iconY = anchorTop + editingRouteColorIcon.y * height;
+      routeColorEditorLeft = Math.min(Math.max(iconX - POPOVER_W / 2, 8), Math.max(8, window.innerWidth - POPOVER_W - 8));
+      routeColorEditorTop = iconY + iconRadiusPx + 10;
+      if (routeColorEditorTop + POPOVER_H > window.innerHeight - 8) {
+        routeColorEditorTop = Math.max(8, iconY - iconRadiusPx - POPOVER_H - 10);
       }
     }
 
@@ -1595,10 +1612,14 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       const POPOVER_W = 230;
       const POPOVER_H = 280;
       const b = ctx ? textBoxBounds(ctx, width, height, editingText, scale) : { left: editingText.x * width, right: editingText.x * width, top: editingText.y * height, bottom: editingText.y * height };
-      textEditorLeft = Math.min(Math.max((b.left + b.right) / 2 - POPOVER_W / 2, 8), Math.max(8, width - POPOVER_W - 8));
-      textEditorTop = b.bottom + 10;
-      if (textEditorTop + POPOVER_H > height - 8) {
-        textEditorTop = Math.max(8, b.top - POPOVER_H - 10);
+      const bLeft = anchorLeft + b.left;
+      const bRight = anchorLeft + b.right;
+      const bTop = anchorTop + b.top;
+      const bBottom = anchorTop + b.bottom;
+      textEditorLeft = Math.min(Math.max((bLeft + bRight) / 2 - POPOVER_W / 2, 8), Math.max(8, window.innerWidth - POPOVER_W - 8));
+      textEditorTop = bBottom + 10;
+      if (textEditorTop + POPOVER_H > window.innerHeight - 8) {
+        textEditorTop = Math.max(8, bTop - POPOVER_H - 10);
       }
     }
 
@@ -1699,8 +1720,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         )}
 
         {/* ── Icon customize popover (tap an icon in Select mode) ── */}
-        {editingIcon && editingIconIndex !== null && (
-          <div className="absolute z-20" style={{ left: editorLeft, top: editorTop }}>
+        {/* Portaled to <body> (position:fixed) so it clamps against the real
+            viewport rather than the canvas's own zoom-scaled coordinate
+            space — see the "Shared popover viewport anchor" comment above. */}
+        {editingIcon && editingIconIndex !== null && createPortal(
+          <div className="fixed z-40" style={{ left: editorLeft, top: editorTop }}>
             <PlayerStyleEditor
               key={editingIconIndex}
               initialLetter={editingIcon.letter}
@@ -1713,12 +1737,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
               }}
               onCancel={() => setEditingIconIndex(null)}
             />
-          </div>
+          </div>,
+          document.body,
         )}
 
         {/* ── Recolor Route popover (tap a route line in Recolor Route mode) ── */}
-        {editingRouteColorIcon && editingRouteColorPath && editingRouteColorPathIndex !== null && (
-          <div className="absolute z-20" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
+        {editingRouteColorIcon && editingRouteColorPath && editingRouteColorPathIndex !== null && createPortal(
+          <div className="fixed z-40" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
             <RouteColorEditor
               key={editingRouteColorPathIndex}
               initialColor={editingRouteColorPath.color}
@@ -1730,12 +1755,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
               }}
               onCancel={() => setEditingRouteColorPathIndex(null)}
             />
-          </div>
+          </div>,
+          document.body,
         )}
 
         {/* ── Text box popover (tap a text box in Select mode, or right after placing one) ── */}
-        {editingText && editingTextIndex !== null && (
-          <div className="absolute z-20" style={{ left: textEditorLeft, top: textEditorTop }}>
+        {editingText && editingTextIndex !== null && createPortal(
+          <div className="fixed z-40" style={{ left: textEditorLeft, top: textEditorTop }}>
             <TextBoxEditor
               key={editingTextIndex}
               initialText={editingText.text}
@@ -1748,7 +1774,8 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
               onDelete={() => deleteTextBox(editingTextIndex)}
               onCancel={() => cancelTextBoxEdit(editingTextIndex)}
             />
-          </div>
+          </div>,
+          document.body,
         )}
 
         {/* ── Action bar (bottom of canvas): Finish + Cancel ── */}

--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -39,6 +39,7 @@ export function FormationMenu({ gameType, onSetGameType, onStamp, getCurrentIcon
   // user — see B-24 follow-up).
   const [coords, setCoords] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const templates = formationsFor(gameType);
 
   useEffect(() => {
@@ -69,16 +70,35 @@ export function FormationMenu({ gameType, onSetGameType, onStamp, getCurrentIcon
     // or the menu would flicker shut immediately after the click that opened
     // it whenever the trigger sits near the scrollable edge.
     const close = () => setOpen(false);
-    const onScroll = () => {
+    const onScroll = (e: Event) => {
+      // The popover body itself is `max-h-[60vh] overflow-y-auto` (it can
+      // list more templates/custom formations than fit). Scroll events don't
+      // bubble, but a capture-phase window listener still sees them fire on
+      // their real target — so without this check, scrolling *inside* the
+      // list was indistinguishable from the page scrolling behind it, and
+      // every scroll of the template list closed the menu it was scrolling.
+      if (e.target instanceof Node && popoverRef.current?.contains(e.target)) return;
       if (Date.now() - openedAt < 300) { updatePosition(); return; }
       close();
     };
+    const onResize = () => {
+      // On Android, the on-screen keyboard opening/closing over the "save
+      // formation" name input fires a window resize — closing here would
+      // silently discard whatever the coach had just typed. Reposition
+      // instead of closing while that input (or anything else in the
+      // popover) has focus.
+      if (popoverRef.current && document.activeElement && popoverRef.current.contains(document.activeElement)) {
+        updatePosition();
+        return;
+      }
+      close();
+    };
     const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
-    window.addEventListener('resize', close);
+    window.addEventListener('resize', onResize);
     window.addEventListener('scroll', onScroll, true);
     window.addEventListener('keydown', onKeyDown);
     return () => {
-      window.removeEventListener('resize', close);
+      window.removeEventListener('resize', onResize);
       window.removeEventListener('scroll', onScroll, true);
       window.removeEventListener('keydown', onKeyDown);
     };
@@ -145,6 +165,7 @@ export function FormationMenu({ gameType, onSetGameType, onStamp, getCurrentIcon
           {/* Click-outside catcher */}
           <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
           <div
+            ref={popoverRef}
             className="fixed z-40 bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56 max-h-[60vh] overflow-y-auto"
             style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/designer/RouteColorButton.tsx
+++ b/src/components/designer/RouteColorButton.tsx
@@ -23,6 +23,7 @@ export function RouteColorButton({ value, onChange, fullWidth = false }: RouteCo
   const [open, setOpen] = useState(false);
   const [coords, setCoords] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -40,16 +41,31 @@ export function RouteColorButton({ value, onChange, fullWidth = false }: RouteCo
     };
     updatePosition();
     const close = () => setOpen(false);
-    const onScroll = () => {
+    const onScroll = (e: Event) => {
+      // Same fix as FormationMenu: a capture-phase window listener sees the
+      // editor's own internal scrolling too, since scroll events don't
+      // bubble but still fire capture handlers on ancestors — without this
+      // check, scrolling inside the popover was indistinguishable from the
+      // page scrolling behind it and closed the very thing being scrolled.
+      if (e.target instanceof Node && popoverRef.current?.contains(e.target)) return;
       if (Date.now() - openedAt < 300) { updatePosition(); return; }
       close();
     };
+    const onResize = () => {
+      // Don't discard in-progress input (e.g. a custom hex value) just
+      // because the on-screen keyboard opening fired a resize.
+      if (popoverRef.current && document.activeElement && popoverRef.current.contains(document.activeElement)) {
+        updatePosition();
+        return;
+      }
+      close();
+    };
     const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
-    window.addEventListener('resize', close);
+    window.addEventListener('resize', onResize);
     window.addEventListener('scroll', onScroll, true);
     window.addEventListener('keydown', onKeyDown);
     return () => {
-      window.removeEventListener('resize', close);
+      window.removeEventListener('resize', onResize);
       window.removeEventListener('scroll', onScroll, true);
       window.removeEventListener('keydown', onKeyDown);
     };
@@ -86,7 +102,7 @@ export function RouteColorButton({ value, onChange, fullWidth = false }: RouteCo
       {open && coords && createPortal(
         <>
           <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          <div className="fixed z-40" style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}>
+          <div ref={popoverRef} className="fixed z-40" style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}>
             <RouteColorEditor
               initialColor={isAuto ? DEFAULT_PREVIEW_COLOR : value}
               initialAuto={isAuto}

--- a/src/components/plays/AddToPlaybookButton.tsx
+++ b/src/components/plays/AddToPlaybookButton.tsx
@@ -244,7 +244,7 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
           />
           
           {/* Dropdown */}
-          <div className={`absolute ${dropdownPositionClass} w-72 bg-board-light border border-chalk/20 rounded-lg shadow-xl z-50 max-h-80 overflow-hidden`}>
+          <div className={`absolute ${dropdownPositionClass} w-72 bg-board-light border border-chalk/20 rounded-lg shadow-xl z-50 max-h-80 overflow-y-auto`}>
             <div className="p-4 border-b border-chalk/10">
               <h3 className="font-medium text-chalk">Select Playbook</h3>
               <p className="text-sm text-chalk/60 mt-1">Add "{playName}" to a playbook</p>

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -781,6 +781,90 @@ test('formation menu opens fully on screen from the mobile bottom toolbar', asyn
   expect((await canvasState(page)).playerIcons).toHaveLength(11);
 });
 
+// B-41: on a phone the canvas itself renders ~290px tall (width-bound, not
+// height-bound — see PlayDesigner.tsx's letterboxing), shorter than the
+// icon-edit popover (260px). The old placement math clamped/flipped against
+// the canvas's own local coordinate space, so when neither the "below" nor
+// "above" branch had room, it fell back to pinning near the top of that
+// space — which sat right on top of the icon being edited instead of beside
+// it. Fixed by portaling to <body> and clamping against the real viewport
+// (which has the whole page's height to work with, not just the canvas).
+test('icon-edit popover stays on screen and clear of the icon on a short phone canvas', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  // Dead center vertically — neither flip direction has enough of the
+  // canvas's own ~290px to fit a 260px popover, so this is exactly the case
+  // the old canvas-relative clamp handled wrong.
+  const spot = await canvasPoint(page, 0.5, 0.5);
+  await page.mouse.click(spot.x, spot.y);
+
+  await btn(page, 'Select / Move').click();
+  const state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  await page.mouse.click(icon.x, icon.y);
+
+  const popover = page.locator('div.fixed.z-40');
+  await expect(popover).toBeVisible();
+  const box = await popover.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(844);
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(390);
+
+  // The popover must sit clear of the icon it's editing, not on top of it.
+  const iconHit = { left: icon.x - 15, right: icon.x + 15, top: icon.y - 15, bottom: icon.y + 15 };
+  const overlapsIcon = !(
+    box!.x > iconHit.right ||
+    box!.x + box!.width < iconHit.left ||
+    box!.y > iconHit.bottom ||
+    box!.y + box!.height < iconHit.top
+  );
+  expect(overlapsIcon).toBe(false);
+});
+
+// B-41: FormationMenu/RouteColorButton register `scroll` on `window` with
+// `capture: true` so a scroll of the page behind the popover closes it. But
+// scroll events don't bubble, and a capture-phase window listener still sees
+// them fire on their real target — so without checking the target, scrolling
+// *inside* the popover's own `overflow-y-auto` template list was
+// indistinguishable from the page scrolling, and closed the very menu being
+// scrolled.
+test('scrolling inside the formation menu does not close it', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Formation templates').click();
+  const popover = page.locator('div.fixed.z-40');
+  await expect(popover).toBeVisible();
+
+  // Past the "just opened, reposition instead of closing" grace window.
+  await page.waitForTimeout(350);
+  await popover.evaluate((el) => el.dispatchEvent(new Event('scroll')));
+
+  await expect(popover).toBeVisible();
+  await expect(page.getByRole('button', { name: 'I-Formation' })).toBeVisible();
+});
+
+// B-41: the same `resize`->close listener fires when a mobile on-screen
+// keyboard opens over an autoFocus'd input inside the popover, discarding
+// whatever the coach had just started typing. Fixed by skipping the close
+// (repositioning instead) while an element inside the popover has focus.
+test('a resize does not close a popover while an input inside it has focus', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Route color: Auto (match player) or a fixed color for every new route').click();
+  const popover = page.locator('div.fixed.z-40');
+  await expect(popover).toBeVisible();
+
+  await page.getByLabel('Custom route color').focus();
+  await page.evaluate(() => window.dispatchEvent(new Event('resize')));
+
+  await expect(popover).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Auto (match player)' })).toBeVisible();
+});
+
 test('mobile toolbar: tools are labelled, and every one is reachable by scrolling', async ({ page }) => {
   // The label class used to be `hidden sm:inline` in the horizontal
   // orientation — which is the ONLY orientation rendered below sm — so every


### PR DESCRIPTION
## What changed and why

Picked up **B-41 · Popover bugs on phones** from BACKLOG.md — four independent popover bugs on mobile, all in the same family (dismissing or mispositioning themselves):

1. **Scroll-inside-closes-it.** `FormationMenu.tsx` and `RouteColorButton.tsx` register `scroll` on `window` with `capture: true` so a page scroll behind the popover closes it. But scroll events don't bubble, and a capture-phase window listener still sees them fire on their real target — so scrolling *inside* the popover's own `overflow-y-auto` list was indistinguishable from the page scrolling behind it, and closed the very list being scrolled. Fixed by checking the event target against a ref on the popover content before treating it as an outside scroll.

2. **Resize discards in-progress input.** The same components' `resize`→close handler fired when a mobile on-screen keyboard opened over the popover's own input (e.g. the "save formation" name field), silently discarding whatever the coach had just typed. Fixed by skipping the close (repositioning instead) while `document.activeElement` is inside the popover.

3. **Canvas popovers covering the icon they edit.** The three canvas-anchored popovers (icon style, route color, text box — `Canvas.tsx`) clamped and flipped against the canvas's own local coordinate space, not the real viewport. On a phone the canvas renders ~290px tall (width-bound, not height-bound — see `PlayDesigner.tsx`'s letterboxing), shorter than the 260-280px popovers, so neither the "below" nor "above" branch had room and the fallback clamp landed the popover directly on top of the icon being edited. It also broke while zoomed, since the canvas's local coordinate space balloons past the visible screen at higher zoom. Fixed by portaling all three to `<body>` (`position: fixed`) and clamping/flipping against `window.innerWidth`/`innerHeight` via the canvas's real `getBoundingClientRect()` — the same pattern `FormationMenu`/`RouteColorButton` already use for the toolbar popovers.

4. **Playbook list truncation.** `AddToPlaybookButton.tsx`'s dropdown wrapper was `max-h-80 overflow-hidden` (not `-auto`), clipping content past 320px instead of scrolling to it — changed to `overflow-y-auto`.

Scope matches the backlog item's stated bugs exactly — nothing extra.

## Verification

- `npx tsc --noEmit`: clean.
- `npx eslint` on the four touched source files: only pre-existing warnings (unrelated), 0 new errors/warnings.
- `npm run build`: succeeds.
- **3 new smoke tests** in `tests/smoke/designer.spec.ts`:
  - `icon-edit popover stays on screen and clear of the icon on a short phone canvas`
  - `scrolling inside the formation menu does not close it`
  - `a resize does not close a popover while an input inside it has focus`
  
  All three confirmed to **fail against the pre-fix code** (stashed the fix and re-ran) and **pass against the fix**.
- **Full Playwright smoke suite:** 147/148 passed on the single concurrent 2-worker run. The one failure (`mobile.spec.ts` "every interactive control clears 44px under touch", a `page.goto` navigation timeout) reproduces the same environmental resource-contention flakiness already documented elsewhere in BACKLOG.md (e.g. B-36 (3)) — confirmed by re-running it alone with `--workers=1`, where it **passed**. Not a regression from this change.
- Ran against a throwaway placeholder `.env` (from `.env.example`) and the container's pre-installed Chromium via `PBP_CHROMIUM_PATH`, per CLAUDE.md — neither is part of this commit.

**Known gap:** no smoke test added for the `AddToPlaybookButton` fix. It's a one-line CSS relaxation (`overflow-hidden` → `overflow-y-auto`, which can only loosen clipping, never newly hide anything) on a component with no existing test scaffolding (no signed-in-session/playbooks-list mock exists for it yet) — building that harness from scratch felt disproportionate to the risk of this specific change. Flagging rather than skipping silently.

BACKLOG.md: moved B-41 to Done with today's date and a full writeup.

No SQL changes, no billing/auth code touched.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012FmK4TUZHrGnoS2r2mJP9w


---
_Generated by [Claude Code](https://claude.ai/code/session_012FmK4TUZHrGnoS2r2mJP9w)_