### PR TITLE
[nightly] Fix modal headers/Escape on phones

### DIFF
--- a/src/components/community/PostFormModal.tsx
+++ b/src/components/community/PostFormModal.tsx
@@ -4,6 +4,7 @@ import { getSafeErrorMessage } from '../../lib/errors';
 import { supabase } from '../../lib/supabase';
 import { sanitizePostContent } from '../../lib/sanitizeHtml';
 import { RichTextEditor } from './RichTextEditor';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 /** RichTextEditor isn't a native form control, so it gets no HTML5 `required`
  *  validation — an editor holding only an empty paragraph still sanitizes to
@@ -29,6 +30,8 @@ export function PostFormModal({ isOpen, onClose, onSaved, post }: PostFormModalP
   const [content, setContent] = useState(post?.content ?? '');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  useEscapeKey(isOpen, onClose);
 
   if (!isOpen) return null;
 
@@ -85,24 +88,23 @@ export function PostFormModal({ isOpen, onClose, onSaved, post }: PostFormModalP
   };
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
 
-        <div className="inline-block w-full max-w-2xl my-8 overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
-          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
-            <h3 className="text-2xl font-bold text-chalk">{isEditing ? 'Edit Post' : 'Create Post'}</h3>
-            <button
-              onClick={onClose}
-              aria-label="Close"
-              className="tap-target flex items-center justify-center text-chalk/70 hover:text-chalk transition-colors"
-            >
-              <X className="w-6 h-6" />
-            </button>
-          </div>
+      <div className="relative flex flex-col w-full max-w-2xl max-h-[90vh] overflow-hidden text-left bg-board-light rounded-lg shadow-xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10 flex-shrink-0">
+          <h3 className="text-2xl font-bold text-chalk">{isEditing ? 'Edit Post' : 'Create Post'}</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="tap-target flex items-center justify-center text-chalk/70 hover:text-chalk transition-colors"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
 
-          <form onSubmit={handleSubmit} className="p-6">
-            <div className="space-y-6">
+        <form onSubmit={handleSubmit} className="overflow-y-auto flex-1 p-6">
+          <div className="space-y-6">
               <div>
                 <label htmlFor="title" className="block text-sm font-medium text-chalk">
                   Title
@@ -154,9 +156,8 @@ export function PostFormModal({ isOpen, onClose, onSaved, post }: PostFormModalP
                   {loading ? (isEditing ? 'Saving...' : 'Creating...') : (isEditing ? 'Save Changes' : 'Create Post')}
                 </button>
               </div>
-            </div>
-          </form>
-        </div>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -7,6 +7,7 @@ import { useEntitlement } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { escapeHtml, paperPageSize, teamBrandHTML, type UserPreferences } from '../../lib/userPreferences';
 import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 const PRO_ONLY_FORMATS = new Set(['detailed-playbook', 'grid-playbook', 'wristband-playbook']);
 
@@ -52,6 +53,10 @@ export function ExportModal({
   const [metadata, setMetadata] = useState<PlayMetadata>(playMetadata);
   const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
   const { isPro, loading: entitlementLoading } = useEntitlement();
+
+  // Escape mirrors the header's X button in each view: back out of the
+  // metadata editor rather than closing the whole modal when it's open.
+  useEscapeKey(isOpen, showMetadataEditor ? () => setShowMetadataEditor(false) : onClose);
 
   if (!isOpen) return null;
 
@@ -856,26 +861,25 @@ export function ExportModal({
 
   if (showMetadataEditor) {
     return (
-      <div className="fixed inset-0 z-50 overflow-y-auto">
-        <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center">
-          <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
-          <div className="inline-block w-full max-w-3xl overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
-              <h3 className="text-xl font-bold text-chalk">
-                {selectedFormat === 'single-play' && 'Single Play Sheet'}
-                {selectedFormat === 'detailed-playbook' && 'Detailed Playbook'}
-                {selectedFormat === 'grid-playbook' && 'Playbook Grid'}
-                {selectedFormat === 'wristband-playbook' && 'Wristband Sheet'}
-              </h3>
-              <button
-                onClick={() => setShowMetadataEditor(false)}
-                className="text-chalk/70 hover:text-chalk transition-colors"
-              >
-                <X className="w-6 h-6" />
-              </button>
-            </div>
-            
-            <div className="p-6 space-y-6">
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
+        <div className="relative flex flex-col w-full max-w-3xl max-h-[90vh] overflow-hidden text-left bg-board-light rounded-lg shadow-xl">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10 flex-shrink-0">
+            <h3 className="text-xl font-bold text-chalk">
+              {selectedFormat === 'single-play' && 'Single Play Sheet'}
+              {selectedFormat === 'detailed-playbook' && 'Detailed Playbook'}
+              {selectedFormat === 'grid-playbook' && 'Playbook Grid'}
+              {selectedFormat === 'wristband-playbook' && 'Wristband Sheet'}
+            </h3>
+            <button
+              onClick={() => setShowMetadataEditor(false)}
+              className="text-chalk/70 hover:text-chalk transition-colors"
+            >
+              <X className="w-6 h-6" />
+            </button>
+          </div>
+
+          <div className="overflow-y-auto flex-1 p-6 space-y-6">
               {/* Single Play Metadata */}
               {selectedFormat === 'single-play' && (
                 <div className="space-y-4">
@@ -980,26 +984,25 @@ export function ExportModal({
                   )}
                 </div>
               )}
