### PR TITLE
Add a way to remove a single player icon from the canvas

### DIFF
--- a/src/components/designer/Canvas.tsx
+++ b/src/components/designer/Canvas.tsx
@@ -346,6 +346,31 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       setZones((prev) => prev.map((z) => (z.iconIndex === idx ? { ...z, color } : z)));
     }, [pushSnapshot]);
 
+    /** Removes a player icon entirely, along with its route(s) and zone (if
+     *  any) — no confirmation, Undo is this designer's safety net for every
+     *  destructive action, same as Delete Route/Delete Zone/Clear All.
+     *
+     *  `startIconIndex`/`iconIndex` are positions in `playerIcons`, not
+     *  stable ids, so removing one element shifts every later icon down by
+     *  one — every reference to an icon AFTER `idx` must shift with it, not
+     *  just the removed icon's own route/zone be dropped. Nothing else in
+     *  this file has ever removed a playerIcons entry (only appended or
+     *  restyled in place), so there's no existing precedent to lean on. */
+    const removeIcon = useCallback((idx: number) => {
+      pushSnapshot();
+      setPaths((prev) => prev
+        .filter((p) => p.startIconIndex !== idx)
+        .map((p) => (p.startIconIndex !== undefined && p.startIconIndex > idx
+          ? { ...p, startIconIndex: p.startIconIndex - 1 }
+          : p)));
+      setZones((prev) => prev
+        .filter((z) => z.iconIndex !== idx)
+        .map((z) => (z.iconIndex > idx ? { ...z, iconIndex: z.iconIndex - 1 } : z)));
+      setPlayerIcons((prev) => prev.filter((_, i) => i !== idx));
+      setSelectedZoneIndex(null);
+      setHoveredIconIndex(null);
+    }, [pushSnapshot]);
+
     /** Recolor one specific route by its index into `paths` — a player can
      *  have 2 independent routes, each recolored on its own. Picking "Auto"
      *  reverts to the icon's current color and clears the override, which is
@@ -1869,6 +1894,10 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(
                 setEditingIconIndex(null);
               }}
               onCancel={() => setEditingIconIndex(null)}
+              onDelete={() => {
+                removeIcon(editingIconIndex);
+                setEditingIconIndex(null);
+              }}
             />
           </div>,
           document.body,

--- a/src/components/designer/PlayerStyleEditor.tsx
+++ b/src/components/designer/PlayerStyleEditor.tsx
@@ -43,6 +43,11 @@ type PlayerStyleEditorProps = {
   applyLabel: string;
   onApply: (letter: string, color: string, shape: IconShape) => void;
   onCancel: () => void;
+  /** Removes the icon this editor is open for. Only meaningful when editing
+   *  an already-placed icon — omitted when this editor is defining a new
+   *  toolbar chip (PlayerToolbar.tsx), since there's nothing on the canvas
+   *  to delete yet. */
+  onDelete?: () => void;
 };
 
 /**
@@ -51,7 +56,7 @@ type PlayerStyleEditorProps = {
  * toolbar's "Custom" chip that defines a new player before placing it.
  * Positioning/backdrop is the parent's job — this renders only the card.
  */
