### PR TITLE
Add Copy Route: paste an existing route onto another player

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -120,6 +120,10 @@ type CanvasProps = {
   deleteRouteMode: boolean;
   /** Tap a player's icon to recolor just their route. */
   recolorRouteMode: boolean;
+  /** Tap a route to pick it up, then tap a player to paste a copy onto them. */
+  copyRouteMode: boolean;
+  /** Mirrors the pasted route's shape left/right relative to its own start point. */
+  copyRouteMirror: boolean;
   zoneMode: boolean;
   deleteZoneMode: boolean;
   textMode: boolean;
@@ -168,7 +172,7 @@ export type CanvasHandle = {
 // Component
 // ---------------------------------------------
 export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
-  ({ width, height, drawingMode, drawMode, capStyle, dashed, routeColorMode, deleteRouteMode, recolorRouteMode, zoneMode, deleteZoneMode, textMode, snapEnabled, selectedPlayer, setSelectedPlayer, onDrawingComplete, onHistoryChange, onPan, onPinch, id }, ref) => {
+  ({ width, height, drawingMode, drawMode, capStyle, dashed, routeColorMode, deleteRouteMode, recolorRouteMode, copyRouteMode, copyRouteMirror, zoneMode, deleteZoneMode, textMode, snapEnabled, selectedPlayer, setSelectedPlayer, onDrawingComplete, onHistoryChange, onPan, onPinch, id }, ref) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
     const [paths, setPaths] = useState<PathItem[]>([]);
@@ -234,6 +238,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     const [deletedZoneFlash, setDeletedZoneFlash] = useState(false);
     const deletedZoneFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    // Flash shown when Copy Route's picked route is tapped back onto its own
+    // source icon — pasting onto yourself can't produce anything useful.
+    const [selfPasteFlash, setSelfPasteFlash] = useState(false);
+    const selfPasteFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
     // Drag state. Shared between icons and text boxes — only one gesture is
     // ever in flight (a single pointer-down picks exactly one target), so
     // draggingIndexRef (icon) and draggingTextIndexRef (text box) are never
@@ -270,6 +279,9 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
      *  — path-indexed, not icon-indexed, so it targets one specific route
      *  when a player has 2. */
     const [editingRouteColorPathIndex, setEditingRouteColorPathIndex] = useState<number | null>(null);
+    // Route (index into `paths`) picked up via Copy Route, waiting for a tap
+    // on a destination player icon.
+    const [copyRoutePickedIndex, setCopyRoutePickedIndex] = useState<number | null>(null);
     // Text box being edited via its popover (Select mode, or immediately
     // after placing a new one in Text mode).
     const [editingTextIndex, setEditingTextIndex] = useState<number | null>(null);
@@ -698,7 +710,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       if (waypointPoints.length === 0 && hoveredIconIndex !== null && playerIcons[hoveredIconIndex]) {
         const hi = toPx(playerIcons[hoveredIconIndex]);
         const hasZone = iconHasZone(hoveredIconIndex);
-        const blocked = (drawingMode && iconRouteCount(hoveredIconIndex) >= MAX_ROUTES_PER_ICON) || (zoneMode && hasZone);
+        const copyRouteBlocked = copyRouteMode && copyRoutePickedIndex !== null && (
+          iconRouteCount(hoveredIconIndex) >= MAX_ROUTES_PER_ICON
+          || hoveredIconIndex === paths[copyRoutePickedIndex]?.startIconIndex
+        );
+        const blocked = (drawingMode && iconRouteCount(hoveredIconIndex) >= MAX_ROUTES_PER_ICON) || (zoneMode && hasZone) || copyRouteBlocked;
         const ringColor = deleteZoneMode
           ? '#f59e0b'
           : (blocked ? '#ef4444' : playerIcons[hoveredIconIndex].color);
@@ -727,8 +743,8 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       // specific targeted route's own points, not a ring around the icon,
       // so a coach can tell which of a player's up-to-2 routes is under the
       // pointer (or currently open in the recolor popover).
-      const targetPathIndex = (deleteRouteMode || recolorRouteMode)
-        ? (editingRouteColorPathIndex ?? hoveredPathIndex)
+      const targetPathIndex = (deleteRouteMode || recolorRouteMode || copyRouteMode)
+        ? (editingRouteColorPathIndex ?? copyRoutePickedIndex ?? hoveredPathIndex)
         : null;
       if (targetPathIndex !== null && paths[targetPathIndex]) {
         const highlightColor = deleteRouteMode ? '#f59e0b' : '#ffffff';
@@ -746,7 +762,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         ctx.stroke();
         ctx.restore();
       }
-    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, waypointSegmentDashed, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, hoveredPathIndex, editingRouteColorPathIndex, drawMode, capStyle, dashed, deleteRouteMode, recolorRouteMode, drawingMode, zoneMode, deleteZoneMode, iconRouteCount, iconHasZone]);
+    }, [paths, playerIcons, zones, textBoxes, editingTextIndex, selectedZoneIndex, zoneDraft, activeGuides, waypointPoints, waypointSegmentDashed, pendingPoint, waypointColor, waypointIconIndex, hoveredIconIndex, hoveredPathIndex, editingRouteColorPathIndex, copyRoutePickedIndex, drawMode, capStyle, dashed, deleteRouteMode, recolorRouteMode, copyRouteMode, drawingMode, zoneMode, deleteZoneMode, iconRouteCount, iconHasZone]);
 
     // Redraw on state change
     useEffect(() => { draw(); }, [draw]);