-            </div>
+          </div>
 
-            {/* Print Actions */}
-            <div className="px-6 py-4 border-t border-chalk/10 flex justify-end space-x-3">
-              <button
-                onClick={() => setShowMetadataEditor(false)}
-                className="px-4 py-2 text-sm font-medium text-chalk bg-board border border-chalk/20 rounded-md hover:bg-board-light"
-              >
-                Back
-              </button>
-              
-              <button
-                onClick={handlePrintExport}
-                disabled={selectedFormat === 'single-play' && !metadata.playName?.trim()}
-                className="px-4 py-2 text-sm font-medium bg-primary text-white rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
-              >
-                <Printer className="h-4 w-4 mr-2" />
-                Print {selectedFormat === 'single-play' ? 'Play' : 'Playbook'}
-              </button>
-            </div>
+          {/* Print Actions */}
+          <div className="flex-shrink-0 px-6 py-4 border-t border-chalk/10 flex justify-end space-x-3">
+            <button
+              onClick={() => setShowMetadataEditor(false)}
+              className="px-4 py-2 text-sm font-medium text-chalk bg-board border border-chalk/20 rounded-md hover:bg-board-light"
+            >
+              Back
+            </button>
+
+            <button
+              onClick={handlePrintExport}
+              disabled={selectedFormat === 'single-play' && !metadata.playName?.trim()}
+              className="px-4 py-2 text-sm font-medium bg-primary text-white rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+            >
+              <Printer className="h-4 w-4 mr-2" />
+              Print {selectedFormat === 'single-play' ? 'Play' : 'Playbook'}
+            </button>
           </div>
         </div>
       </div>
