### PR TITLE
[nightly] Show the "jump to a defense" dropdown on mobile (B-48)

### DIFF
--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -600,7 +600,7 @@ export function VsDefenseView() {
                   if (at >= 0) setIndex(at);
                 }}
                 aria-label="Jump to a defense"
-                className="hidden sm:block max-w-[14rem] px-2 py-2 text-sm bg-board border border-chalk/20 text-chalk rounded-lg"
+                className="block max-w-[6.5rem] sm:max-w-[14rem] px-2 py-2 text-sm bg-board border border-chalk/20 text-chalk rounded-lg"
               >
                 {defenses.map((d) => (
                   <option key={d.id} value={d.id}>{d.name}</option>

--- a/tests/smoke/vs-defense.spec.ts
+++ b/tests/smoke/vs-defense.spec.ts
@@ -324,3 +324,26 @@ test('B-36 (1): export modal has no "whole deck" section when the deck is empty'
   await expect(page.getByText('This matchup')).toBeVisible();
   await expect(page.getByText(/Whole deck/)).toHaveCount(0);
 });
+
+test.describe('mobile', () => {
+  // B-48: the "Jump to a defense" <select> was `hidden sm:block`, so on a
+  // phone the only way through a deck of 12 defenses was up to 11 taps of
+  // "Next". `hasTouch` (not just a narrow viewport) is what puts Playwright
+  // on the phone-layout code path here — see the note in mobile.spec.ts.
+  test.use({ viewport: { width: 375, height: 667 }, hasTouch: true });
+
+  test('B-48: the "jump to a defense" dropdown is reachable on a phone, not just Next taps', async ({ page }) => {
+    await mockBackend(page, DEFENSES);
+    await openVs(page);
+
+    const select = page.getByLabel('Jump to a defense');
+    await expect(select).toBeVisible();
+    const box = (await select.boundingBox())!;
+    expect(box.width, 'dropdown should render with real width on a phone, not be collapsed').toBeGreaterThan(0);
+
+    // Jumping straight to the second defense — no repeated "Next" taps needed.
+    await select.selectOption({ label: 'Man Blitz' });
+    await expect(page.locator('#vs-defense-label')).toContainText('Man Blitz');
+    expect((await vsState(page)).index).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `VsDefenseView.tsx:603`'s "jump to a defense" `<select>` was `hidden sm:block`, so on a phone the only way through a deck was tapping Next/Previous repeatedly — up to 11 taps for 12 saved defenses, with no mobile equivalent.
- Removed the `hidden sm:block` and gave the dropdown a smaller `max-w` on small screens (`max-w-[6.5rem] sm:max-w-[14rem]`) so it now shows on mobile too, fitting alongside the prev/next buttons and the truncating defense-name label in the same flex row.

Verified the issue's file:line reference (`VsDefenseView.tsx:493`) had drifted to line 603 through prior refactors — worked from the current code.

## Test plan
- Added a smoke test in `tests/smoke/vs-defense.spec.ts` (`mobile` describe block, `hasTouch: true` + 375×667 viewport) asserting the dropdown is visible and can jump straight to a defense by name.
- **Confirmed the new test fails without the fix**: stashed the `VsDefenseView.tsx` change, ran the test, watched it fail (`toBeVisible()` — received "hidden"), then restored the fix and re-ran to green.
- `npm run typecheck` — clean.
- `npm run build` — succeeds.
- `npx eslint src/components/vs/VsDefenseView.tsx tests/smoke/vs-defense.spec.ts` — 0 errors (2 pre-existing `no-explicit-any` warnings, unrelated to this change, both outside the touched lines).
- `npm run smoke` (full suite, `PBP_CHROMIUM_PATH` set to the container's Chromium): 155/156 passed, including the new test. The one failure (`every interactive control clears 44px under touch`) is unrelated — it never visits `/vs`, and re-running it alone (isolated from full-suite parallelism) passes cleanly, matching the known environmental flakiness this repo already documents for the smoke suite under load.

Closes #98


---
_Generated by [Claude Code](https://claude.ai/code/session_01HzzetZ6uk7v2fSiuTeViTi)_