### PR TITLE
Docs: record what's actually deployed in the feedback pipeline

### DIFF
--- a/docs/automation/feedback-triage.md
+++ b/docs/automation/feedback-triage.md
@@ -30,11 +30,31 @@ Supabase dashboard.
 | # | Step | Status |
 |---|------|--------|
 | 1 | `supabase/feedback_triage.sql` run in the SQL Editor | ✅ 2026-08-05 (per `supabase/SCHEMA.md`) |
-| 2 | `supabase secrets set FEEDBACK_TRIAGE_SECRET=…` | ⬜ not confirmed |
-| 3 | `supabase functions deploy feedback-triage --no-verify-jwt` | ⬜ not confirmed |
+| 2 | `supabase secrets set FEEDBACK_TRIAGE_SECRET=…` | ✅ 2026-08-19 (see the probe below) |
+| 3 | `supabase functions deploy feedback-triage --no-verify-jwt` | ✅ 2026-08-19 (see the probe below) |
 | 4 | Dry run passed (see [the dry run](#before-scheduling-it-the-dry-run)) | ⬜ not run |
 | 5 | Routine created at claude.ai/code/routines, daily | ⬜ not confirmed |
 | 6 | Prompt updated to the intake-only version below (2026-08-17) | ⬜ not confirmed |
+
+**Rows 2 and 3 are confirmed by the endpoint itself**, not by anyone's memory:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  "https://<project-ref>.supabase.co/functions/v1/feedback-triage" \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+`401` = deployed **and** failing closed on a missing secret, which is both rows
+at once. `404` = not deployed. This is the check that diagnosed the digest
+outage on 2026-08-14: `feedback-notify` was returning 404 for weeks while
+feedback piled up uncollected, and one curl found it after a lot of guessing.
+Prefer it over trusting a tick in this table.
+
+⚠ **Rows 4–6 are what stand between "captured" and "triaged" today.** Feedback
+*is* arriving — rows are visible in `/admin` — but **the routine has never filed
+an issue.** The only `from-feedback` issues in the repo (#100, #101) were
+created by hand while rescuing two stranded proposal branches. Nothing is
+converting submissions into queue items.
 
 Do them **in that order**. Steps 2 and 3 together are what makes the endpoint
 reachable: deploying before the secret is set leaves a live function whose

--- a/supabase/EMAIL_SETUP.md
+++ b/supabase/EMAIL_SETUP.md
@@ -101,6 +101,18 @@ unless that changes.
 
 ## 6. Feedback digest (separate from everything above)
 
+> **Status 2026-08-19:** the function is **deployed** — `POST` to
+> `/functions/v1/feedback-notify` returns `401` (deployed, failing closed on a
+> missing secret) rather than `404`. Steps 1–2 below are done.
+> **Not confirmed:** whether `feedback_notify.sql`'s cron block was re-run with
+> its two placeholders filled in. It was originally run *before* the function
+> existed, so unless it was re-run, `cron.job` still POSTs nightly to a literal
+> `<PROJECT-REF>` host and no digest is ever sent. Check with
+> `SELECT command FROM cron.job WHERE jobname = 'feedback-digest';` — a literal
+> `<` in the output means it's still broken. Re-running the file is safe; it
+> unschedules first.
+
+
 Steps 1–5 configure Resend as Supabase **Auth's** SMTP provider — signup
 confirmations and password resets, sent by Supabase itself. The feedback digest
 is a different path: the `feedback-notify` Edge Function calls **Resend's HTTP


### PR DESCRIPTION
Docs only. No code, no schema, no behaviour change.

## The correction

Rows 2 and 3 of the triage deployment table said **"not confirmed"** while the endpoint had been answering `401` for days — meaning deployed *and* failing closed on a missing secret. A `404` would mean not deployed.

Ticked both, with the probe recorded inline so the next person confirms it from the endpoint rather than trusting a mark in a table:

```sh
curl -s -o /dev/null -w '%{http_code}\n' -X POST \
  ".../functions/v1/feedback-triage" -H 'Content-Type: application/json' -d '{}'
```

That distinction isn't academic. **404-vs-401 is exactly what diagnosed the digest outage on 2026-08-14** — `feedback-notify` had been returning 404 for weeks while feedback accumulated uncollected, and one curl found it after a lot of guessing.

## The gap it makes visible

With rows 2–3 ticked, what's actually blocking is narrower and clearer: **rows 4–6.**

⚠ **Feedback is being captured but never triaged.** Rows are arriving (visible in `/admin`), but the routine **has never filed an issue** — the only `from-feedback` issues in the repo (#100, #101) were created by hand while rescuing two stranded proposal branches.

Row 4 is the one I'd not skip: the dry run is the only supervised test of the prompt-injection guardrails, and this doc's own instructions say don't schedule the routine until it passes.

## Also: the digest's status, including what's still unknown

Added the same note to `EMAIL_SETUP.md` §6 — the function is deployed, **but** it's still unconfirmed whether `feedback_notify.sql`'s cron block was re-run with its two placeholders filled in. It was originally run *before* the function existed, so unless it was re-run, `cron.job` still POSTs nightly to a literal `<PROJECT-REF>` host and no digest is ever sent.

```sql
SELECT command FROM cron.job WHERE jobname = 'feedback-digest';
```

A literal `<` in that output means it's still broken. Re-running the file is safe — it unschedules first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)