### PR TITLE
[nightly] Sticky navbar + xs Tailwind breakpoint

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -59,12 +59,17 @@ export function Navbar() {
     { path: '/blog', label: 'Blog' }
   ];
 
-  // Deliberately no `position`/`z-index` here: the nav must stay a plain in-flow box so it
-  // doesn't form a stacking context. That lets UserMenu's `z-50` dropdown compete in the root
-  // context and paint above the Hero's `relative z-10`. Adding `relative z-50` here instead
-  // floats the whole bar over page content and swallows clicks on the designer toolbar.
+  // `sticky top-0 z-40` keeps the nav reachable while scrolling a long page (Blog,
+  // Community) instead of vanishing once you leave normal flow. z-40 sits below every
+  // modal/dropdown in the app (all z-50, including UserMenu's own dropdown, which still
+  // paints above its ancestor nav) and above Hero's `relative z-10`, which is the point.
+  // /designer and /vs are the one exception: both are `fixed inset-0` full-screen tools
+  // that are meant to cover the nav entirely, so they carry an explicit `z-50` of their
+  // own — without it, a z-40 positioned nav would float above their z-auto container and
+  // swallow clicks on their toolbar, which is the failure mode this used to avoid by
+  // keeping the nav non-positioned. Check both spots before changing this z-index.
   return (
-    <nav className="bg-board-light border-b border-chalk/10">
+    <nav className="sticky top-0 z-40 bg-board-light border-b border-chalk/10">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16">
           <div className="flex">
@@ -100,7 +105,7 @@ export function Navbar() {
               </button>
             )}
           </div>