-export function PlayerStyleEditor({ initialLetter, initialColor, initialShape = 'circle', applyLabel, onApply, onCancel }: PlayerStyleEditorProps) {
+export function PlayerStyleEditor({ initialLetter, initialColor, initialShape = 'circle', applyLabel, onApply, onCancel, onDelete }: PlayerStyleEditorProps) {
   const [letter, setLetter] = useState(initialLetter);
   const [color, setColor] = useState(initialColor);
   const [shape, setShape] = useState<IconShape>(initialShape);
@@ -141,20 +146,31 @@ export function PlayerStyleEditor({ initialLetter, initialColor, initialShape = 
         More colors…
       </label>
 
-      <div className="flex justify-end gap-2">
-        <button
-          onClick={onCancel}
-          className="px-3 py-1.5 text-xs font-medium text-chalk/70 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={apply}
-          disabled={!canApply}
-          className="px-3 py-1.5 text-xs font-semibold text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {applyLabel}
-        </button>
+      <div className={`flex items-center gap-2 ${onDelete ? 'justify-between' : 'justify-end'}`}>
+        {onDelete && (
+          <button
+            onClick={onDelete}
+            title="Delete Player"
+            className="px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+          >
+            Delete
+          </button>
+        )}
+        <div className="flex gap-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 text-xs font-medium text-chalk/70 hover:text-chalk rounded-lg hover:bg-white/10 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={apply}
+            disabled={!canApply}
+            className="px-3 py-1.5 text-xs font-semibold text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {applyLabel}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -1085,6 +1085,98 @@ test('defense: place a safety and drag a zone of responsibility', async ({ page 
   expect(state.zones[0].color).toBe('#8B5CF6');
 });
 
+test('player icon: Delete in the edit popover removes the icon and its own route in one undo step', async ({ page }) => {
+  await openDesigner(page);
+
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.6);
+  await page.mouse.click(spot.x, spot.y);
+  let state = await canvasState(page);
+  const icon = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+
+  await btn(page, 'Straight Line Route').click();
+  await page.mouse.click(icon.x, icon.y);
+  await page.waitForTimeout(TAP_GAP);
+  const end = await canvasPoint(page, 0.4, 0.3);
+  await page.mouse.click(end.x, end.y);
+  await page.getByRole('button', { name: 'Finish Route' }).click();
+
+  const before = await canvasState(page);
+  expect(before.playerIcons).toHaveLength(1);
+  expect(before.paths).toHaveLength(1);
+
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(icon.x, icon.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+  state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(0);
+  expect(state.paths).toHaveLength(0);
+  await expect(page.getByLabel('Player label')).not.toBeVisible();
+
+  await btn(page, 'Undo').click();
+  const undone = await canvasState(page);
+  expect(undone.playerIcons).toHaveLength(1);
+  expect(undone.paths).toHaveLength(1);
+});
+
+test('player icon: deleting one icon re-targets later icons\' routes and zones instead of orphaning them', async ({ page }) => {
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'defense', exact: true }).click();
+
+  // Three icons at indices 0, 1, 2 — deleting index 0 must shift every
+  // reference to 1 and 2 down by one, not just drop icon 0's own stuff.
+  await btn(page, 'Player D').click();
+  const aSpot = await canvasPoint(page, 0.2, 0.5);
+  await page.mouse.click(aSpot.x, aSpot.y);
+  await btn(page, 'Player LB').click();
+  const bSpot = await canvasPoint(page, 0.5, 0.5);
+  await page.mouse.click(bSpot.x, bSpot.y);
+  await btn(page, 'Player S').click();
+  const cSpot = await canvasPoint(page, 0.8, 0.5);
+  await page.mouse.click(cSpot.x, cSpot.y);
+
+  let state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(3);
+  const aPx = await canvasPoint(page, state.playerIcons[0].x, state.playerIcons[0].y);
+  const bPx = await canvasPoint(page, state.playerIcons[1].x, state.playerIcons[1].y);
+
+  // A route from icon 1 (B) and a zone on icon 2 (C).
+  await drawStraightRoute(page, bPx, await canvasPoint(page, 0.5, 0.3));
+  await btn(page, 'Draw a zone of responsibility (drag from a player)').click();
+  const cPx = await canvasPoint(page, state.playerIcons[2].x, state.playerIcons[2].y);
+  await page.mouse.move(cPx.x, cPx.y);
+  await page.mouse.down();
+  await page.mouse.move(cPx.x + 90, cPx.y + 60, { steps: 8 });
+  await page.mouse.up();
+
+  const before = await canvasState(page);
+  expect(before.paths[0].startIconIndex).toBe(1);
+  expect(before.zones[0].iconIndex).toBe(2);
+
+  // Delete icon 0 (A) via its edit popover.
+  await btn(page, 'Select / Move').click();
+  await page.mouse.click(aPx.x, aPx.y);
+  await expect(page.getByLabel('Player label')).toBeVisible();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+  state = await canvasState(page);
+  expect(state.playerIcons).toHaveLength(2);
+  // B and C shifted down to indices 0 and 1 — their route/zone must follow.
+  expect(state.playerIcons[0].letter).toBe('LB');
+  expect(state.playerIcons[1].letter).toBe('S');
+  expect(state.paths[0].startIconIndex).toBe(0);
+  expect(state.zones[0].iconIndex).toBe(1);
+
+  // Undo restores the original 3-icon layout with the original indices.
+  await btn(page, 'Undo').click();
+  const undone = await canvasState(page);
+  expect(undone.playerIcons).toHaveLength(3);
+  expect(undone.paths[0].startIconIndex).toBe(1);
+  expect(undone.zones[0].iconIndex).toBe(2);
+});
+
 // B-27: special teams gets its own roster (K/P, LS, RET, COV) and the
 // zone tool (coverage lanes), but not the offense-only Formation menu.
 test('special teams: roster swaps, zone tool available, formation menu is not', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Reported: there was no simple way to remove one player icon from the canvas — only "Clear All" (wipes routes/zones/text too) or dragging it out of the way.
- Adds a **Delete** button to the existing tap-icon-to-edit popover (Select mode) rather than a new toolbar mode — a tap on an icon is never ambiguous the way routes/zones can be (a player can have 2 routes; zones can overlap), so a dedicated mode isn't needed just for disambiguation. Confirmed with the user before implementing.
- No confirmation dialog — matches this designer's existing pattern (Delete Route / Delete Zone / Clear All are all one tap + Undo as the safety net).
- Deleting an icon cascades to its own route(s) and zone. The subtle part: `startIconIndex`/`iconIndex` are array positions into `playerIcons`, not stable ids — removing one element shifts every later icon down by one, so every route/zone referencing a *later* icon needs its index shifted too, not just the removed icon's own stuff dropped. Nothing in `Canvas.tsx` had ever removed a `playerIcons` entry before (only appended or restyled in place), so this had no existing pattern to copy.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on all three touched files — no new errors
- [x] Two new smoke tests: (1) delete an icon with its own route, confirm both disappear in one undo step; (2) delete icon 0 of 3 (defense, with a route on icon 1 and a zone on icon 2), confirm icon 1/2's route/zone re-point to indices 0/1 instead of dangling or pointing at the wrong player — both confirmed to **fail without the fix**, then confirmed green with it applied
- [x] `npm run smoke` — full suite green (172 passed, 1 pre-existing environmental skip)
- [ ] Manual visual check in a real browser (no browser tool available in this environment) — recommend confirming the Delete button reads clearly in the popover and the icon-count-based auto-scaling (`iconScaleForCount`) looks right immediately after a delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)