@@ -803,11 +819,11 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     // its own popover right after placement, so it's excluded from closing
     // itself here — see the textMode branch in handlePointerDown).
     useEffect(() => {
-      if (drawingMode || zoneMode || deleteRouteMode || recolorRouteMode || deleteZoneMode || selectedPlayer) {
+      if (drawingMode || zoneMode || deleteRouteMode || recolorRouteMode || copyRouteMode || deleteZoneMode || selectedPlayer) {
         setEditingIconIndex(null);
         setEditingTextIndex(null);
       }
-    }, [drawingMode, zoneMode, deleteRouteMode, recolorRouteMode, deleteZoneMode, selectedPlayer]);
+    }, [drawingMode, zoneMode, deleteRouteMode, recolorRouteMode, copyRouteMode, deleteZoneMode, selectedPlayer]);
 
     // Switching into text mode dismisses the icon popover (they're mutually
     // exclusive tools); leaving text mode dismisses the text popover.
@@ -823,6 +839,12 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
     useEffect(() => {
       if (!recolorRouteMode) setEditingRouteColorPathIndex(null);
     }, [recolorRouteMode]);
+
+    // The picked-up route for Copy Route only makes sense while that mode is
+    // active — same reasoning as the Recolor Route popover above.
+    useEffect(() => {
+      if (!copyRouteMode) setCopyRoutePickedIndex(null);
+    }, [copyRouteMode]);
 
     // ------------------------------------------
     // Imperative handle
@@ -1146,6 +1168,60 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         return;
       }
 
