### PR TITLE
[nightly] Tell mobile users to tap the field after selecting a roster chip

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1440,7 +1440,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
       // Hover highlight: show which icon will be the route origin, or which
       // zone will be affected.
-      if ((drawingMode && waypointPoints.length === 0) || zoneMode || deleteZoneMode) {
+      if ((drawingMode && waypointPoints.length === 0) || zoneMode || deleteZoneMode || selectedPlayer) {
         const idx = findIcon(p);
         setHoveredIconIndex(idx >= 0 ? idx : null);
       } else if (hoveredIconIndex !== null) {
@@ -1631,7 +1631,14 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       ? playerIcons[hoveredPath.startIconIndex]?.letter
       : undefined;
     let instructionText: string | null = null;
-    if (deleteRouteMode) {
+    if (selectedPlayer) {
+      // The toolbar's HTML5 drag-and-drop never fires on touch (no browser
+      // synthesizes it), so tap-chip-then-tap-field is the only way to place
+      // a player on mobile. Nothing said so until this branch existed.
+      instructionText = hoveredIconIndex !== null
+        ? `Tap to turn this player into "${selectedPlayer.letter}"`
+        : `"${selectedPlayer.letter}" selected · Tap the field to place them`;
+    } else if (deleteRouteMode) {
       instructionText = hoveredPath
         ? `Tap to remove ${hoveredPathOriginLetter ? `"${hoveredPathOriginLetter}"'s` : 'this'} route`
         : 'Tap a route to remove it';

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -4890,3 +4890,26 @@ test('touch: a small wobble during a tap opens the editor instead of nudging the
   expect(after.x).toBeCloseTo(placed.x, 5);
   expect(after.y).toBeCloseTo(placed.y, 5);
 });
+
+test('selecting a roster chip tells the user to tap the field to place it', async ({ page }) => {
+  // The toolbar's HTML5 drag-and-drop never fires from a touch gesture (no
+  // mobile browser synthesizes it), so tap-chip-then-tap-field is the only
+  // way to place a player on a phone — but nothing said so. Regression check
+  // for the instruction-bar branch added for selectedPlayer.
+  await openDesigner(page);
+
+  await expect(page.getByText('selected · Tap the field to place them', { exact: false })).toHaveCount(0);
+
+  await page.locator('button[title="Player Q"]:visible').first().click();
+  await expect(page.getByText('"Q" selected · Tap the field to place them')).toBeVisible();
+
+  // Placing it clears the instruction (selectedPlayer resets to null).
+  const spot = await canvasPoint(page, 0.5, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  await expect(page.getByText('"Q" selected · Tap the field to place them')).toHaveCount(0);
+
+  // Selecting again and hovering an existing player offers the swap message.
+  await page.locator('button[title="Player R"]:visible').first().click();
+  await page.mouse.move(spot.x, spot.y);
+  await expect(page.getByText('Tap to turn this player into "R"')).toBeVisible();
+});


### PR DESCRIPTION
Closes #96

## What changed and why

The issue's premise checked out against current code, with one correction: `PlayerToolbar.tsx`'s tap-to-select and `Canvas.tsx`'s tap-to-place handler (`handlePointerDown`, `selectedPlayer && !drawingMode`) **already work** on touch — pointer events unify mouse/touch, so tapping a chip then tapping the field already placed a player correctly. The actual gap, exactly as the issue also flagged, was that the HTML5-drag-and-drop-only path (`PlayerToolbar.tsx` chip `onDragStart`, `Canvas.tsx`'s `onDrop`) never fires from touch, and the canvas's contextual instruction bar had no branch for `selectedPlayer` — so a coach who tried to drag on a phone got nothing, and nothing told them tap-then-tap was the way.

Fix, scoped to that gap:
- `Canvas.tsx`: added a `selectedPlayer` branch to the instruction-bar text — `"Q" selected · Tap the field to place them` when nothing is hovered, `Tap to turn this player into "Q"` when hovering an existing icon (swap).
- Extended the hover-tracking condition (`handlePointerMove`) to include `selectedPlayer` so `hoveredIconIndex` actually populates in this mode — without it the swap message could never trigger, and the existing hover-ring highlight (already generic to any `hoveredIconIndex`) now also lights up the icon that tap will overwrite.

No changes to placement logic itself — that path was already correct on touch.

## Verification

```
npm run typecheck   # only pre-existing tsconfig deprecation warnings (target/moduleResolution/baseUrl), unrelated to touched files
npm run build        # ✓ built in ~11s
npm run smoke         # 153 passed, 2 failed (see below)
npx eslint src/components/designer/Canvas.tsx tests/smoke/designer.spec.ts   # 0 errors, only pre-existing warnings far from the touched lines
```

The 2 smoke failures (`mobile.spec.ts`: "no page scrolls sideways at phone width", "every interactive control clears 44px under touch") are `page.goto` timeouts navigating to unrelated routes (`/account`, `/playbooks`, `/community` — varies by run). I stashed this PR's changes and reproduced the identical failures against unmodified `main` in this same environment — pre-existing dev-server flakiness in this sandbox, not a regression from this change. All 134 tests in `designer.spec.ts` pass, including the new one.

**New test added**, `tests/smoke/designer.spec.ts`: `selecting a roster chip tells the user to tap the field to place it`. Confirmed it fails without the fix — stashed `Canvas.tsx`'s change (kept the test), ran it, got:
```
Error: expect(locator).toBeVisible() failed
Locator: getByText('"Q" selected · Tap the field to place them')
```
then restored the source change and reran — passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017M1b1DGXX6PxHP9iD6czkA)_