### PR TITLE
[nightly] Trim plays select('*') to explicit columns on the two real call sites

### DIFF
--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -163,7 +163,7 @@ export function PlayDesigner() {
       try {
         const { data, error: fetchError } = await supabase
           .from('plays')
-          .select('*')
+          .select('id, name, type, canvas_data, metadata, is_public')
           .eq('id', sourceId)
           .single();
         if (fetchError) throw fetchError;

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -20,13 +20,9 @@ interface Play {
   id: string;
   name: string;
   type: 'offense' | 'defense' | 'special_teams';
-  canvas_data: string;
-  description: string;
   thumbnail?: string;
-  user_id: string;
   is_public: boolean;
   upvotes?: number;
-  metadata?: any;
   profiles?: {
     username: string;
     avatar_url?: string;
@@ -79,9 +75,13 @@ export function PlaysPage() {
             .maybeSingle()
             .then(({ data }) => setIsPro(rowIsPro(data)));
 
+          // The card grid only ever reads these columns — canvas_data (the
+          // committed play JSON) and description/metadata are dead weight
+          // here; PlayDesigner's own load is the one place that needs
+          // canvas_data (see issue #120).
           let query = supabase
             .from('plays')
-            .select('*')
+            .select('id, name, type, thumbnail, is_public, upvotes')
             .eq('user_id', currentUser.id)
             .order('created_at', { ascending: false });
 


### PR DESCRIPTION
Closes #120

## What changed and why

`select('*')` on `plays` pulls `canvas_data` (JSON, and per #118 the row's
`thumbnail` averages 46 KB) even on the one page that renders neither at
full size. Two call sites genuinely query `plays` with `select('*')`:

- **`PlaysPage.tsx:84`** (My Plays list) — reads `id, name, type, is_public,
  upvotes` off each row and hands `thumbnail` to `PlayCard` for its `<img>`.
  It never touches `canvas_data`, `description`, `metadata`, or `user_id`
  (the query already filters `.eq('user_id', currentUser.id)`, so every row
  has the same value). Trimmed the select to
  `id, name, type, thumbnail, is_public, upvotes` and shrank the local `Play`
  interface to match — a coach with 20 saved plays was moving ~1 MB of
  `canvas_data` per visit that the card grid never used.
- **`PlayDesigner.tsx:166`** (opening `/designer?play=<id>` or
  `?template=<id>`) — reads `data.canvas_data`, `data.metadata`, `data.name`,
  `data.type`, `data.is_public`, `data.id`. It correctly needs `canvas_data`
  (as the issue already noted), but was also over-fetching `thumbnail`,
  `description`, and `user_id`, none of which the load path reads. Trimmed to
  `id, name, type, canvas_data, metadata, is_public`.

### The issue's other 7 call sites are stale — verified against current code, not touched

The issue lists 9 `select('*')` sites as all part of the same `plays`
canvas_data/thumbnail bloat. Re-checking each `.from(...)` against the
current code:

- `AddToPlaybookButton.tsx:104` and `SavePlayModal.tsx:140` query
  **`playbooks`**, not `plays` — the issue itself flags the first as "same
  pattern," but `supabase/SCHEMA.md` shows `playbooks` is just
  `id, user_id, name, description, is_public, timestamps`. No JSON blob, no
  base64 thumbnail — `select('*')` there is already cheap.
- `BlogPage.tsx:44`, `BlogPage.tsx:145`, `BlogManagement.tsx:148` query
  **`blog_posts`**; `CommunityPage.tsx:40` queries **`posts`**;
  `CommentThread.tsx:52` queries **`comments`**. None of these are the
  `plays` table at all, and per `SCHEMA.md` none carry a heavy column the way
  `plays.canvas_data`/`thumbnail` do — their `content`/`description` text
  fields are what each page actually renders, so `select('*')` there isn't
  the overfetch the issue describes.

So of the 9 listed sites, exactly 2 touch `plays`, and both are fixed here.
Widening this PR to rewrite 5 unrelated tables' queries felt out of scope for
an issue titled around `plays` payload size — each would need its own
per-column read-usage check the way `plays` got here, and none has the
`plays` table's actual bloat problem.

## Verification

```
npm run typecheck   # clean on touched files (repo-wide tsconfig deprecation
                     # notices only, pre-existing, unrelated to this change)
npm run build        # ✓ built in 32.50s, no errors
npx eslint src/components/plays/PlaysPage.tsx src/components/designer/PlayDesigner.tsx
                     # 0 errors, 11 pre-existing `no-explicit-any` warnings
                     # (all in PlayDesigner.tsx, none touch changed lines;
                     # PlaysPage.tsx is fully clean)
```

**`npm run smoke` could not be run in this environment.** The suite reads
`.env` for `VITE_SUPABASE_URL`/seeds a mocked auth session from it, and
`src/lib/supabase.ts` throws at module load without both
`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` — neither is present in
this session's environment variables (only `FEEDBACK_TRIAGE_*` are set), and
no `.env` exists. This blocks the smoke suite for *any* change in this
environment, not just this one — worth fixing at the environment level so
nightly runs can actually verify designer/save-load changes going forward.

In lieu of running it, I hand-verified both call sites by reading every
place each query's result is used (`grep` for `play.<field>`/`data.<field>`
across each file) before deciding what to drop — not a substitute for the
smoke suite, but the change is a pure column-list narrowing with no
behavioral change to either flow, and both selected-column lists were
checked to cover every field actually read.

No schema change, no new dependency, no `.env` touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPurxWVUW6sirqx734GvpX)_