-          <div className="flex items-center gap-1 sm:hidden">
+          <div className="flex items-center gap-1 xs:gap-2 sm:hidden">
             {user && <UserMenu user={user} showName={false} />}
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1729,9 +1729,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         {/* ── Icon customize popover (tap an icon in Select mode) ── */}
         {/* Portaled to <body> (position:fixed) so it clamps against the real
             viewport rather than the canvas's own zoom-scaled coordinate
-            space — see the "Shared popover viewport anchor" comment above. */}
+            space — see the "Shared popover viewport anchor" comment above.
+            z-[60], not z-40: being portaled means this now competes directly
+            with /designer's own `z-50` full-screen shell (see the z-index
+            note in Navbar.tsx) instead of nesting inside it. */}
         {editingIcon && editingIconIndex !== null && createPortal(
-          <div className="fixed z-40" style={{ left: editorLeft, top: editorTop }}>
+          <div className="fixed z-[60]" style={{ left: editorLeft, top: editorTop }}>
             <PlayerStyleEditor
               key={editingIconIndex}
               initialLetter={editingIcon.letter}
@@ -1750,7 +1753,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
         {/* ── Recolor Route popover (tap a route line in Recolor Route mode) ── */}
         {editingRouteColorIcon && editingRouteColorPath && editingRouteColorPathIndex !== null && createPortal(
-          <div className="fixed z-40" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
+          <div className="fixed z-[60]" style={{ left: routeColorEditorLeft, top: routeColorEditorTop }}>
             <RouteColorEditor
               key={editingRouteColorPathIndex}
               initialColor={editingRouteColorPath.color}
@@ -1768,7 +1771,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
         {/* ── Text box popover (tap a text box in Select mode, or right after placing one) ── */}
         {editingText && editingTextIndex !== null && createPortal(
-          <div className="fixed z-40" style={{ left: textEditorLeft, top: textEditorTop }}>
+          <div className="fixed z-[60]" style={{ left: textEditorLeft, top: textEditorTop }}>
             <TextBoxEditor
               key={editingTextIndex}
               initialText={editingText.text}

--- a/src/components/designer/FormationMenu.tsx
+++ b/src/components/designer/FormationMenu.tsx
@@ -162,11 +162,14 @@ export function FormationMenu({ gameType, onSetGameType, onStamp, getCurrentIcon
 
       {open && coords && createPortal(
         <>
-          {/* Click-outside catcher */}
-          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          {/* Click-outside catcher. z-[55]/z-[60], not z-30/z-40: portaled to
+              <body>, so this now competes directly with /designer's own
+              `z-50` full-screen shell (see the z-index note in Navbar.tsx)
+              instead of nesting inside it. */}
+          <div className="fixed inset-0 z-[55]" onClick={() => setOpen(false)} />
           <div
             ref={popoverRef}
-            className="fixed z-40 bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56 max-h-[60vh] overflow-y-auto"
+            className="fixed z-[60] bg-board-light border border-chalk/20 rounded-xl shadow-2xl p-2 w-56 max-h-[60vh] overflow-y-auto"
             style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}
             onPointerDown={(e) => e.stopPropagation()}
           >

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -475,7 +475,9 @@ export function PlayDesigner() {
   );
 
   return (
-    <div className="fixed inset-0 flex flex-col bg-board overflow-hidden">
+    // z-50: must outrank Navbar's sticky z-40 so this still fully covers it — see
+    // the z-index note in Navbar.tsx.
+    <div className="fixed inset-0 z-50 flex flex-col bg-board overflow-hidden">
 
       {/* ── HEADER ─────────────────────────────────────────────── */}
       <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 py-2 flex items-center gap-2 z-30">

--- a/src/components/designer/RouteColorButton.tsx
+++ b/src/components/designer/RouteColorButton.tsx
@@ -101,8 +101,11 @@ export function RouteColorButton({ value, onChange, fullWidth = false }: RouteCo
 
       {open && coords && createPortal(
         <>
-          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          <div ref={popoverRef} className="fixed z-40" style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}>
+          {/* z-[55]/z-[60], not z-30/z-40: portaled to <body>, so this now competes
+              directly with /designer's own `z-50` full-screen shell (see the
+              z-index note in Navbar.tsx) instead of nesting inside it. */}
+          <div className="fixed inset-0 z-[55]" onClick={() => setOpen(false)} />
+          <div ref={popoverRef} className="fixed z-[60]" style={{ left: coords.left, top: coords.top, bottom: coords.bottom }}>
             <RouteColorEditor
               initialColor={isAuto ? DEFAULT_PREVIEW_COLOR : value}
               initialAuto={isAuto}

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -415,7 +415,7 @@ export function VsDefenseView() {
   // ── Render ──────────────────────────────────────────────────
   if (loading) {
     return (
-      <div className="fixed inset-0 bg-board flex items-center justify-center text-chalk/50">
+      <div className="fixed inset-0 z-50 bg-board flex items-center justify-center text-chalk/50">
         Loading…
       </div>
     );
@@ -423,7 +423,7 @@ export function VsDefenseView() {
 
   if (error || !offensePlay) {
     return (
-      <div className="fixed inset-0 bg-board flex flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="fixed inset-0 z-50 bg-board flex flex-col items-center justify-center gap-4 px-6 text-center">
         <p className="text-chalk/70">{error || 'That play could not be found.'}</p>
         <Link to="/plays" className="px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors">
           Back to My Plays
@@ -433,7 +433,9 @@ export function VsDefenseView() {
   }
 
   return (
-    <div className="fixed inset-0 flex flex-col bg-board overflow-hidden">
+    // z-50: must outrank Navbar's sticky z-40 so this still fully covers it — see
+    // the z-index note in Navbar.tsx.
+    <div className="fixed inset-0 z-50 flex flex-col bg-board overflow-hidden">
       {/* ── HEADER ─────────────────────────────────────────────── */}
       <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 py-2 flex items-center gap-2 z-30">
         <Link

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,13 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      // Default Tailwind screens jump straight from 0 to `sm: 640px`, so a
+      // 320px phone and a 639px foldable get identical mobile treatment.
+      // `xs` gives layouts a checkpoint inside that range without touching
+      // the existing sm/md/lg/xl/2xl breakpoints (this extends, not replaces).
+      screens: {
+        xs: '400px',
+      },
       colors: {
         primary: {
           DEFAULT: '#1FA75D', // Turf green (brand accent)

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -713,7 +713,10 @@ test('custom formations (Pro): save current icons, see it listed, stamp it, then
 
   await btn(page, 'Formation templates').click();
   await expect(page.getByText('Save your own formations')).toHaveCount(0);
-  const popover = page.locator('div.fixed.z-40');
+  // z-[60], not z-40: these popovers are portaled to <body>, so /designer's
+  // own `z-50` full-screen shell (added for the sticky navbar, see the
+  // z-index note in Navbar.tsx) needs outranking too, not just the app nav.
+  const popover = page.locator('div.fixed.z-\\[60\\]');
   await popover.getByText('Save current arrangement').click();
   await popover.getByPlaceholder('Formation name').fill('My Trips Set');
   await popover.getByRole('button', { name: 'Save' }).click();
@@ -768,7 +771,10 @@ test('formation menu opens fully on screen from the mobile bottom toolbar', asyn
   await openDesigner(page);
 
   await btn(page, 'Formation templates').click();
-  const popover = page.locator('div.fixed.z-40');
+  // z-[60], not z-40: these popovers are portaled to <body>, so /designer's
+  // own `z-50` full-screen shell (added for the sticky navbar, see the
+  // z-index note in Navbar.tsx) needs outranking too, not just the app nav.
+  const popover = page.locator('div.fixed.z-\\[60\\]');
   await expect(popover).toBeVisible();
   const box = await popover.boundingBox();
   expect(box).not.toBeNull();
@@ -805,7 +811,10 @@ test('icon-edit popover stays on screen and clear of the icon on a short phone c
   const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
   await page.mouse.click(icon.x, icon.y);
 
-  const popover = page.locator('div.fixed.z-40');
+  // z-[60], not z-40: these popovers are portaled to <body>, so /designer's
+  // own `z-50` full-screen shell (added for the sticky navbar, see the
+  // z-index note in Navbar.tsx) needs outranking too, not just the app nav.
+  const popover = page.locator('div.fixed.z-\\[60\\]');
   await expect(popover).toBeVisible();
   const box = await popover.boundingBox();
   expect(box).not.toBeNull();
@@ -836,7 +845,10 @@ test('scrolling inside the formation menu does not close it', async ({ page }) =
   await openDesigner(page);
 
   await btn(page, 'Formation templates').click();
-  const popover = page.locator('div.fixed.z-40');
+  // z-[60], not z-40: these popovers are portaled to <body>, so /designer's
+  // own `z-50` full-screen shell (added for the sticky navbar, see the
+  // z-index note in Navbar.tsx) needs outranking too, not just the app nav.
+  const popover = page.locator('div.fixed.z-\\[60\\]');
   await expect(popover).toBeVisible();
 
   // Past the "just opened, reposition instead of closing" grace window.
@@ -855,7 +867,10 @@ test('a resize does not close a popover while an input inside it has focus', asy
   await openDesigner(page);
 
   await btn(page, 'Route color: Auto (match player) or a fixed color for every new route').click();
-  const popover = page.locator('div.fixed.z-40');
+  // z-[60], not z-40: these popovers are portaled to <body>, so /designer's
+  // own `z-50` full-screen shell (added for the sticky navbar, see the
+  // z-index note in Navbar.tsx) needs outranking too, not just the app nav.
+  const popover = page.locator('div.fixed.z-\\[60\\]');
   await expect(popover).toBeVisible();
 
   await page.getByLabel('Custom route color').focus();
@@ -890,7 +905,7 @@ test('mobile toolbar: tools are labelled, and every one is reachable by scrollin
   const formation = page.locator('button[title="Formation templates"]:visible');
   await formation.scrollIntoViewIfNeeded();
   await realClick(page, formation);
-  await expect(page.locator('div.fixed.z-40')).toBeVisible();
+  await expect(page.locator('div.fixed.z-\\[60\\]')).toBeVisible();
 });
 
 test('formation templates: game-format picker in the menu offers 5v5/6v6/7v7/11v11 sets', async ({ page }) => {

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -4913,3 +4913,34 @@ test('selecting a roster chip tells the user to tap the field to place it', asyn
   await page.mouse.move(spot.x, spot.y);
   await expect(page.getByText('Tap to turn this player into "R"')).toBeVisible();
 });
+
+test('the app navbar stays visible while scrolling a long page', async ({ page }) => {
+  // Regression for B-47: the nav used to be a plain in-flow box, so it scrolled
+  // out of view on any page taller than the viewport. `boundingBox().y` (not
+  // toBeVisible(), which passes for an occluded element too) is the real check
+  // that it's pinned to the top of the viewport, not just present in the DOM.
+  await page.goto('/');
+  await page.evaluate(() => window.scrollTo(0, 800));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+  const box = await page.locator('nav').first().boundingBox();
+  expect(box?.y).toBe(0);
+});
+
+test('the sticky navbar stays fully covered by the full-screen /designer view', async ({ page }) => {
+  // Regression for B-47: making the app navbar `sticky` (positioned, with a
+  // z-index) means it now competes on z-index instead of losing automatically
+  // to later, non-positioned DOM content. /designer's `fixed inset-0` shell
+  // has to explicitly outrank it (z-50 vs. nav's z-40) or the navbar would
+  // float back on top and swallow clicks on the designer's own header —
+  // exactly the failure the old "keep nav non-positioned" comment warned about.
+  await openDesigner(page);
+
+  const hitsAppNavbar = await page.evaluate(() => {
+    const header = document.querySelector('header');
+    const headerBox = header?.getBoundingClientRect();
+    const point = headerBox ? { x: headerBox.left + headerBox.width / 2, y: headerBox.top + headerBox.height / 2 } : { x: 200, y: 20 };
+    return !!document.elementFromPoint(point.x, point.y)?.closest('nav');
+  });
+  expect(hitsAppNavbar).toBe(false);
+});


### PR DESCRIPTION
Closes #97

## What changed and why

`Navbar.tsx` was a plain in-flow box (deliberately non-positioned — see its old comment), so it scrolled out of view on any page taller than the viewport. Made it `sticky top-0 z-40`.

That alone isn't safe, though: `/designer` and `/vs` are `fixed inset-0` full-screen tools that were relying on the nav being non-positioned (and thus automatically losing the stacking order to their later, DOM-order-only `z-auto` container) to stay fully covered. Giving the nav an explicit z-index breaks that, so both routes' root containers now carry an explicit `z-50` to keep outranking it.

That in turn surfaced a second, less obvious break, found during verification (see below): `/designer`'s `FormationMenu`, `RouteColorButton`, and three of `Canvas.tsx`'s popovers (`createPortal(..., document.body)`, used to escape the toolbar's `overflow-y-auto` clipping) stopped nesting inside the new `z-50` shell's local stacking context once it became a real stacking context, and started losing to it as flat siblings instead. Bumped those to `z-[55]`/`z-[60]` (matching the `z-[60]` convention `UpgradePrompt.tsx` already uses to outrank a `z-50` modal) and updated the smoke suite's `div.fixed.z-40` popover selectors to match.

Also adds the `xs: 400px` Tailwind breakpoint called out in the issue (`tailwind.config.js` never set `screens`, so one `sm:640` flip governed everything from a 320px phone to a 639px foldable) and uses it for a bit more breathing room in the mobile header's action row (`gap-1 xs:gap-2`).

**Issue text vs. current code:** the issue said adding `relative z-50` would "swallow UserMenu's dropdown" — the actual comment in the code said it swallows clicks on the *designer toolbar* instead, which is what I verified and fixed (root-caused with a hit-test, see below).

## Verification

```
npm run typecheck && npm run build
npx eslint src/components/Navbar.tsx src/components/designer/PlayDesigner.tsx \
  src/components/vs/VsDefenseView.tsx src/components/designer/Canvas.tsx \
  src/components/designer/FormationMenu.tsx src/components/designer/RouteColorButton.tsx \
  tailwind.config.js tests/smoke/designer.spec.ts
```
Both clean — typecheck 0 errors, build succeeds, eslint 0 new errors (only pre-existing `no-explicit-any`/fast-refresh warnings in files I touched).

```
PBP_CHROMIUM_PATH=/opt/pw-browsers/chromium npm run smoke
```
160 passed, 1 failed (`mobile.spec.ts` "every interactive control clears 44px under touch" — a `page.goto` navigation timeout after ~19 minutes of continuous runs, not an assertion about the change). Re-ran that one test in isolation and it passed cleanly, confirming a transient flake rather than a regression.

Two new smoke tests added, both confirmed to fail without their fix before I wrote the fix (stashed the source change, ran the test, watched it fail, restored — then reran to confirm green):
- `the app navbar stays visible while scrolling a long page` — fails on unmodified `Navbar.tsx` (`boundingBox().y` was `-800` after scrolling instead of `0`).
- `the sticky navbar stays fully covered by the full-screen /designer view` — fails when `Navbar.tsx`'s sticky change is present but `PlayDesigner.tsx`'s z-50 bump is reverted (hit-tests `document.elementFromPoint` at the designer header's center and asserts it doesn't resolve inside `<nav>`).

The portal-stacking regression itself was caught by the *existing* smoke suite (not new tests) — full run went from 15 failures to 0 once root-caused and fixed, reproduced consistently (2 runs each way) and isolated to the exact commit via `git checkout <parent-commit> -- <file>` bisection before writing the fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGEySjGvy2Sz3J7aXqq8E7)_