### PR TITLE
Fix: top instruction bar can overlap a defensive player icon

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1719,6 +1719,25 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       }
     }
 
+    // Keep the top instruction bar from sitting on top of a player icon
+    // placed near the canvas's top edge — defense's own boundary (17 yards
+    // above the LOS maps toward y=0, same direction offense almost never
+    // reaches), so a coach placing a deep defensive back routinely ends up
+    // under this bar. Unlike the Finish/Cancel bar above, this isn't tied to
+    // one icon (the instruction bar shows in nearly every mode) — check all
+    // of them, and push down below whichever one(s) actually intrude.
+    const TOP_BAR_DEFAULT_TOP = 12; // matches the old top-3
+    const TOP_BAR_EST_HEIGHT = 56; // generous — this pill can wrap to two lines
+    let instructionBarTop = TOP_BAR_DEFAULT_TOP;
+    for (const icon of playerIcons) {
+      const iconScreenY = icon.y * height;
+      const iconTopEdge = iconScreenY - iconRadiusPx;
+      if (iconTopEdge <= TOP_BAR_DEFAULT_TOP + TOP_BAR_EST_HEIGHT) {
+        const desiredTop = iconScreenY + iconRadiusPx + 10;
+        instructionBarTop = Math.max(instructionBarTop, Math.min(desiredTop, height - TOP_BAR_EST_HEIGHT - 8));
+      }
+    }
+
     const hoveredHasZone = hoveredIconIndex !== null && iconHasZone(hoveredIconIndex);
     const hoveredPath = hoveredPathIndex !== null ? paths[hoveredPathIndex] : null;
     const hoveredPathOriginLetter = hoveredPath?.startIconIndex !== undefined
@@ -1805,7 +1824,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
 
         {/* ── Contextual instruction bar (top of canvas) ── */}
         {(savedFlash || conflictFlash || finishFirstFlash || deletedFlash || deletedZoneFlash || selfPasteFlash || instructionText) && (
-          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 pointer-events-none px-3 w-full max-w-sm">
+          <div
+            className="absolute left-1/2 -translate-x-1/2 z-10 pointer-events-none px-3 w-full max-w-sm"
+            style={{ top: instructionBarTop }}
+          >
             <div
               className={`text-white text-xs font-medium px-4 py-2 rounded-full shadow-lg text-center leading-snug transition-colors duration-300 ${
                 savedFlash ? 'bg-green-600'


### PR DESCRIPTION
## Summary
- The canvas's top "instruction bar" (contextual text like "Tap a route to copy it") sat at a static `top-3`, unaware of what's drawn beneath it — the same issue the Finish/Cancel action bar had at the bottom before that earlier fix (#125).
- Defense's own boundary (17 yards above the LOS) maps toward the canvas's top edge, a spot offense rarely reaches — there are no built-in defensive formation templates, so defensive icons are always hand-placed, and a coach placing a deep defensive back routinely ends up with an icon right under this bar.
- Unlike the bottom bar's fix (tied to one icon, the route's origin), the top bar shows in nearly every mode with no single "the icon in question" — so this checks clearance against **every** player icon and pushes down below whichever one(s) intrude, clearing the most constraining icon when more than one is near the top.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on the touched file — no new errors
- [x] Verified the clearance math numerically (no shift for mid-field icons, correct downward push for top-edge icons, clears the lower of two overlapping icons)
- [x] `npm run smoke` — full suite green; a handful of unrelated tests (Copy Route, mobile layout, gotrue auth) flaked under resource contention on two different full-suite runs today but passed cleanly every time when rerun in isolation — confirmed environmental, not caused by this change
- [ ] Manual visual check in a real browser (no browser tool available in this environment) — recommend placing a defensive icon near the top edge and confirming the bar drops below it in various modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)