### PR TITLE
⚠ MONEY — Stripe webhook: refuse test-mode events by default

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -8,6 +8,10 @@
 // Required secrets (supabase secrets set KEY=value):
 //   STRIPE_SECRET_KEY      — sk_live_... / sk_test_...
 //   STRIPE_WEBHOOK_SECRET  — whsec_... from the webhook endpoint config
+// Optional:
+//   STRIPE_ALLOW_TEST_MODE — 'true' lets test-mode events grant entitlements.
+//     OFF by default. A signed test-mode event is a valid request, so without
+//     this guard a Stripe test card buys real Pro for free.
 // (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically.)
 //
 // Webhook endpoint events to subscribe:
@@ -17,6 +21,7 @@
 
 import Stripe from 'npm:stripe@18';
 import { createClient } from 'npm:@supabase/supabase-js@2';
+import { shouldProcessEvent } from './livemode.ts';
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
   httpClient: Stripe.createFetchHttpClient(),
@@ -81,6 +86,19 @@ Deno.serve(async (req) => {
   } catch (err) {
     console.error('Webhook signature verification failed:', err);
     return new Response('Invalid signature', { status: 400 });
+  }
+
+  // A valid signature does not mean real money. Test-mode events are signed
+  // too, so entitlement-granting has to gate on livemode explicitly.
+  const gate = shouldProcessEvent(event.livemode, Deno.env.get('STRIPE_ALLOW_TEST_MODE'));
+  if (!gate.process) {
+    console.warn(`Ignoring ${event.type} (${event.id}): ${gate.reason}`);
+    // 200, not an error: this is a correctly-signed event we are deliberately
+    // declining. A non-2xx would make Stripe retry it for days.
+    return new Response(JSON.stringify({ received: true, ignored: gate.reason }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   try {

--- a/supabase/functions/stripe-webhook/livemode.check.mjs
+++ b/supabase/functions/stripe-webhook/livemode.check.mjs
@@ -1,0 +1,40 @@
+// Standalone check for livemode.ts. The repo has no unit runner and Playwright
+// can't reach Deno-targeted files, so this is a plain script — same approach as
+// feedback-notify/digest.check.mjs.
+//
+//   npx esbuild supabase/functions/stripe-webhook/livemode.ts \
+//     --format=esm --outfile=/tmp/livemode.mjs
+//   node supabase/functions/stripe-webhook/livemode.check.mjs /tmp/livemode.mjs
+
+const mod = await import(process.argv[2] ?? '/tmp/livemode.mjs');
+const { shouldProcessEvent } = mod;
+
+let failed = 0;
+const check = (name, got, want) => {
+  const ok = got === want;
+  if (!ok) failed++;
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${name}${ok ? '' : ` — got ${got}, want ${want}`}`);
+};
+
+// The whole point: a signed test-mode event must not grant anything.
+check('test mode, flag unset → ignored', shouldProcessEvent(false, undefined).process, false);
+check('test mode, flag empty → ignored', shouldProcessEvent(false, '').process, false);
+check('live mode, flag unset → processed', shouldProcessEvent(true, undefined).process, true);
+
+// The escape hatch, and its exact-match rule. 'TRUE' silently failing the
+// === 'true' check is a mistake this repo has already made once with
+// VITE_BILLING_ENABLED, so it is asserted rather than assumed.
+check('test mode + STRIPE_ALLOW_TEST_MODE=true → processed', shouldProcessEvent(false, 'true').process, true);
+check('test mode + TRUE (wrong case) → ignored', shouldProcessEvent(false, 'TRUE').process, false);
+check('test mode + "1" → ignored', shouldProcessEvent(false, '1').process, false);
+check('test mode + "yes" → ignored', shouldProcessEvent(false, 'yes').process, false);
+
+// Live mode is never affected by the flag in either direction.
+check('live mode + flag off → still processed', shouldProcessEvent(true, 'false').process, true);
+check('live mode + flag on → still processed', shouldProcessEvent(true, 'true').process, true);
+
+// Reasons are logged, so they must be non-empty.
+check('ignored reason is explanatory', shouldProcessEvent(false, undefined).reason.includes('STRIPE_ALLOW_TEST_MODE'), true);
+
+console.log(failed ? `\n${failed} FAILED` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/supabase/functions/stripe-webhook/livemode.ts
+++ b/supabase/functions/stripe-webhook/livemode.ts
@@ -1,0 +1,34 @@
+/** Should this webhook event be allowed to grant entitlements?
+ *
+ *  Stripe signs test-mode and live-mode events with different secrets, but a
+ *  correctly-signed TEST event is still a valid request — nothing about
+ *  signature verification distinguishes real money from a test card. Without
+ *  this check, anyone who reaches a checkout backed by test keys and types
+ *  Stripe's published test card (4242 4242 4242 4242) is granted full Pro,
+ *  permanently, for nothing. That is not hypothetical: it happened on
+ *  playbuilderpro.com in August 2026 while VITE_BILLING_ENABLED was true in
+ *  Netlify and the keys were still the sandbox pair.
+ *
+ *  Pure and dependency-free so it can be exercised without Deno or a live
+ *  Stripe — same pattern as feedback-notify's digest.ts.
+ *
+ *  @param livemode      `event.livemode` from the verified Stripe event.
+ *  @param allowTestMode `STRIPE_ALLOW_TEST_MODE` — the deliberate escape hatch
+ *                       for sandbox end-to-end testing (B-18 requires one).
+ *                       Anything other than the exact string 'true' is off,
+ *                       matching VITE_BILLING_ENABLED's convention.
+ */
+export function shouldProcessEvent(
+  livemode: boolean,
+  allowTestMode: string | undefined,
+): { process: boolean; reason: string } {
+  if (livemode) return { process: true, reason: 'live-mode event' };
+  if (allowTestMode === 'true') {
+    return { process: true, reason: 'test-mode event allowed by STRIPE_ALLOW_TEST_MODE' };
+  }
+  return {
+    process: false,
+    reason:
+      'test-mode event ignored — set STRIPE_ALLOW_TEST_MODE=true to allow sandbox testing',
+  };
+}


### PR DESCRIPTION
**A real visitor obtained full Pro access with a Stripe test card. No money was collected.** Confirmed by Jeremy: the customer is in the Playbuilder Pro *sandbox*, not live.

## How

Two independent facts, neither wrong alone:

**1. Billing is live on production.** `VITE_BILLING_ENABLED` is `true` in Netlify, so the homepage Pro button opens a real Stripe Checkout. Verified against the deployed bundle rather than assumed — `"Redirecting to checkout…"` (which exists only in the `BILLING_ENABLED` branch) is present, and `"Coming soon"` (the disabled branch) appears in **no chunk**.

**2. The webhook had no `livemode` check.** It verified the signature, then granted entitlements. But Stripe signs test-mode events too — **a valid signature proves the request came from Stripe, not that money changed hands.** Anyone entering `4242 4242 4242 4242` got unlimited plays, unlimited playbooks, full playbook PDFs and wristband export, permanently, for free.

That card number is the first result for "stripe test card".

## What this PR fixes — and what it doesn't

**Fixes (2).** Non-livemode events are now ignored unless `STRIPE_ALLOW_TEST_MODE=true` is set explicitly. Off by default; kept because B-18 requires a sandbox end-to-end test before going live.

Declined events return **200, not an error** — they're correctly-signed events we're deliberately refusing, and a non-2xx would make Stripe retry them for days.

**Does not fix (1).** `VITE_BILLING_ENABLED` is a Netlify env var, not code. **Setting it to `false` and redeploying is the containment step, and it's faster than merging this.** Do that first.

**Does not resolve the existing Pro row.** `admin_set_user_plan` raises `PBP06` for any row with a `stripe_subscription_id`, so `/admin` cannot change it by design. That needs a decision and hand-run SQL — see below.

## Verification

- `livemode.check.mjs` — **10/10**. Pure function, standalone script, same pattern as `feedback-notify/digest.ts`, since the repo has no unit runner and Playwright can't reach Deno files.
- It asserts `'TRUE'` and `'1'` do **not** enable test mode. The exact-string convention isn't pedantry — `VITE_BILLING_ENABLED` already made that exact mistake once, and it's recorded in `CLAUDE.md`.
- `npm run typecheck`, `npm run build` clean; **smoke 162/162**. (One unrelated flake on the first run — "free-plan user sees no Founding Member badge" — passed in isolation and on a clean re-run.)

## After merging, this needs a deploy

```sh
supabase functions deploy stripe-webhook --no-verify-jwt --project-ref nlfwfbbpcvyfyugxiysz
```

The function does not update itself on merge. Until that runs, the guard isn't live.

## Decisions for you

1. **The existing user.** They have Pro they didn't pay for. Leave it as goodwill, or clear it? Clearing needs SQL — `/admin` refuses. I'd want your call before writing that.
2. **Are there others?** Worth checking `subscriptions` for other rows with a `stripe_subscription_id` — this was found by chance.
3. **B-18 said live-mode was blocked on B-21 (attorney review) by choice.** `VITE_BILLING_ENABLED=true` in Netlify quietly bypassed that gate. The env var is the real switch; the backlog item was only ever a note about intent.

Money code — **PR only, human review required. Do not merge without reading.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)