### PR TITLE
[nightly] Fix admin users table on mobile

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -242,7 +242,7 @@ export function AdminDashboard() {
                     ))}
                   </div>
                 ) : (
-                  <table className="w-full">
+                  <table className="w-full min-w-[640px]">
                     <thead>
                       <tr className="border-b border-chalk/10">
                         <th className="px-4 py-2 text-left text-chalk">User</th>
@@ -263,7 +263,7 @@ export function AdminDashboard() {
                               </span>
                             )}
                           </td>
-                          <td className="px-4 py-2 text-chalk">{user.email}</td>
+                          <td className="px-4 py-2 text-chalk break-all">{user.email}</td>
                           <td className="px-4 py-2">
                             {user.is_stripe_backed ? (
                               // Paying subscriber — the server refuses to change these
@@ -280,7 +280,7 @@ export function AdminDashboard() {
                                 value={user.plan}
                                 disabled={savingPlanFor === user.id}
                                 onChange={(e) => handleSetPlan(user, e.target.value as Plan)}
-                                className={`px-2 py-1 rounded-lg border border-chalk/20 bg-board text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 ${PLAN_BADGE[user.plan]}`}
+                                className={`px-2 py-1 rounded-lg border border-chalk/20 bg-board text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 ${PLAN_BADGE[user.plan]}`}
                               >
                                 {ASSIGNABLE_PLANS.map(({ value, label }) => (
                                   <option key={value} value={value}>{label}</option>
@@ -288,7 +288,7 @@ export function AdminDashboard() {
                               </select>
                             )}
                           </td>
-                          <td className="px-4 py-2 text-chalk">
+                          <td className="px-4 py-2 text-chalk whitespace-nowrap">
                             {new Date(user.created_at).toLocaleDateString()}
                           </td>
                           <td className="px-4 py-2 text-right">


### PR DESCRIPTION
Closes #92

## What changed and why

`AdminDashboard.tsx`'s users table (the app's only `<table>`) was `w-full`
with no `min-w-*` inside its `overflow-x-auto` wrapper, so on narrow screens
it just compressed columns to ~27px instead of the wrapper actually
scrolling. Fixed by:

- `min-w-[640px]` on the `<table>` so `overflow-x-auto` has something to
  scroll instead of squashing columns unreadably.
- `break-all` on the email cell so long addresses wrap inside their cell
  instead of overflowing/forcing extra width.
- `whitespace-nowrap` on the Joined date cell so it doesn't wrap awkwardly.
- The plan `<select>` bumped from `text-xs` to `text-sm` for legibility, as
  flagged in the issue.

Scope note: verified the issue's file:line references (`AdminDashboard.tsx:242`
table, `:280` plan select) still matched current code before touching
anything — they did, no drift.

## Verification

```
npm run typecheck   # 0 errors
npm run build        # succeeds
npx eslint src/components/admin/AdminDashboard.tsx   # 0 errors, 0 new
npm run smoke         # 146 passed, 2 failed
```

The 2 smoke failures (`no page scrolls sideways at phone width`,
`every interactive control clears 44px under touch`) are both `page.goto`
30s timeouts navigating to `/community` and `/account` — unrelated pages,
not `/admin`. Confirmed pre-existing/environmental by stashing this change
and re-running just those two tests against a clean `origin/main` checkout:
they fail identically (same timeouts, same routes) with no code changes at
all, matching the container-Chromium timing issues this repo's `CLAUDE.md`
already documents.

This is a CSS-only fix to the admin dashboard, not the designer or
save/load flow, so no smoke test was added per the nightly-executor
criteria.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MEi4kgNMWrzGLoCAHH7WA1)_