### PR TITLE
Upgrade the team-name + play-name header across export/print formats

### DIFF
--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -5,7 +5,7 @@ import { X, FileText, Printer, BookOpen, Grid3X3, Lock, Watch } from 'lucide-rea
 import type { PlayMetadata } from '../../types/play';
 import { useEntitlement } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
-import { escapeHtml, paperPageSize, teamBrandHTML, type UserPreferences } from '../../lib/userPreferences';
+import { escapeHtml, paperPageSize, teamBrandHTML, playTitleHTML, type UserPreferences } from '../../lib/userPreferences';
 import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 
@@ -112,28 +112,16 @@ export function ExportModal({
     }
     
     .header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
       margin-bottom: 30px;
       padding-bottom: 15px;
       border-bottom: 2px solid #2563eb;
     }
-    
-    .play-title {
-      font-size: 28pt;
-      font-weight: bold;
-      color: #1e40af;
-      text-transform: uppercase;
-      letter-spacing: 1px;
-      flex: 1;
-    }
-    
+
     .play-info {
-      text-align: right;
+      text-align: center;
+      margin-top: 10px;
       font-size: 11pt;
       color: #64748b;
-      max-width: 200px;
     }
     
     .main-content {
@@ -208,7 +196,7 @@ export function ExportModal({
   <div class="page">
     ${teamBrandHTML(preferences)}
     <div class="header">
-      <div class="play-title">${playData.metadata.playName || 'Untitled Play'}</div>
+      ${playTitleHTML(playData.metadata.playName || 'Untitled Play', '28pt')}
       <div class="play-info">
         ${playData.metadata.formation ? `<div class="metadata-row"><span class="metadata-label">Formation:</span> ${playData.metadata.formation}</div>` : ''}
         ${playData.metadata.playType ? `<div class="metadata-row"><span class="metadata-label">Type:</span> ${playData.metadata.playType}</div>` : ''}
@@ -243,7 +231,7 @@ export function ExportModal({
     const playPages = plays.map(play => `
       <div class="play-page">
         <div class="play-header">
-          <h2 class="play-name">${play.metadata.playName || 'Untitled Play'}</h2>
+          ${playTitleHTML(play.metadata.playName || 'Untitled Play', '16pt')}
           <div class="play-meta">
             ${play.metadata.formation ? `<span>Formation: ${play.metadata.formation}</span>` : ''}
             ${play.metadata.playType ? `<span>Type: ${play.metadata.playType}</span>` : ''}
@@ -320,27 +308,20 @@ export function ExportModal({
     }
     
     .play-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
       margin-bottom: 15px;
       padding-bottom: 10px;
       border-bottom: 1px solid #d1d5db;
     }
-    
-    .play-name {
-      font-size: 16pt;
-      font-weight: bold;
-      color: #1e40af;
-    }
-    
+
     .play-meta {
+      text-align: center;
+      margin-top: 6px;
       font-size: 9pt;
       color: #6b7280;
     }
-    
+
     .play-meta span {
-      margin-left: 15px;
+      margin: 0 8px;
     }
     
     .play-content {
@@ -406,7 +387,7 @@ export function ExportModal({
   const generatePlaybookGridHTML = (plays: PlayData[]): string => {
     const playItems = plays.map(play => `
       <div class="grid-item">
-        <div class="grid-play-name">${play.metadata.playName || 'Untitled'}</div>
+        <div class="grid-play-name">${playTitleHTML(play.metadata.playName || 'Untitled', '11pt')}</div>
         <div class="grid-play-image">
           <img src="${play.canvasDataURL}" alt="${play.metadata.playName}" />
         </div>
@@ -479,9 +460,6 @@ export function ExportModal({
     }
     
     .grid-play-name {
-      font-size: 11pt;
-      font-weight: bold;
-      color: #1e40af;
       margin-bottom: 8px;
       min-height: 30px;
       display: flex;

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -30,7 +30,7 @@ import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { UsageWarningBanner } from '../UsageWarningBanner';
 import { PlayCard } from '../plays/PlayCard';
-import { getUserPreferences, paperPageSize, teamBrandHTML, type UserPreferences } from '../../lib/userPreferences';
+import { getUserPreferences, paperPageSize, teamBrandHTML, playTitleHTML, type UserPreferences } from '../../lib/userPreferences';
 import { usePageMeta } from '../../lib/seo';
 import { PlaybookPackLibrary } from './PlaybookPackLibrary';
 import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
@@ -426,14 +426,9 @@ export function PlaybooksPage() {
     }
     
     .play-title {
-      font-size: 32pt;
-      font-weight: bold;
-      color: #1e40af;
-      text-transform: uppercase;
-      letter-spacing: 2px;
       margin-bottom: 40px;
     }
-    
+
     .diagram-container {
       flex: 1;
       display: flex;
@@ -459,7 +454,7 @@ export function PlaybooksPage() {
 <body>
   <div class="page">
     ${teamBrandHTML(prefs)}
-    <div class="play-title">${play.name}</div>
+    <div class="play-title">${playTitleHTML(play.name, '32pt')}</div>
     <div class="diagram-container">
       ${play.thumbnail ? 
         `<img src="${play.thumbnail}" alt="${play.name}" class="diagram-image" />` :
@@ -511,14 +506,9 @@ export function PlaybooksPage() {
     }
     
     .play-title {
-      font-size: 28pt;
-      font-weight: bold;
-      color: #1e40af;
-      text-transform: uppercase;
-      letter-spacing: 1px;
       margin-bottom: 10px;
     }
-    
+
     .play-type {
       font-size: 14pt;
       color: #64748b;
@@ -603,7 +593,7 @@ export function PlaybooksPage() {
   <div class="page">
     ${teamBrandHTML(prefs)}
     <div class="header">
-      <div class="play-title">${play.name}</div>
+      <div class="play-title">${playTitleHTML(play.name, '28pt')}</div>
       <div class="play-type">${play.type} Play</div>
     </div>
     
@@ -681,7 +671,7 @@ export function PlaybooksPage() {
   const generateGridPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string): string => {
     const playItems = plays.map(play => `
       <div class="grid-item">
-        <div class="grid-play-name">${play.name}</div>
+        <div class="grid-play-name">${playTitleHTML(play.name, '11pt')}</div>
         <div class="grid-play-image">
           ${play.thumbnail ? 
             `<img src="${play.thumbnail}" alt="${play.name}" />` :
@@ -757,17 +747,13 @@ export function PlaybooksPage() {
     }
     
     .grid-play-name {
-      font-size: 11pt;
-      font-weight: bold;
-      color: #1e40af;
       margin-bottom: 8px;
       min-height: 30px;
       display: flex;
       align-items: center;
       justify-content: center;
-      text-align: center;
     }
-    
+
     .grid-play-image {
       margin-bottom: 8px;
       background: white;

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -83,16 +83,38 @@ export const escapeHtml = (s: string) =>
 
 /** Team name + logo header snippet for the print/export HTML documents
  *  (single-play sheet, playbook PDFs). Empty string when the user has no
- *  team identity configured, so exports look exactly as before. */
+ *  team identity configured, so exports look exactly as before.
+ *
+ *  Styled as a small tracked-out caption (a "kicker" line) that sits above
+ *  playTitleHTML()'s bigger headline below it — these two are meant to be
+ *  read as one pairing, not two independent headers. Georgia is a system
+ *  font available on every platform this prints from (macOS/Windows/iOS/
+ *  Android); these are window.open()+print documents with no <link>/
+ *  @font-face anywhere and nothing waiting on document.fonts.ready, so a
+ *  real web font would be a real risk here, not just unnecessary. */
 export function teamBrandHTML(prefs: Pick<UserPreferences, 'team_name' | 'team_logo_url'> | null): string {
   if (!prefs || (!prefs.team_name && !prefs.team_logo_url)) return '';
   const logo = prefs.team_logo_url
     ? `<img src="${escapeHtml(prefs.team_logo_url)}" alt="Team logo" style="height:42px;width:auto;" />`
     : '';
   const name = prefs.team_name
-    ? `<div style="font-size:13pt;font-weight:bold;color:#1e40af;letter-spacing:0.5px;">${escapeHtml(prefs.team_name)}</div>`
+    ? `<div style="font-family: Georgia, 'Times New Roman', serif; font-size:10pt; font-weight:600; letter-spacing:2.5px; text-transform:uppercase; color:#64748b;">${escapeHtml(prefs.team_name)}</div>`
     : '';
   return `<div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:10px;">${logo}${name}</div>`;
+}
+
+/** A play's name as the centered headline in an export document, paired
+ *  with teamBrandHTML() above it. Always centers itself regardless of what
+ *  flex row it's dropped into — callers whose title used to share a
+ *  `justify-content: space-between` row with metadata need to stack that
+ *  metadata below instead, since a centered title can't share a row with
+ *  right-aligned text the way the old left-aligned title could.
+ *
+ *  `fontSize` lets each export format keep its own existing relative
+ *  hierarchy (a single-play sheet's title has always been bigger than a
+ *  grid-view thumbnail's) instead of flattening every format to one size. */
+export function playTitleHTML(name: string, fontSize = '26pt'): string {
+  return `<div style="text-align:center; font-family: Georgia, 'Times New Roman', serif; font-size:${fontSize}; font-weight:700; color:#1e40af; letter-spacing:0.5px;">${escapeHtml(name)}</div>`;
 }
 
 /** CSS @page size value for the user's paper preference (B-15). */


### PR DESCRIPTION
## Summary
- Screenshotted feedback: the team name ("Colts") and play name ("Quick Out & Up") on a printed/PDF playbook looked visually mismatched and plain, with the team name's position unclear.
- Traced to six independently-styled play-title implementations across `ExportModal.tsx` and `PlaybooksPage.tsx` — already inconsistent with each other (some 28-32pt uppercase centered, some 16pt title-case left-aligned in a flex row with metadata). The team name (`teamBrandHTML`) was already correctly centered via flex; it just read as unintentional plain text with nothing pairing it visually to the title.
- Adds one shared `playTitleHTML()` helper (sibling to `teamBrandHTML` in `userPreferences.ts`) and applies both consistently across all six non-wristband export formats: team name as a small tracked-out Georgia caption, play name as a bigger centered Georgia headline in the existing brand blue (`#1e40af`, kept as-is).
- Georgia is a system font on every platform these documents print from (macOS/Windows/iOS/Android) — these are `window.open()` print documents with no `<link>`/`@font-face` and no `document.fonts.ready` wait, so a real web font would be a genuine rendering risk here, not just unnecessary.
- Three templates had their title sharing a `justify-content: space-between` flex row with metadata and needed restructuring (metadata moved below the now-centered title, not beside it) — a fourth I initially thought needed the same treatment turned out, on direct inspection, to already be stacked/centered, so I left it as a pure style swap rather than restructuring something that didn't need it.
- **Wristband export is untouched** — a bigger centered headline doesn't fit a 4.5"×2.2" wristband insert. **Deduplicating the six near-identical template functions is out of scope** — this only fixes their header styling, confirmed with the user before implementing.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on all three touched files — no new errors
- [x] `npm run smoke` — full suite green (172 passed, 1 pre-existing environmental skip)
- [x] Drove the actual export flow in a headless browser and inspected the generated HTML directly (no browser tool available in this environment otherwise) — confirmed the rendered header markup matches exactly: centered Georgia title, metadata correctly stacked below it instead of beside it
- [ ] Manual visual check in a real browser/print preview — recommend generating one export per format (Single Play, Playbook Detailed, Playbook Grid, both files' variants) with a team name set, and confirming the header reads as intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)