### PR TITLE
Fix: Copy Route ignored a non-Auto sticky route color

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -1204,13 +1204,15 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
             ...srcPath,
             points: newPoints,
             startIconIndex: clicked,
-            // Color intentionally NOT cloned from srcPath — matches destIcon's
-            // color and stays synced to it going forward, exactly like a
-            // route freshly drawn on this icon in routeColorMode 'auto'.
+            // Color intentionally NOT cloned from srcPath — the paste
+            // behaves exactly like a route freshly drawn on this icon under
+            // the CURRENT routeColorMode (same resolution as finishRoute's
+            // caller, e.g. line ~1283): 'auto' syncs to destIcon's color
+            // going forward, a fixed color pins it independent of the icon.
             // The source's own color/independentColor (even if it was
-            // custom-recolored) is deliberately discarded.
-            color: destIcon.color,
-            independentColor: undefined,
+            // custom-recolored) is deliberately discarded either way.
+            color: routeColorMode === 'auto' ? destIcon.color : routeColorMode,
+            independentColor: routeColorMode !== 'auto' ? true : undefined,
             segmentDashed: srcPath.segmentDashed ? [...srcPath.segmentDashed] : undefined,
           }]);
           return;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -4909,6 +4909,46 @@ test('routes: Copy Route re-picking a different route swaps which one pastes', a
   });
 });
 
+test('routes: Copy Route respects a non-Auto sticky route color instead of always matching the destination icon', async ({ page }) => {
+  await openDesigner(page);
+
+  // Set the sticky default to a fixed color before drawing/copying — this is
+  // the regression: pasting used to hardcode destIcon.color regardless of
+  // routeColorMode, so a coach who'd set a fixed color would still get the
+  // destination player's own color on every pasted route.
+  await btn(page, ROUTE_COLOR_TRIGGER).click();
+  await page.getByLabel('Color #000000').click();
+  await page.getByRole('button', { name: 'Set' }).click();
+
+  await btn(page, 'Player Q').click();
+  const qSpot = await canvasPoint(page, 0.2, 0.6);
+  await page.mouse.click(qSpot.x, qSpot.y);
+  await btn(page, 'Player X').click();
+  const xSpot = await canvasPoint(page, 0.6, 0.6);
+  await page.mouse.click(xSpot.x, xSpot.y);
+
+  let state = await canvasState(page);
+  const qPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const xPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+  const qEnd = await canvasPoint(page, 0.2, 0.3);
+
+  await drawStraightRoute(page, qPx, qEnd);
+  const before = await canvasState(page);
+  expect(before.paths[0].color).toBe('#000000');
+  const destIcon = before.playerIcons[1];
+  expect(destIcon.color).not.toBe('#000000'); // X's own default color, for contrast
+
+  await btn(page, 'Copy a route (tap the route, then tap a player)').click();
+  await page.mouse.click(qEnd.x, qEnd.y);
+  await page.mouse.click(xPx.x, xPx.y);
+
+  state = await canvasState(page);
+  expect(state.paths).toHaveLength(2);
+  const pasted = state.paths[1];
+  expect(pasted.color).toBe('#000000');
+  expect(pasted.independentColor).toBe(true);
+});
+
 // A zone's dashed connector to its icon is only meaningful once the icon is
 // visibly outside the zone. It used to be decided by comparing the icon's
 // raw distance from the zone center against a threshold scaled off the


### PR DESCRIPTION
## Summary
- Reported: when a route's color is set to something other than Auto, copying another player's route still defaults to the destination player's own color instead of the sticky non-Auto color.
- Root cause: the Copy Route paste logic (added in #124) hardcoded `color: destIcon.color, independentColor: undefined` on every paste, which matches how a fresh route is drawn under `routeColorMode: 'auto'` but not under a fixed color — in that case a freshly-drawn route takes the fixed color and pins `independentColor: true` instead.
- Fix: resolve color/independentColor the same way `finishRoute`'s caller already does elsewhere in this file (`routeColorMode === 'auto' ? icon.color : routeColorMode`, `independentColor: routeColorMode !== 'auto' ? true : undefined`), so a paste behaves exactly like a fresh draw under whatever the current setting is.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on both touched files — no new errors
- [x] New smoke test: sets a fixed sticky route color, draws a route, copies it onto another player, asserts the pasted route keeps the fixed color (not the destination icon's) — confirmed to **fail without the fix** (came back with the destination icon's own color, `#8B5CF6`, instead of the sticky `#000000`), then confirmed it passes with the fix applied
- [x] Full Copy Route test suite (7 tests) run twice each — stable
- [x] `npm run smoke` — full suite green (170 passed, 1 pre-existing environmental skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)