### PR TITLE
Fix: Community Forum post-card header can overflow its card on mobile

### DIFF
--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -131,9 +131,9 @@ export function PostList({ posts, loading, timeRange: _timeRange, searchQuery, c
               </div>
 
               {/* Content */}
-              <div className="flex-1">
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-3 mb-2">
-                  <div className="flex items-center gap-3 min-w-0">
+                  <div className="flex items-center gap-3 min-w-0 flex-wrap">
                     <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center overflow-hidden shrink-0">
                       {post.author?.avatar_url ? (
                         <img src={post.author.avatar_url} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -208,6 +208,56 @@ test('no page scrolls sideways at phone width', async ({ page }) => {
   }
 });
 
+test('community post card: edit/delete buttons stay inside the card with a long username', async ({ page }) => {
+  // Regression: PostList's byline row (avatar/"Posted by"/username/"•") was
+  // all shrink-0 except the trailing timestamp, and its flex-1 content
+  // column was missing min-w-0 — so a long username could force the whole
+  // header wider than the card, spilling the delete button's red highlight
+  // past the card's own rounded border. See PostList.tsx.
+  const userJson = {
+    id: '44444444-4444-4444-4444-444444444444',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 't', refresh_token: 'r',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+
+  // Catch-all first — see the sideways-scroll test's note above on why.
+  await page.route('**/rest/v1/**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/auth/v1/user**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/posts**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([
+      {
+        id: 'post-1', user_id: userJson.id, title: 'Best blitz package for 5v5?',
+        content: 'What do you all run on 3rd and long', upvotes: 3, downvotes: 0,
+        created_at: '2025-09-01T00:00:00Z', updated_at: '2025-09-01T00:00:00Z',
+      },
+    ]) }));
+  await page.route('**/rest/v1/rpc/get_community_authors**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([
+      { id: userJson.id, username: 'GoodtimeCharlieAndTheGang2026', avatar_url: null },
+    ]) }));
+  await page.route('**/rest/v1/comments**', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+
+  await page.goto('/community', { waitUntil: 'domcontentloaded' });
+  const deleteButton = page.getByTitle('Delete Post');
+  await expect(deleteButton).toBeVisible();
+  const card = page.locator('article').first();
+
+  const cardBox = await card.boundingBox();
+  const buttonBox = await deleteButton.boundingBox();
+  if (!cardBox || !buttonBox) throw new Error('Expected both the card and delete button to have a layout box');
+
+  expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+});
+
 test('navigating to a new route scrolls back to the top', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => window.scrollTo(0, 600));


### PR DESCRIPTION
## Summary
- Reported with a screenshot: on a narrow phone, a post card's edit/delete icon buttons spill past the card's own rounded background, with the delete button's red highlight reaching the screen edge.
- Root cause: the byline row's `flex-1` content column (`PostList.tsx`) was missing `min-w-0`, and the "Posted by {author}" cluster's children were all `shrink-0` except the trailing timestamp — so a longer username's intrinsic width could force the whole header wider than the card, with nothing to clip it since the card has no `overflow-hidden`.
- Fix: `min-w-0` on the content column (lets it actually shrink to fit) + `flex-wrap` on the byline cluster (wraps onto a second line under real pressure instead of relying entirely on the timestamp to truncate to nothing). Deliberately did **not** add `overflow-hidden` to the card as a blanket fix — that could silently hide the edit/delete buttons entirely in an extreme case rather than degrading gracefully.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on both touched files — no new errors
- [x] New smoke test (seeds a post with a long username, asserts the delete button's bounding box stays inside the card's) — confirmed to **fail without the fix** (button spilled to x=689 against a 360px-wide card), then confirmed it passes with the fix applied
- [x] `npm run smoke` — full suite green (169 passed, 1 pre-existing environmental skip); one unrelated test flaked once under full-suite parallel load and passed cleanly on rerun in isolation and on a second full-suite run
- [ ] Manual visual check in a real browser (no browser tool available in this environment) — recommend confirming at phone width with a real long-username post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)