+      // Copy-route mode — tap a route to pick it up, then tap a player to
+      // paste a translated copy onto them. Stays picked after a paste
+      // (stamp-like), so the same route can be stamped onto several players
+      // without re-picking it each time.
+      if (copyRouteMode) {
+        if (copyRoutePickedIndex === null) {
+          const pathHit = findPathAt(p);
+          if (pathHit >= 0) setCopyRoutePickedIndex(pathHit);
+          setHoveredPathIndex(null);
+          return;
+        }
+        if (clicked >= 0) {
+          const srcPath = paths[copyRoutePickedIndex];
+          if (clicked === srcPath.startIconIndex) {
+            if (selfPasteFlashTimerRef.current) clearTimeout(selfPasteFlashTimerRef.current);
+            setSelfPasteFlash(true);
+            selfPasteFlashTimerRef.current = setTimeout(() => setSelfPasteFlash(false), 2500);
+            return;
+          }
+          if (iconRouteCount(clicked) >= MAX_ROUTES_PER_ICON) {
+            if (conflictFlashTimerRef.current) clearTimeout(conflictFlashTimerRef.current);
+            setConflictFlash(true);
+            conflictFlashTimerRef.current = setTimeout(() => setConflictFlash(false), 2500);
+            return;
+          }
+          const srcStart = srcPath.points[0];
+          const destIcon = playerIcons[clicked];
+          const newPoints = srcPath.points.map((pt) => {
+            const offX = copyRouteMirror ? -(pt.x - srcStart.x) : pt.x - srcStart.x;
+            return { x: destIcon.x + offX, y: destIcon.y + (pt.y - srcStart.y) };
+          });
+          pushSnapshot();
+          setPaths((prev) => [...prev, {
+            ...srcPath,
+            points: newPoints,
+            startIconIndex: clicked,
+            // Color intentionally NOT cloned from srcPath — matches destIcon's
+            // color and stays synced to it going forward, exactly like a
+            // route freshly drawn on this icon in routeColorMode 'auto'.
+            // The source's own color/independentColor (even if it was
+            // custom-recolored) is deliberately discarded.
+            color: destIcon.color,
+            independentColor: undefined,
+            segmentDashed: srcPath.segmentDashed ? [...srcPath.segmentDashed] : undefined,
+          }]);
+          return;
+        }
+        // No icon hit — allow re-picking a different route instead of no-op.
+        const pathHit = findPathAt(p);
+        if (pathHit >= 0) setCopyRoutePickedIndex(pathHit);
+        setHoveredPathIndex(null);
+        return;
+      }
+
       // Delete-zone mode — tap a zone (or its player) to remove it
       if (deleteZoneMode) {
         let zoneIdx = clicked >= 0 ? findZoneByIcon(clicked) : -1;
@@ -1440,17 +1516,18 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
       // Hover highlight: show which icon will be the route origin, or which
       // zone will be affected.
-      if ((drawingMode && waypointPoints.length === 0) || zoneMode || deleteZoneMode || selectedPlayer) {
+      if ((drawingMode && waypointPoints.length === 0) || zoneMode || deleteZoneMode || selectedPlayer || (copyRouteMode && copyRoutePickedIndex !== null)) {
         const idx = findIcon(p);
         setHoveredIconIndex(idx >= 0 ? idx : null);
       } else if (hoveredIconIndex !== null) {
         setHoveredIconIndex(null);
       }
 
-      // Delete/Recolor Route hover which specific route LINE is under the
-      // pointer (an icon can have 2 routes, so icon-based hover can't tell
-      // them apart — see findPathAt).
-      if (deleteRouteMode || recolorRouteMode) {
+      // Delete/Recolor/Copy Route hover which specific route LINE is under
+      // the pointer (an icon can have 2 routes, so icon-based hover can't
+      // tell them apart — see findPathAt). Copy Route only hovers routes
+      // while nothing is picked yet — once picked, hovering targets icons.
+      if (deleteRouteMode || recolorRouteMode || (copyRouteMode && copyRoutePickedIndex === null)) {
         const idx = findPathAt(p);
         setHoveredPathIndex(idx >= 0 ? idx : null);
       } else if (hoveredPathIndex !== null) {
@@ -1646,6 +1723,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       instructionText = hoveredPath
         ? `Tap to recolor ${hoveredPathOriginLetter ? `"${hoveredPathOriginLetter}"'s` : 'this'} route`
         : 'Tap a route to recolor it';
+    } else if (copyRouteMode) {
+      instructionText = copyRoutePickedIndex === null
+        ? (hoveredPath ? `Tap to copy ${hoveredPathOriginLetter ? `"${hoveredPathOriginLetter}"'s` : 'this'} route` : 'Tap a route to copy it')
+        : (copyRouteMirror ? 'Tap a player to paste the mirrored route' : 'Tap a player to paste the route');
     } else if (deleteZoneMode) {
       if (hoveredIconIndex !== null && playerIcons[hoveredIconIndex]) {
         const ltr = playerIcons[hoveredIconIndex].letter;
@@ -1706,13 +1787,13 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         />
 
         {/* ── Contextual instruction bar (top of canvas) ── */}
-        {(savedFlash || conflictFlash || finishFirstFlash || deletedFlash || deletedZoneFlash || instructionText) && (
+        {(savedFlash || conflictFlash || finishFirstFlash || deletedFlash || deletedZoneFlash || selfPasteFlash || instructionText) && (
           <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 pointer-events-none px-3 w-full max-w-sm">
             <div
               className={`text-white text-xs font-medium px-4 py-2 rounded-full shadow-lg text-center leading-snug transition-colors duration-300 ${
                 savedFlash ? 'bg-green-600'
                 : (deletedFlash || deletedZoneFlash) ? 'bg-amber-600'
-                : (conflictFlash || finishFirstFlash) ? 'bg-red-600'
+                : (conflictFlash || finishFirstFlash || selfPasteFlash) ? 'bg-red-600'
                 : 'bg-black/65 backdrop-blur-sm'
               }`}
             >
@@ -1721,6 +1802,7 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
                 : deletedZoneFlash ? '✓ Zone removed'
                 : finishFirstFlash ? 'Finish or cancel the current route first'
                 : conflictFlash ? 'This player already has 2 routes · Use Remove Route to clear one'
+                : selfPasteFlash ? 'Pick a different player to paste onto'
                 : instructionText}
             </div>
           </div>

--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet, Shield, Type, ArrowUpRight, Palette } from 'lucide-react';
+import { MousePointer, Undo, Redo, Eraser, Minus, GitBranch, RouteOff, Circle, CircleOff, Magnet, Shield, Type, ArrowUpRight, Palette, Copy, FlipHorizontal } from 'lucide-react';
 import { PlayerToolbar } from './PlayerToolbar';
 import { resolveRoster, type CustomRoster } from './rosters';
 import { FormationMenu } from './FormationMenu';
@@ -39,6 +39,15 @@ interface DesignerToolbarProps {
    *  sticky default above and any other route. */
   recolorRouteMode: boolean;
   setRecolorRouteMode: (mode: boolean) => void;
+  /** Tap a route to pick it up, then tap a player to paste a copy onto them —
+   *  translated to start at that player's position. Stays picked after one
+   *  paste so a coach can stamp the same route onto several players. */
+  copyRouteMode: boolean;
+  setCopyRouteMode: (mode: boolean) => void;
+  /** Sticky like capStyle/dashed above: reflects the pasted route's shape
+   *  left/right relative to its own start point. */
+  copyRouteMirror: boolean;
+  setCopyRouteMirror: (mirror: boolean) => void;
   zoneMode: boolean;
   setZoneMode: (mode: boolean) => void;
   deleteZoneMode: boolean;
@@ -87,6 +96,10 @@ export function DesignerToolbar({
   setDeleteRouteMode,
   recolorRouteMode,
   setRecolorRouteMode,
+  copyRouteMode,
+  setCopyRouteMode,
+  copyRouteMirror,
+  setCopyRouteMirror,
   zoneMode,
   setZoneMode,
   deleteZoneMode,
@@ -120,6 +133,7 @@ export function DesignerToolbar({
     setDrawingMode(false);
     setDeleteRouteMode(false);
     setRecolorRouteMode(false);
+    setCopyRouteMode(false);
     setZoneMode(false);
     setDeleteZoneMode(false);
     setTextMode(false);
@@ -130,6 +144,7 @@ export function DesignerToolbar({
     setDrawingMode(true);
     setDeleteRouteMode(false);
     setRecolorRouteMode(false);
+    setCopyRouteMode(false);
     setZoneMode(false);
     setDeleteZoneMode(false);
     setTextMode(false);
@@ -140,31 +155,37 @@ export function DesignerToolbar({
   const toggleDeleteRouteMode = () => {
     const next = !deleteRouteMode;
     setDeleteRouteMode(next);
-    if (next) { setDrawingMode(false); setRecolorRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setRecolorRouteMode(false); setCopyRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleRecolorRouteMode = () => {
     const next = !recolorRouteMode;
     setRecolorRouteMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setCopyRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+  };
+
+  const toggleCopyRouteMode = () => {
+    const next = !copyRouteMode;
+    setCopyRouteMode(next);
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleZoneMode = () => {
     const next = !zoneMode;
     setZoneMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setCopyRouteMode(false); setDeleteZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleDeleteZoneMode = () => {
     const next = !deleteZoneMode;
     setDeleteZoneMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setZoneMode(false); setTextMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setCopyRouteMode(false); setZoneMode(false); setTextMode(false); onSelectPlayer(null); }
   };
 
   const toggleTextMode = () => {
     const next = !textMode;
     setTextMode(next);
-    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); onSelectPlayer(null); }
+    if (next) { setDrawingMode(false); setDeleteRouteMode(false); setRecolorRouteMode(false); setCopyRouteMode(false); setZoneMode(false); setDeleteZoneMode(false); onSelectPlayer(null); }
   };
 
   const handlePlayerSelect = (player: { letter: string; color: string; isSquare?: boolean; shape?: IconShape } | null) => {
@@ -172,6 +193,7 @@ export function DesignerToolbar({
       setDrawingMode(false);
       setDeleteRouteMode(false);
       setRecolorRouteMode(false);
+      setCopyRouteMode(false);
       setZoneMode(false);
       setDeleteZoneMode(false);
       setTextMode(false);
@@ -336,6 +358,35 @@ export function DesignerToolbar({
           <span className={label}>Recolor Route</span>
         </button>
 
+        {/* Copy Route: tap a route to pick it up, then tap a player to paste
+            a copy onto them — translated to start at that player's position,
+            same math the drag-a-player-carries-their-route behavior already
+            uses. Stays picked after a paste, so one route can be stamped onto
+            several players without re-picking it each time. */}
+        <button
+          onClick={toggleCopyRouteMode}
+          title="Copy a route (tap the route, then tap a player)"
+          className={`${tool} ${copyRouteMode ? active : inactive}`}
+        >
+          <Copy className="h-4 w-4" />
+          <span className={label}>Copy Route</span>
+        </button>
+
+        {/* Mirror is only relevant while Copy Route is active — hidden the
+            rest of the time to keep the bar uncluttered. The setting itself
+            is sticky (see the prop doc comment), so it survives toggling
+            Copy Route off and back on. */}
+        {copyRouteMode && (
+          <button
+            onClick={() => setCopyRouteMirror(!copyRouteMirror)}
+            title="Mirror the pasted route left/right"
+            className={`${vertical ? tool : iconOnly} ${copyRouteMirror ? active : inactive}`}
+          >
+            <FlipHorizontal className="h-4 w-4" />
+            {vertical && <span className={label}>Mirror</span>}
+          </button>
+        )}
+
         {playType === 'offense' && (
           <>
             <div className={divider} />
@@ -440,16 +491,17 @@ export function DesignerToolbar({
       </div>
 
       {/* Active mode label */}
-      {(activeDraw || deleteRouteMode || recolorRouteMode || zoneMode || deleteZoneMode || textMode) && (
+      {(activeDraw || deleteRouteMode || recolorRouteMode || copyRouteMode || zoneMode || deleteZoneMode || textMode) && (
         <p className="text-[10px] text-chalk/50 px-1 flex items-center gap-1">
           <span className={`font-semibold ${(deleteRouteMode || deleteZoneMode) ? 'text-amber-400' : 'text-primary'}`}>
             {deleteRouteMode && 'Remove route mode'}
             {recolorRouteMode && 'Recolor route mode'}
+            {copyRouteMode && 'Copy route mode'}
             {deleteZoneMode && 'Remove zone mode'}
             {zoneMode && 'Zone mode'}
             {textMode && 'Text mode'}
-            {!deleteRouteMode && !recolorRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'straight' && 'Straight line mode'}
-            {!deleteRouteMode && !recolorRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'waypoint' && 'Curved route mode'}
+            {!deleteRouteMode && !recolorRouteMode && !copyRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'straight' && 'Straight line mode'}
+            {!deleteRouteMode && !recolorRouteMode && !copyRouteMode && !deleteZoneMode && !zoneMode && !textMode && activeDraw === 'waypoint' && 'Curved route mode'}
           </span>
           {activeDraw && (
             <span>

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -46,6 +46,10 @@ export function PlayDesigner() {
   const [routeColorMode, setRouteColorMode] = useState<'auto' | string>('auto');
   const [deleteRouteMode, setDeleteRouteMode] = useState(false);
   const [recolorRouteMode, setRecolorRouteMode] = useState(false);
+  const [copyRouteMode, setCopyRouteMode] = useState(false);
+  // Sticky like capStyle/dashed/routeColorMode above — a coach's mirror
+  // preference should survive turning Copy Route off and back on.
+  const [copyRouteMirror, setCopyRouteMirror] = useState(false);
   const [zoneMode, setZoneMode] = useState(false);
   const [deleteZoneMode, setDeleteZoneMode] = useState(false);
   const [textMode, setTextMode] = useState(false);
@@ -561,6 +565,10 @@ export function PlayDesigner() {
             setDeleteRouteMode={setDeleteRouteMode}
             recolorRouteMode={recolorRouteMode}
             setRecolorRouteMode={setRecolorRouteMode}
+            copyRouteMode={copyRouteMode}
+            setCopyRouteMode={setCopyRouteMode}
+            copyRouteMirror={copyRouteMirror}
+            setCopyRouteMirror={setCopyRouteMirror}
             zoneMode={zoneMode}
             setZoneMode={setZoneMode}
             deleteZoneMode={deleteZoneMode}
@@ -602,6 +610,8 @@ export function PlayDesigner() {
               routeColorMode={routeColorMode}
               deleteRouteMode={deleteRouteMode}
               recolorRouteMode={recolorRouteMode}
+              copyRouteMode={copyRouteMode}
+              copyRouteMirror={copyRouteMirror}
               zoneMode={zoneMode}
               deleteZoneMode={deleteZoneMode}
               textMode={textMode}
@@ -671,6 +681,10 @@ export function PlayDesigner() {
           setDeleteRouteMode={setDeleteRouteMode}
           recolorRouteMode={recolorRouteMode}
           setRecolorRouteMode={setRecolorRouteMode}
+          copyRouteMode={copyRouteMode}
+          setCopyRouteMode={setCopyRouteMode}
+          copyRouteMirror={copyRouteMirror}
+          setCopyRouteMirror={setCopyRouteMirror}
           zoneMode={zoneMode}
           setZoneMode={setZoneMode}
           deleteZoneMode={deleteZoneMode}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -4675,6 +4675,240 @@ test('routes: dragging a player leaves another player\'s route untouched', async
   expect(after.paths[qRouteIdx].points[0].y).toBeGreaterThan(before.paths[qRouteIdx].points[0].y + 0.05);
 });
 
+test('routes: Copy Route pastes a translated copy onto another player', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  let state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(2);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+
+  // A dog-leg so a translation bug (offsetting only some points) would be
+  // caught, not just a bug that moves the whole route's bounding box.
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(qPx.x, qPx.y);
+  await page.waitForTimeout(TAP_GAP);
+  const mid = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.3, 0.3);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  const before = await canvasState(page);
+  expect(before.paths).toHaveLength(1);
+  const srcStart = before.paths[0].points[0];
+  const srcPoints = before.paths[0].points;
+  const destIcon = before.playerIcons[1];
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(end.x, end.y); // pick the route (tap near its far end, not the shared origin icon)
+  await page.mouse.click(xPx.x, xPx.y); // paste onto X
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+  const pasted = state.paths[1];
+  expect(pasted.startIconIndex).toBe(1);
+  expect(pasted.points).toHaveLength(srcPoints.length);
+  const dx = destIcon.x - srcStart.x;
+  const dy = destIcon.y - srcStart.y;
+  pasted.points.forEach((pt, i) => {
+    expect(pt.x).toBeCloseTo(srcPoints[i].x + dx, 5);
+    expect(pt.y).toBeCloseTo(srcPoints[i].y + dy, 5);
+  });
+
+  // Color matches the destination player, not the source route, and stays
+  // synced (independentColor undefined) rather than being pinned.
+  expect(pasted.color).toBe(destIcon.color);
+  expect(pasted.independentColor).toBeFalsy();
+  // The source route is untouched.
+  expect(state.paths[0].points).toEqual(srcPoints);
+});
+
+test('routes: Copy Route with Mirror reflects the pasted route\'s shape', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  let state = await canvasState(page);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(qPx.x, qPx.y);
+  await page.waitForTimeout(TAP_GAP);
+  const mid = await canvasPoint(page, 0.3, 0.6);
+  await page.mouse.click(mid.x, mid.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.3, 0.3);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  const before = await canvasState(page);
+  const srcStart = before.paths[0].points[0];
+  const srcPoints = before.paths[0].points;
+  const destIcon = before.playerIcons[1];
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await btn(page, 'Mirror the pasted route left/right').click();
+  await page.mouse.click(end.x, end.y);
+  await page.mouse.click(xPx.x, xPx.y);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+  const pasted = state.paths[1];
+  const dy = destIcon.y - srcStart.y;
+  pasted.points.forEach((pt, i) => {
+    // x is negated relative to the start, y is unaffected.
+    expect(pt.x).toBeCloseTo(destIcon.x - (srcPoints[i].x - srcStart.x), 5);
+    expect(pt.y).toBeCloseTo(srcPoints[i].y + dy, 5);
+  });
+});
+
+test('routes: Copy Route is blocked when the destination already has 2 routes', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  let state = await canvasState(page);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+
+  await drawStraightRoute(page, qPx, await canvasPoint(page, 0.2, 0.3));
+  // Fill X to the 2-route cap.
+  await drawStraightRoute(page, xPx, await canvasPoint(page, 0.6, 0.4));
+  await drawStraightRoute(page, xPx, await canvasPoint(page, 0.8, 0.3));
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(3);
+
+  const qRouteEnd = await canvasPoint(page, 0.2, 0.3);
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(qRouteEnd.x, qRouteEnd.y);
+  await page.mouse.click(xPx.x, xPx.y);
+
+  await expect(page.getByText('This player already has 2 routes', { exact: false })).toBeVisible();
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(3);
+});
+
+test('routes: Copy Route blocks pasting a route back onto its own source player', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  const state = await canvasState(page);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const qEnd = await canvasPoint(page, 0.2, 0.3);
+
+  await drawStraightRoute(page, qPx, qEnd);
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(qEnd.x, qEnd.y);
+  await page.mouse.click(qPx.x, qPx.y);
+
+  await expect(page.getByText('Pick a different player to paste onto', { exact: false })).toBeVisible();
+  const after = await canvasState(page);
+  expect(after.paths).toHaveLength(1);
+});
+
+test('routes: Copy Route paste is a single undo step', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  let state = await canvasState(page);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+  const qEnd = await canvasPoint(page, 0.2, 0.3);
+
+  await drawStraightRoute(page, qPx, qEnd);
+  const before = await canvasState(page);
+  expect(before.paths).toHaveLength(1);
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(qEnd.x, qEnd.y);
+  await page.mouse.click(xPx.x, xPx.y);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+
+  await btn(page, 'Undo').click();
+  const undone = await canvasState(page);
+  expect(undone.paths).toHaveLength(1);
+  expect(undone.paths[0].points).toEqual(before.paths[0].points);
+  expect(undone.paths[0].startIconIndex).toBe(0);
+});
+
+test('routes: Copy Route re-picking a different route swaps which one pastes', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.5, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+  await btn(page, 'Player Z').click();
+  const zSpot = await canvasPoint(page, 0.8, 0.6);
+  await page.mouse.click(zSpot.x, zSpot.y);
+
+  let state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(3);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+  const zPx = await canvasPoint(page, state.playerIcons[2].x, state.playerIcons[2].y);
+  const qEnd = await canvasPoint(page, 0.2, 0.3);
+  const xEnd = await canvasPoint(page, 0.5, 0.2);
+
+  await drawStraightRoute(page, qPx, qEnd);
+  await drawStraightRoute(page, xPx, xEnd);
+
+  const before = await canvasState(page);
+  const xRoute = before.paths.find((p) => p.startIconIndex === 1)!;
+  const xStart = xRoute.points[0];
+  const destIcon = before.playerIcons[2];
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(qEnd.x, qEnd.y); // pick Q's route first
+  await page.mouse.click(xEnd.x, xEnd.y); // re-pick X's route instead
+  await page.mouse.click(zPx.x, zPx.y); // paste onto Z
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(3);
+  const pasted = state.paths[2];
+  expect(pasted.startIconIndex).toBe(2);
+  const dx = destIcon.x - xStart.x;
+  const dy = destIcon.y - xStart.y;
+  pasted.points.forEach((pt, i) => {
+    expect(pt.x).toBeCloseTo(xRoute.points[i].x + dx, 5);
+    expect(pt.y).toBeCloseTo(xRoute.points[i].y + dy, 5);
+  });
+});
+
 // A zone's dashed connector to its icon is only meaningful once the icon is
 // visibly outside the zone. It used to be decided by comparing the icon's
 // raw distance from the zone center against a threshold scaled off the


### PR DESCRIPTION
## Summary
- New toolbar mode (matches the existing Remove/Recolor Route pattern): tap a route to pick it up, then tap a player icon to paste a translated copy onto them. Stays picked after a paste so one route can be stamped onto several players.
- Mirror toggle reflects the pasted route's shape left/right relative to its own start point.
- The pasted route takes the **destination player's color** and stays synced to it going forward, exactly like a route freshly drawn in `routeColorMode: 'auto'` — the source route's own color (even if custom-recolored) is intentionally not carried over.
- Self-paste and pasting onto a player already at the 2-route cap are both blocked with distinct flash messages.
- One paste = one undo step.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on touched files — no new errors
- [x] 6 new smoke tests added (plain copy, mirrored copy, destination-full block, self-paste block, undo-as-one-step, re-picking) — each confirmed to fail without the corresponding fix (stashed source, reran, restored)
- [x] `npm run smoke` — full suite green (168 passed, 1 pre-existing environmental skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)