@@ -1007,58 +1010,56 @@ export function ExportModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center">
-        <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
-        <div className="inline-block w-full max-w-md overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
-          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
-            <h3 className="text-xl font-bold text-chalk">Export Play</h3>
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
+      <div className="relative flex flex-col w-full max-w-md max-h-[90vh] overflow-hidden text-left bg-board-light rounded-lg shadow-xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10 flex-shrink-0">
+          <h3 className="text-xl font-bold text-chalk">Export Play</h3>
+          <button
+            onClick={onClose}
+            className="text-chalk/70 hover:text-chalk transition-colors"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+        <div className="overflow-y-auto flex-1 p-6">
+          <p className="text-chalk/70 mb-4">
+            Choose a print format:
+          </p>
+          <div className="space-y-3">
+            {printFormatOptions.map((option) => {
+              const locked = PRO_ONLY_FORMATS.has(option.id) && !entitlementLoading && !isPro;
+              return (
+                <button
+                  key={option.id}
+                  onClick={() => handleFormatClick(option.id)}
+                  className="w-full flex items-center p-4 bg-board hover:bg-board-light border border-chalk/10 rounded-lg transition-colors"
+                >
+                  <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary/10 text-primary">
+                    <option.icon className="h-6 w-6" />
+                  </div>
+                  <div className="ml-4 text-left">
+                    <h4 className="text-lg font-medium text-chalk flex items-center gap-2">
+                      {option.name}
+                      {locked && (
+                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                          <Lock className="h-3 w-3" /> Pro
+                        </span>
+                      )}
+                    </h4>
+                    <p className="text-sm text-chalk/70">{option.description}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-6 flex justify-end">
             <button
               onClick={onClose}
-              className="text-chalk/70 hover:text-chalk transition-colors"
+              className="px-4 py-2 text-sm font-medium text-chalk bg-board border border-chalk/20 rounded-md hover:bg-board-light"
             >
-              <X className="w-6 h-6" />
+              Cancel
             </button>
-          </div>
-          <div className="p-6">
-            <p className="text-chalk/70 mb-4">
-              Choose a print format:
-            </p>
-            <div className="space-y-3">
-              {printFormatOptions.map((option) => {
-                const locked = PRO_ONLY_FORMATS.has(option.id) && !entitlementLoading && !isPro;
-                return (
-                  <button
-                    key={option.id}
-                    onClick={() => handleFormatClick(option.id)}
-                    className="w-full flex items-center p-4 bg-board hover:bg-board-light border border-chalk/10 rounded-lg transition-colors"
-                  >
-                    <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary/10 text-primary">
-                      <option.icon className="h-6 w-6" />
-                    </div>
-                    <div className="ml-4 text-left">
-                      <h4 className="text-lg font-medium text-chalk flex items-center gap-2">
-                        {option.name}
-                        {locked && (
-                          <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
-                            <Lock className="h-3 w-3" /> Pro
-                          </span>
-                        )}
-                      </h4>
-                      <p className="text-sm text-chalk/70">{option.description}</p>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-            <div className="mt-6 flex justify-end">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 text-sm font-medium text-chalk bg-board border border-chalk/20 rounded-md hover:bg-board-light"
-              >
-                Cancel
-              </button>
-            </div>
           </div>
         </div>
       </div>

--- a/src/components/designer/SavePlayModal.tsx
+++ b/src/components/designer/SavePlayModal.tsx
@@ -7,6 +7,7 @@ import { supabase } from '../../lib/supabase';
 import type { UserPreferences } from '../../lib/userPreferences';
 import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UsageWarningBanner } from '../UsageWarningBanner';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 interface Playbook {
   id: string;
@@ -188,26 +189,28 @@ export function SavePlayModal({
     setStep('metadata');
   };
 
+  useEscapeKey(isOpen, onClose);
+
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center">
-        <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 transition-opacity bg-black bg-opacity-75" onClick={onClose} />
 
-        <div className="inline-block w-full max-w-2xl overflow-hidden text-left align-middle transition-all transform bg-board-light rounded-lg shadow-xl">
-          <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10">
-            <h3 className="text-2xl font-bold text-chalk">
-              {step === 'metadata' ? 'Save Play' : 'Select Playbook'}
-            </h3>
-            <button
-              onClick={onClose}
-              className="text-chalk/70 hover:text-chalk transition-colors"
-            >
-              <X className="w-6 h-6" />
-            </button>
-          </div>
+      <div className="relative flex flex-col w-full max-w-2xl max-h-[90vh] overflow-hidden text-left bg-board-light rounded-lg shadow-xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-chalk/10 flex-shrink-0">
+          <h3 className="text-2xl font-bold text-chalk">
+            {step === 'metadata' ? 'Save Play' : 'Select Playbook'}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-chalk/70 hover:text-chalk transition-colors"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
 
+        <div className="overflow-y-auto">
           {step === 'metadata' ? (
             // Step 1: Play metadata with thumbnail preview
             <div className="p-6 space-y-6">

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+/** Closes a modal/overlay on Escape while it's open. Shared by SavePlayModal,
+ *  ExportModal and PostFormModal (B-43) — each previously had no Escape
+ *  handling at all. */
+export function useEscapeKey(isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -1514,6 +1514,105 @@ test('SavePlayModal (B-22): free user one play from the cap sees an early usage 
   await expect(page.getByText('14 of 15 free plays used.')).toBeVisible();
 });
 
+/* ── Modals on phones (B-43) ────────────────────────────────────────────────
+   SavePlayModal/ExportModal/PostFormModal previously had non-sticky headers
+   that scrolled out of reach on a tall form (leaving only the backdrop click
+   as a dismiss, which isn't a visible affordance) and no Escape handling at
+   all. Both are fixed via a shared useEscapeKey hook plus a flex-col/
+   max-h-[90vh] modal shell whose header never enters the scrolling flow. */
+
+async function openSavePlayModal(page: Page) {
+  await page.addInitScript((storageKey) => {
+    const session = {
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: 'bearer',
+      user: {
+        id: '11111111-1111-1111-1111-111111111111',
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'coach@example.com',
+        app_metadata: {},
+        user_metadata: {},
+        created_at: new Date(0).toISOString(),
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify(session));
+  }, AUTH_STORAGE_KEY);
+
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+
+  await openDesigner(page);
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+  await page.locator('button[title="Save play"]:visible').click();
+  await expect(page.getByText('Save Play')).toBeVisible();
+}
+
+test('Escape closes the Save Play modal', async ({ page }) => {
+  await openSavePlayModal(page);
+  await page.keyboard.press('Escape');
+  await expect(page.getByPlaceholder('Enter play name...')).toHaveCount(0);
+});
+
+test('the Save Play modal close button stays reachable after scrolling a tall form', async ({ page }) => {
+  // Regression: the form (~1039px tall, measured at 1280x900) is taller than
+  // a typical viewport, and the header used to be part of the SAME scrolling
+  // flow as the rest of the card — scrolling down to reach lower fields
+  // carried the header (and its close button) up off-screen with it, leaving
+  // only the backdrop click as a dismiss. The modal shell is now flex-col
+  // with the header pinned outside a max-h-[90vh] scrolling body, so the
+  // header must never move no matter how far the body scrolls.
+  await page.setViewportSize({ width: 500, height: 600 });
+  await openSavePlayModal(page);
+
+  const closeButton = page.locator('button:has(svg.lucide-x):visible').first();
+  const before = (await closeButton.boundingBox())!;
+
+  // Scroll whatever container is scrollable under the pointer — the whole
+  // page in the old layout, just the modal body in the fixed one.
+  await page.mouse.move(300, 300);
+  await page.mouse.wheel(0, 2000);
+  await page.waitForTimeout(200);
+
+  const after = (await closeButton.boundingBox())!;
+  expect(after.y, 'close button moved off its original position after scrolling the form').toBe(before.y);
+  expect(after.y, 'close button should stay within the viewport').toBeGreaterThanOrEqual(0);
+  expect(after.y, 'close button should stay within the viewport').toBeLessThan(600);
+
+  const cx = after.x + after.width / 2;
+  const cy = after.y + after.height / 2;
+  const hitsCloseButton = await page.evaluate(
+    ([x, y]) => Boolean(document.elementFromPoint(x as number, y as number)?.closest('button')),
+    [cx, cy],
+  );
+  expect(hitsCloseButton, 'close button should not be covered by scrolled-over content').toBe(true);
+
+  await closeButton.click();
+  await expect(page.getByPlaceholder('Enter play name...')).toHaveCount(0);
+});
+
+test('Escape steps back out of the Export metadata editor instead of closing the whole modal', async ({ page }) => {
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+  await expect(page.getByText('Choose a print format:')).toBeVisible();
+
+  await page.getByRole('button', { name: /Single Play Sheet/ }).click();
+  await expect(page.getByText('Notes & Execution')).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByText('Choose a print format:')).toBeVisible();
+  await expect(page.getByText('Notes & Execution')).toHaveCount(0);
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByText('Choose a print format:')).toHaveCount(0);
+});
+
 test('account settings page renders for a signed-in user (mocked backend)', async ({ page }) => {
   // Regression test: the page previously rendered blank because a type-only
   // `User` import was used as a JSX component (undefined at runtime), which

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -306,3 +306,37 @@ test('every interactive control clears 44px under touch', async ({ page }) => {
 
   expect(undersized).toEqual([]);
 });
+
+/* ── Modals on phones (B-43) ────────────────────────────────────────────────
+   PostFormModal centered itself with `min-h-screen` (100vh), which fights the
+   viewport shrink an iOS keyboard causes — the layout kept assuming full
+   viewport height while the visual viewport shrank underneath it — and had no
+   Escape handling. Both are fixed: the modal now centers with real flexbox
+   inside a max-h-[90vh] card instead of a 100vh assumption, and Escape closes
+   it via the shared useEscapeKey hook. */
+test('Create Post modal: Escape closes it, and the close button survives a keyboard-sized viewport', async ({ page }) => {
+  await seedForTapTargets(page);
+  await page.goto('/community', { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(700);
+
+  await page.getByRole('button', { name: 'Create Post' }).click();
+  await expect(page.getByRole('heading', { name: 'Create Post' })).toBeVisible();
+
+  // Simulate the visual viewport an iOS keyboard leaves behind — the failure
+  // mode was a 100vh centering assumption that didn't shrink with it.
+  await page.setViewportSize({ width: 375, height: 260 });
+
+  const closeButton = page.getByRole('button', { name: 'Close' });
+  const box = (await closeButton.boundingBox())!;
+  expect(box.y, 'close button should be within the shrunk viewport').toBeGreaterThanOrEqual(0);
+  expect(box.y, 'close button should be within the shrunk viewport').toBeLessThan(260);
+
+  const hitsCloseButton = await page.evaluate(
+    ([x, y]) => Boolean(document.elementFromPoint(x as number, y as number)?.closest('button[aria-label="Close"]')),
+    [box.x + box.width / 2, box.y + box.height / 2],
+  );
+  expect(hitsCloseButton, 'close button should not be covered by scrolled-over content').toBe(true);
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('heading', { name: 'Create Post' })).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #93

## What changed and why

`SavePlayModal.tsx`, `ExportModal.tsx` (both its format-picker and metadata-editor
views), and `PostFormModal.tsx` all used the same old inline-block/`min-h-screen`
centering hack: `<div class="fixed inset-0 z-50 overflow-y-auto"><div class="flex
items-center justify-center min-h-screen ...">`. Because the header lived inside
the *same* scrolling flow as the rest of the card, once a form was taller than the
viewport, scrolling down to reach lower fields carried the header — and its 24px
`×` — up off-screen with it, leaving only a backdrop click as a (non-obvious)
dismiss. `PostFormModal`'s `min-h-screen` (100vh) centering also fought the
viewport an iOS keyboard leaves behind. None of the three handled Escape at all.

Fix, applied identically to all three modal shells:
- Replaced the inline-block/min-h-screen hack with real flexbox centering
  (`fixed inset-0 z-50 flex items-center justify-center p-4`) and a card capped
  at `max-h-[90vh] flex flex-col overflow-hidden`.
- The header is now a `flex-shrink-0` sibling of an internally-scrolling body
  (`overflow-y-auto flex-1`), so it can never leave the viewport regardless of
  form height.
- Added a shared `src/hooks/useEscapeKey.ts` hook (`window.addEventListener`
  keydown/Escape with cleanup) used by all three. In `ExportModal`, Escape
  mirrors whichever header X is currently showing — closes the whole modal from
  the format-picker view, or steps back out of the metadata editor to the format
  list, matching that view's own X button.

## Verification

Confirmed against the code as it exists today — file/line numbers in the issue
had drifted slightly (e.g. `ExportModal.tsx:1013` is now the *second* of two
modal branches in that file; the first branch, the metadata editor at line
~862, has the identical bug and got the same fix for consistency).

```
npm run typecheck   # no errors in touched files (repo-wide pre-existing
                     # tsconfig deprecation warnings only, confirmed present
                     # on main via git stash before touching anything)
npm run build        # ✓ built in 10.93s
npx eslint src/components/community/PostFormModal.tsx \
  src/components/designer/ExportModal.tsx \
  src/components/designer/SavePlayModal.tsx \
  src/hooks/useEscapeKey.ts \
  tests/smoke/designer.spec.ts tests/smoke/mobile.spec.ts
                     # 0 new errors — 12 pre-existing-style warnings only
                     # (no-explicit-any / exhaustive-deps, same patterns
                     # already present elsewhere in these files)
npm run smoke         # 150/152 passed
```

Full smoke run: **150/152 passed.** The 2 failures
(`tests/smoke/mobile.spec.ts:148` "no page scrolls sideways at phone width" and
`:281` "every interactive control clears 44px under touch") are **pre-existing
and unrelated** — both are 30s `page.goto` timeouts partway through a
multi-route navigation loop, on a *different* route each run (`/community` in
the full run, `/designer` in a re-run). Confirmed via `git stash` of every
source file this PR touches: the identical two tests fail identically on
unmodified `main`, and re-running afterward flipped which of the two failed and
on which route — a timing/environmental race, not a deterministic regression,
consistent with the flakiness this suite's own comments already document
(see `CLAUDE.md`'s notes on `PBP_CHROMIUM_PATH` and the `test-bridge-race.md`
memory).

### New tests (extends `tests/smoke/`, save/load + designer flows)

Added 4 regression tests, one per fix, and confirmed **each one fails without
the corresponding source change** by stashing just the 3 modal source files
(keeping the hook file moved aside) and re-running:

- `designer.spec.ts` — **"Escape closes the Save Play modal"**: failed (modal
  stayed open) on unfixed code.
- `designer.spec.ts` — **"the Save Play modal close button stays reachable
  after scrolling a tall form"**: scrolls whatever container is scrollable
  under the pointer, then re-measures the close button. On unfixed code it
  jumped from y=36 to **y=-499** (off-screen) — the exact bug described in the
  issue. On fixed code its position never moves.
- `designer.spec.ts` — **"Escape steps back out of the Export metadata editor
  instead of closing the whole modal"**: failed (no Escape handling at all) on
  unfixed code.
- `mobile.spec.ts` — **"Create Post modal: Escape closes it, and the close
  button survives a keyboard-sized viewport"**: shrinks the viewport to
  375×260 (simulating the visual viewport an iOS keyboard leaves) and checks
  the close button is still hit-testable. Failed (button covered/unreachable)
  on unfixed code.

All 4 pass on the fixed code, individually and as part of the full 152-test
suite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkpFdKKF7cCMdfP2i5GMTH)_