### PR TITLE
[nightly] Fix autofill/autocapitalize on the auth form

### DIFF
--- a/src/components/auth/AuthPage.tsx
+++ b/src/components/auth/AuthPage.tsx
@@ -194,6 +194,11 @@ export function AuthPage() {
                     name="email"
                     type="email"
                     autoComplete="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    inputMode="email"
+                    enterKeyHint="done"
                     required
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -218,6 +223,11 @@ export function AuthPage() {
                       id="username"
                       name="username"
                       type="text"
+                      autoComplete="username"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      enterKeyHint="next"
                       required
                       value={username}
                       onChange={handleUsernameChange}
@@ -250,6 +260,11 @@ export function AuthPage() {
                     name="email"
                     type="email"
                     autoComplete="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    inputMode="email"
+                    enterKeyHint="next"
                     required
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -271,7 +286,8 @@ export function AuthPage() {
                     id="password"
                     name="password"
                     type="password"
-                    autoComplete="current-password"
+                    autoComplete={isSignUp ? 'new-password' : 'current-password'}
+                    enterKeyHint="done"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -340,3 +340,30 @@ test('Create Post modal: Escape closes it, and the close button survives a keybo
   await page.keyboard.press('Escape');
   await expect(page.getByRole('heading', { name: 'Create Post' })).toHaveCount(0);
 });
+
+/* ── Auth form autofill (B-44) ──────────────────────────────────────────────
+   AuthPage.tsx reused one <input> for both sign-in and sign-up, hardcoded to
+   autoComplete="current-password" — so a password manager offered to *fill*
+   a password on signup instead of *generating* one, since "current-password"
+   tells it this account already exists. The username field carried no
+   autoComplete/autoCapitalize/autoCorrect/spellCheck at all, so iOS
+   capitalized the first letter of every new username. */
+test('signup password field asks for a new password, not the current one', async ({ page }) => {
+  await page.goto('/auth?mode=signup');
+
+  const password = page.locator('#password');
+  await expect(password).toHaveAttribute('autocomplete', 'new-password');
+
+  const username = page.locator('#username');
+  await expect(username).toHaveAttribute('autocomplete', 'username');
+  await expect(username).toHaveAttribute('autocapitalize', 'none');
+  await expect(username).toHaveAttribute('autocorrect', 'off');
+  await expect(username).toHaveAttribute('spellcheck', 'false');
+});
+
+test('sign-in password field still asks for the current password', async ({ page }) => {
+  await page.goto('/auth');
+
+  const password = page.locator('#password');
+  await expect(password).toHaveAttribute('autocomplete', 'current-password');
+});


### PR DESCRIPTION
Closes #94

## What changed and why

`AuthPage.tsx` reused one `<input>` for both sign-in and sign-up, hardcoded to
`autoComplete="current-password"`. On the signup path this tells a password
manager "this account already exists, fill its saved password" instead of
"generate a new one" — so it never offered to generate/save. Fixed by making
it conditional: `autoComplete={isSignUp ? 'new-password' : 'current-password'}`.

The username field had no `autoComplete`, `autoCapitalize`, `autoCorrect`, or
`spellCheck` at all, so iOS capitalized the first letter of every new
username and offered spellcheck/autocorrect suggestions on it. Added
`autoComplete="username"`, `autoCapitalize="none"`, `autoCorrect="off"`,
`spellCheck={false}`.

Also added `autoCapitalize`/`autoCorrect`/`spellCheck`/`inputMode="email"` to
both email inputs, and `enterKeyHint` (`next`/`done`) across the auth form's
fields, per the issue's broader "no inputMode/enterKeyHint anywhere" note.

I verified the issue's file:line reference (`AuthPage.tsx:274`) still matched
current code before touching it — it did, unchanged since the issue was
filed. `ResetPasswordPage.tsx` was already correct (`new-password` on both
fields) and needed no change.

## Verification

```
npm run typecheck   # clean, no errors
npm run build       # clean
npx eslint src/components/auth/AuthPage.tsx tests/smoke/mobile.spec.ts
  # 0 errors; 2 pre-existing `no-explicit-any` warnings at lines 242/248,
  # unrelated to this change (already present on main)
```

Added two tests to `tests/smoke/mobile.spec.ts` (`Auth form autofill (B-44)`
block):
- `signup password field asks for a new password, not the current one`
- `sign-in password field still asks for the current password`

**Confirmed the new test fails without the fix**: stashed the `AuthPage.tsx`
change (keeping only the test), ran it, and the signup test failed with
`Expected: "new-password" / Received: "current-password"` — exactly the bug
described in the issue. Restored the fix and it passed.

Full smoke suite (`npm run smoke`, `PBP_CHROMIUM_PATH` set to this
container's Chromium): **152/154 passed**, including both new auth tests. The
2 failures are pre-existing, unrelated tests (`no page scrolls sideways at
phone width`, `every interactive control clears 44px under touch`) that
navigate to routes this PR doesn't touch (`/blog`, `/community`,
`/playbooks`, `/account`) and fail only on a 30s `page.goto` timeout. I
confirmed this is environmental container slowness, not a regression: all
five routes load in under 1.1s via direct `curl` against the dev server, and
the touch-target test passes cleanly (39.7s) when given a longer timeout in
isolation — the default 30s budget is just tight for a cold first
navigation in this sandbox. Both tests are unmodified by this PR and
unrelated to the auth form.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DkMuLgYk9rs79DhbyaU3m9)_