### PR TITLE
Fix two CLS sources found in the Cloudflare Web Vitals report

### DIFF
--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -220,7 +220,17 @@ export function PlayDesigner() {
   // fits the container. Locking the on-screen aspect ratio to the export's
   // keeps shapes WYSIWYG — a circular zone used to print as a squished
   // ellipse because radii are stored normalized per-axis.
-  useEffect(() => {
+  //
+  // useLayoutEffect + a synchronous initial call (not requestAnimationFrame)
+  // so the fitted size is measured and committed before the browser paints —
+  // the sidebar/main flex layout is already resolved by the time this runs,
+  // so there's nothing to "wait a frame" for. Skipping that frame means
+  // visitors never see the canvas at its hardcoded 600x480 fallback size
+  // before it snaps to the real one (a real, guaranteed-every-load CLS hit,
+  // confirmed via the Cloudflare Web Vitals report 2026-08-25 — the flagged
+  // element traced exactly to this container). ResizeObserver still handles
+  // later window/orientation changes, which aren't first-paint CLS.
+  useLayoutEffect(() => {
     const update = () => {
       const el = canvasContainerRef.current;
       if (!el) return;
@@ -230,10 +240,10 @@ export function PlayDesigner() {
       const w = Math.min(maxW, maxH * ratio);
       setCanvasSize({ width: w, height: w / ratio });
     };
-    const frame = requestAnimationFrame(update);
+    update();
     const ro = new ResizeObserver(update);
     if (canvasContainerRef.current) ro.observe(canvasContainerRef.current);
-    return () => { cancelAnimationFrame(frame); ro.disconnect(); };
+    return () => ro.disconnect();
   }, []);
 
   // Zoom levels available at the current base size (see MAX_CANVAS_PIXELS) —

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -63,6 +63,12 @@ export function PlaybooksPage() {
   // own playbooks. Mirrors PlaysPage.tsx's ?tab=community pattern.
   const tab: 'mine' | 'packs' = searchParams.get('tab') === 'packs' ? 'packs' : 'mine';
   const [user, setUser] = useState<import('@supabase/supabase-js').User | null>(null);
+  // Distinct from `loading` (which tracks the playbooks fetch below): this
+  // tracks whether the auth.getUser() call itself has resolved yet, so the
+  // "Sign In Required" guard doesn't fire for a signed-in user during the
+  // brief window before we know who they are. `user === null` is ambiguous
+  // between "not checked yet" and "checked, signed out" — this disambiguates.
+  const [authChecked, setAuthChecked] = useState(false);
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
   const [selectedPlaybook, setSelectedPlaybook] = useState<Playbook | null>(null);
   const [playsInPlaybook, setPlaysInPlaybook] = useState<PlayInPlaybook[]>([]);
@@ -93,6 +99,7 @@ export function PlaybooksPage() {
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user } }) => {
       setUser(user);
+      setAuthChecked(true);
     });
   }, []);
 
@@ -1154,7 +1161,9 @@ export function PlaybooksPage() {
 
   // My Playbooks requires sign-in; Starter Packs is public to browse (cloning
   // still requires sign-in + Pro, handled inside PlaybookPackLibrary).
-  if (!user && tab === 'mine') {
+  // Gated on authChecked so a signed-in coach never sees this flash before
+  // getUser() resolves — see the authChecked declaration above.
+  if (authChecked && !user && tab === 'mine') {
     return (
       <div className="min-h-screen bg-board flex items-center justify-center">
         <div className="text-center">


### PR DESCRIPTION
## Summary
Analyzed a Cloudflare Web Analytics report showing 25% "poor" CLS. Traced all 5 flagged DOM elements to source via exact-class grep (not guessed) and confirmed two independent root causes:

- **PlaybooksPage.tsx**: the "My Playbooks" tab flashed a "Sign In Required" screen for signed-in coaches before `supabase.auth.getUser()` resolved, then swapped to the full page — a large layout shift. `PlaysPage.tsx` already solves this identical pattern with an extra loading-gate; `PlaybooksPage` was missing the equivalent. Fix adds a dedicated `authChecked` flag (not a reuse of the existing `loading` state, which turned out to be ambiguous for this — caught and corrected during implementation before it shipped).
- **Designer canvas**: started at a hardcoded `600x480` and only resized to fit its container after mount, via a `useEffect` further deferred through `requestAnimationFrame` — a real, guaranteed-every-load reflow. Switched to `useLayoutEffect` with a synchronous initial measurement so the fitted size commits before the browser's first paint.

Two other flagged elements (Navbar nav-links, ConsentBanner buttons) point to a likely font-swap (FOUT) cause, but that's deliberately out of scope here — it touches the CSP-fragile font-loading setup in `index.html` that broke production fonts for 3 weeks once before, and deserves its own careful pass rather than being bundled under this fix.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on both touched files — no new errors
- [x] `npm run smoke` — full suite green (168 passed, 1 pre-existing environmental skip), including all 10 Playbooks-specific tests, confirming signed-in flows still work with the new `authChecked` gate
- [ ] Manual visual check in a real browser (no browser tool available in this environment) — recommend: hard-refresh `/playbooks` while signed in (no more sign-in flash) and while signed out (still shows sign-in prompt correctly, not stuck loading); hard-refresh `/designer` on both desktop and mobile width (canvas renders at correct size immediately, no visible resize snap).
- [ ] Re-pull the Cloudflare Web Analytics report after traffic accumulates to confirm CLS "poor" share drops and these elements stop appearing in the Debug View.

🤖 Generated with [Claude Code](https://claude.com/claude-code)