### PR TITLE
Fix: Finish/Cancel action bar can overlap a player icon near the bottom

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1702,6 +1702,23 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
     // ── Instruction text for the canvas overlay ──────────────────
     const originIcon = waypointIconIndex !== null ? playerIcons[waypointIconIndex] : null;
+
+    // Keep the Finish/Cancel bar from sitting on top of the icon the
+    // in-progress route started from — that's the icon a coach's eye/thumb is
+    // on while drawing, and the one guaranteed to be near the bar when the
+    // origin is placed deep (e.g. a safety near the bottom of the field).
+    const ACTION_BAR_DEFAULT_BOTTOM = 16; // matches the old bottom-4
+    const ACTION_BAR_EST_HEIGHT = 56;
+    let actionBarBottom = ACTION_BAR_DEFAULT_BOTTOM;
+    if (originIcon) {
+      const iconScreenY = originIcon.y * height;
+      const clearZoneStart = height - (ACTION_BAR_DEFAULT_BOTTOM + ACTION_BAR_EST_HEIGHT);
+      if (iconScreenY + iconRadiusPx >= clearZoneStart) {
+        const desiredBottom = height - (iconScreenY - iconRadiusPx - 10);
+        actionBarBottom = Math.max(ACTION_BAR_DEFAULT_BOTTOM, Math.min(desiredBottom, height - ACTION_BAR_EST_HEIGHT - 8));
+      }
+    }
+
     const hoveredHasZone = hoveredIconIndex !== null && iconHasZone(hoveredIconIndex);
     const hoveredPath = hoveredPathIndex !== null ? paths[hoveredPathIndex] : null;
     const hoveredPathOriginLetter = hoveredPath?.startIconIndex !== undefined
@@ -1872,7 +1889,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
         {/* ── Action bar (bottom of canvas): Finish + Cancel ── */}
         {drawingMode && (drawMode === 'waypoint' || drawMode === 'straight') && waypointPoints.length >= 1 && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10">
+          <div
+            className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 z-10"
+            style={{ bottom: actionBarBottom }}
+          >
             {waypointPoints.length >= 2 && (
               <button
                 onPointerDown={(e) => { e.stopPropagation(); finishWaypoint(); }}


### PR DESCRIPTION
## Summary
- The route-drawing "Finish Route" / "Cancel" action bar was pinned to a static `bottom-4`, unaware of where the route's origin icon actually sits.
- A player placed deep (e.g. a safety near the bottom of the field) could end up hidden under the bar — confusing, and it blocked taps on that icon while the bar was showing. Reported with a screenshot on an iPhone-sized portrait canvas.
- Fix computes vertical clearance against the route's origin icon specifically (the one icon guaranteed to matter during that interaction — the coach's eye/thumb is on it while drawing) and lifts the bar above it when needed, reusing the same icon-radius/gap values already used for popover placement elsewhere in `Canvas.tsx`. Falls back to the previous default position whenever there's no conflict.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint src/components/designer/Canvas.tsx` — no new errors
- [x] `npm run smoke` — full suite green (168 passed, 1 pre-existing environmental skip), confirming no regression to existing Finish/Cancel button-click tests
- [ ] Manual visual check in a real browser (no browser tool available in this environment) — recommend confirming in devtools iPhone SE portrait: place an icon near the bottom of the field, start both a straight and a curved route from it, and verify the bar lifts clear of the icon instead of covering it, and that it stays at the normal position when the origin is mid-field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)