### PR TITLE
[nightly] Fix blog post typography (working prose, mobile padding, URL wrap)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@eslint/js": "^9.9.1",
         "@playwright/test": "^1.61.1",
+        "@tailwindcss/typography": "^0.5.20",
         "@types/node": "^24.3.0",
         "@types/react": "^18.2.7",
         "@types/react-dom": "^18.2.4",
@@ -1414,6 +1415,33 @@
         "@supabase/postgrest-js": "1.21.3",
         "@supabase/realtime-js": "2.15.1",
         "@supabase/storage-js": "^2.10.4"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tiptap/core": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@eslint/js": "^9.9.1",
     "@playwright/test": "^1.61.1",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/node": "^24.3.0",
     "@types/react": "^18.2.7",
     "@types/react-dom": "^18.2.4",

--- a/src/components/blog/BlogPage.tsx
+++ b/src/components/blog/BlogPage.tsx
@@ -80,7 +80,7 @@ export function BlogPostPage() {
         </Link>
 
         {loading ? (
-          <div className="bg-board-light rounded-lg p-8 border border-chalk/10 animate-pulse">
+          <div className="bg-board-light rounded-lg p-4 sm:p-8 border border-chalk/10 animate-pulse">
             <div className="h-8 bg-chalk/10 rounded w-2/3 mb-6"></div>
             <div className="h-4 bg-chalk/10 rounded w-full mb-3"></div>
             <div className="h-4 bg-chalk/10 rounded w-5/6"></div>
@@ -94,9 +94,9 @@ export function BlogPostPage() {
             <p className="text-chalk/70">This post may have been removed or the link is incorrect.</p>
           </div>
         ) : (
-          <article className="bg-board-light rounded-lg p-8 border border-chalk/10">
+          <article className="bg-board-light rounded-lg p-4 sm:p-8 border border-chalk/10">
             <header className="mb-8">
-              <h1 className="text-3xl font-bold text-chalk mb-4">{post.title}</h1>
+              <h1 className="text-3xl font-bold text-chalk mb-4 break-words">{post.title}</h1>
               <div className="flex items-center gap-4 text-sm text-chalk/70">
                 <div className="flex items-center gap-1">
                   <Calendar className="h-4 w-4" />
@@ -111,7 +111,7 @@ export function BlogPostPage() {
               </div>
             </header>
 
-            <div className="prose prose-invert max-w-none">{formatContent(post.content)}</div>
+            <div className="prose prose-invert break-words">{formatContent(post.content)}</div>
           </article>
         )}
       </div>
@@ -159,7 +159,7 @@ export function BlogPage() {
     <div className="min-h-screen bg-board">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
-        <div className="bg-board-light rounded-lg p-8 mb-8 border border-chalk/10">
+        <div className="bg-board-light rounded-lg p-4 sm:p-8 mb-8 border border-chalk/10">
           <div className="flex items-center gap-3 mb-4">
             <Book className="h-8 w-8 text-primary" />
             <h1 className="text-3xl font-chalk font-bold text-chalk">Blog</h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import typography from '@tailwindcss/typography';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
@@ -31,5 +33,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [typography],
 };

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -411,3 +411,39 @@ test('taps get no default highlight flash and the page does not rubber-band', as
   expect(styles.overscrollX).toBe('none');
   expect(styles.overscrollY).toBe('none');
 });
+
+/* ── Blog post typography on phones (B-49) ──────────────────────────────────
+   `prose prose-invert` was inert (no `@tailwindcss/typography` plugin
+   registered), so a post carrying a long unbroken token — a URL with no
+   spaces — had nothing to wrap it and pushed the whole article sideways.
+   The `/blog/<slug>` route wasn't in the existing "no page scrolls
+   sideways" sweep (which only exercises unauthenticated fixed routes), so
+   this regression had no guard at all. */
+test('a long unbroken URL in a blog post does not push the page sideways', async ({ page }) => {
+  const longUrl = 'https://example.com/' + 'a'.repeat(120) + '/deep/path/segment';
+  await page.route('**/rest/v1/blog_posts**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'post-1',
+        title: 'A post with a long link',
+        content: `Check this out: ${longUrl}\n\nMore text after it.`,
+        slug: 'long-link-post',
+        description: null,
+        author_id: 'someone',
+        published_at: '2025-09-01T00:00:00Z',
+        created_at: '2025-09-01T00:00:00Z',
+        updated_at: '2025-09-01T00:00:00Z',
+      }),
+    }));
+
+  await page.goto('/blog/long-link-post', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: 'A post with a long link' })).toBeVisible();
+
+  const { scrollW, clientW } = await page.evaluate(() => ({
+    scrollW: document.documentElement.scrollWidth,
+    clientW: document.documentElement.clientWidth,
+  }));
+  expect(scrollW, 'the long URL should wrap instead of widening the document').toBeLessThanOrEqual(clientW + 1);
+});


### PR DESCRIPTION
Closes #99

## What changed and why

`BlogPostPage` (`src/components/blog/BlogPage.tsx`) used `prose prose-invert max-w-none`, but `@tailwindcss/typography` was never installed (`tailwind.config.js` had `plugins: []`), so the class was inert:

- **No measure.** Installed and registered `@tailwindcss/typography` and dropped the `max-w-none` override, so long-form posts now get the plugin's default ~65ch reading width inside the existing `max-w-4xl` container, instead of stretching full-width.
- **No overflow-wrap.** A long unbroken token (a URL with no spaces) had nothing to wrap it and pushed the whole document sideways. Added `break-words` to the prose container (inherited by the rendered `<p>` tags).
- **279px mobile column.** `p-8` nested inside the page's `px-4` left only 279px of width on a 375px phone. Changed the three `p-8` containers on the blog pages (list-page header, post article, post loading skeleton) to `p-4 sm:p-8`.

**Out of scope:** the issue also notes `formatContent()` only splits on `\n\n` and doesn't render markdown/images. I checked `BlogManagement.tsx` (the admin post editor) — posts are authored as plain text via a `<textarea>`, with no markdown or image support anywhere in the authoring or storage path (no markdown parser dependency, no image upload for post bodies). Adding that is a real feature (parser + sanitization + editor changes), not a typography fix, so I left it alone rather than bundling it into a low-priority styling issue. Happy to file it as a separate issue if wanted.

## Verification

```
npm run typecheck && npm run build
```
Both clean.

```
npx eslint src/components/blog/BlogPage.tsx tailwind.config.js tests/smoke/mobile.spec.ts
```
0 errors, 2 pre-existing warnings (both in `seedForTapTargets`, lines 242/248 — untouched by this change).

```
PBP_CHROMIUM_PATH=<pinned chromium> npm run smoke
```
161 passed, 1 failed (`every interactive control clears 44px under touch` — a `page.goto` navigation timeout on `/account`, unrelated to this change). Re-ran that single test in isolation and it passed in 28.4s, confirming an environmental flake under this sandbox's parallel load rather than a regression (consistent with the flakiness CLAUDE.md documents for this suite).

**New regression test:** added `a long unbroken URL in a blog post does not push the page sideways` to `tests/smoke/mobile.spec.ts`, mocking `blog_posts` with a post containing a 140+ char unbroken URL and asserting the document doesn't scroll horizontally at 375px. Confirmed it **fails without the fix** — stashed the source changes, ran the test, got `document width 1406 > viewport 376`; restored the fix and it passed. The existing "no page scrolls sideways" sweep doesn't cover `/blog/:slug`, so nothing previously caught this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEE3HaFYWSWeJA1nP9rws7)_