### PR TITLE
Add a text-only wristband export (play number + name, no diagram)

### DIFF
--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -569,7 +569,11 @@ export function ExportModal({
         return `
       <div class="wb-insert wb-insert-text">
         <div class="wb-insert-label">${insertLabel}</div>
-        <table class="wb-text-table"><tbody>${rowsHtml}
+        <table class="wb-text-table">
+          <colgroup>
+            <col class="col-num" /><col class="col-name" /><col class="col-num" /><col class="col-name" />
+          </colgroup>
+          <tbody>${rowsHtml}
         </tbody></table>
       </div>`;
       }
@@ -762,15 +766,28 @@ export function ExportModal({
       line-height: 1.3;
     }
 
+    /* Column widths are set here, on <colgroup>'s <col> elements — the
+       authoritative, unambiguous way to size a table-layout:fixed table.
+       Setting width on the repeated .wb-num/.wb-play-name TD classes was
+       unreliable (the name column rendered far too narrow and truncated
+       aggressively — reported with a screenshot), since table-layout:fixed
+       only reads the first row's cells to fix column widths, easy to get
+       inconsistent results from cell-level CSS across 4 repeating columns. */
+    .col-num {
+      width: 10%;
+    }
+
+    .col-name {
+      width: 40%;
+    }
+
     .wb-num {
-      width: 0.28in;
       font-weight: bold;
       color: #1e40af;
       text-align: right;
     }
 
     .wb-play-name {
-      width: 1.7in;
       text-align: left;
       white-space: nowrap;
       overflow: hidden;

--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -50,6 +50,9 @@ export function ExportModal({
 }: ExportModalProps) {
   const [showMetadataEditor, setShowMetadataEditor] = useState(false);
   const [selectedFormat, setSelectedFormat] = useState<'single-play' | 'detailed-playbook' | 'grid-playbook' | 'wristband-playbook'>('single-play');
+  // Wristband-only option: a dense #+name table instead of image cells —
+  // see generateWristbandPlaybookHTML's textOnly branch.
+  const [wristbandTextOnly, setWristbandTextOnly] = useState(false);
   const [metadata, setMetadata] = useState<PlayMetadata>(playMetadata);
   const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);
   const { isPro, loading: entitlementLoading } = useEntitlement();
@@ -520,7 +523,7 @@ export function ExportModal({
 </html>`;
   };
 
-  const generateWristbandPlaybookHTML = (plays: PlayData[]): string => {
+  const generateWristbandPlaybookHTML = (plays: PlayData[], textOnly = false): string => {
     // 4.5in x 2.2in matches the play window on Wristband Interactive Y23-style
     // QB wristbands, which hold 3 cut inserts arranged as a 4x2 grid of
     // numbered plays (8 per insert) — same layout as the printed inserts
@@ -528,14 +531,52 @@ export function ExportModal({
     const PLAYS_PER_INSERT = 8;
     const INSERTS_PER_BAND = 3;
 
+    // Text-only mode is a genuinely different, denser layout (a two-column
+    // table of #+name rows), not the same 8 image cells with the picture
+    // removed — confirmed against a photo of a real text-only wristband
+    // insert. Rows take far less room than a diagram cell, so an insert
+    // holds many more plays. ROWS_PER_COLUMN_TEXT is an estimate (no way to
+    // physically print-test in this environment) — needs a real print check
+    // before trusting the exact count; easy to retune afterward.
+    const ROWS_PER_COLUMN_TEXT = 14;
+    const COLUMNS_PER_INSERT_TEXT = 2;
+    const PLAYS_PER_INSERT_TEXT = ROWS_PER_COLUMN_TEXT * COLUMNS_PER_INSERT_TEXT;
+    const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
+
     const insertGroups: PlayData[][] = [];
-    for (let i = 0; i < plays.length; i += PLAYS_PER_INSERT) {
-      insertGroups.push(plays.slice(i, i + PLAYS_PER_INSERT));
+    for (let i = 0; i < plays.length; i += perInsert) {
+      insertGroups.push(plays.slice(i, i + perInsert));
     }
 
     const inserts = insertGroups.map((group, groupIndex) => {
+      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
+      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
+      const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
+
+      if (textOnly) {
+        const rows = group.map((play, i) => {
+          const playNumber = groupIndex * perInsert + i + 1;
+          return { playNumber, name: play.metadata.playName || 'Untitled' };
+        });
+        const mid = Math.ceil(rows.length / 2);
+        const columnHtml = (col: typeof rows) => `
+          <table class="wb-text-col"><tbody>
+            ${col.map((r) => `
+            <tr><td class="wb-num">${r.playNumber}</td><td class="wb-play-name">${r.name}</td></tr>`).join('')}
+          </tbody></table>`;
+
+        return `
+      <div class="wb-insert wb-insert-text">
+        <div class="wb-insert-label">${insertLabel}</div>
+        <div class="wb-text-columns">
+          ${columnHtml(rows.slice(0, mid))}
+          ${columnHtml(rows.slice(mid))}
+        </div>
+      </div>`;
+      }
+
       const cells = group.map((play, i) => {
-        const playNumber = groupIndex * PLAYS_PER_INSERT + i + 1;
+        const playNumber = groupIndex * perInsert + i + 1;
         return `
         <div class="wb-cell">
           <div class="wb-cell-header">
@@ -546,12 +587,9 @@ export function ExportModal({
         </div>`;
       }).join('');
 
-      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
-      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
-
       return `
       <div class="wb-insert">
-        <div class="wb-insert-label">Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}</div>
+        <div class="wb-insert-label">${insertLabel}</div>
         <div class="wb-cells">${cells}</div>
       </div>`;
     }).join('');
@@ -703,6 +741,42 @@ export function ExportModal({
       max-height: 100%;
     }
 
+    .wb-text-columns {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.15in;
+      min-height: 0;
+    }
+
+    .wb-text-col {
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+    }
+
+    .wb-text-col td {
+      padding: 0.01in 0.03in;
+      font-size: 8pt;
+      line-height: 1.3;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .wb-num {
+      width: 0.28in;
+      font-weight: bold;
+      color: #1e40af;
+      text-align: right;
+    }
+
+    .wb-play-name {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 0; /* forces overflow/ellipsis to respect the table column width */
+    }
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
       .wb-insert { page-break-inside: avoid; }
@@ -772,7 +846,7 @@ export function ExportModal({
         if (selectedFormat === 'detailed-playbook') {
           htmlContent = generatePlaybookDetailedHTML(plays);
         } else if (selectedFormat === 'wristband-playbook') {
-          htmlContent = generateWristbandPlaybookHTML(plays);
+          htmlContent = generateWristbandPlaybookHTML(plays, wristbandTextOnly);
         } else {
           htmlContent = generatePlaybookGridHTML(plays);
         }
@@ -939,6 +1013,18 @@ export function ExportModal({
                     </div>
                   </div>
                 </div>
+              )}
+
+              {selectedFormat === 'wristband-playbook' && (
+                <label className="flex items-center gap-2 mb-3 text-sm text-chalk cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={wristbandTextOnly}
+                    onChange={(e) => setWristbandTextOnly(e.target.checked)}
+                    className="rounded border-chalk/30"
+                  />
+                  Text only (no play diagrams) — fits more plays per insert
+                </label>
               )}
 
               {selectedFormat === 'wristband-playbook' && (

--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -531,16 +531,14 @@ export function ExportModal({
     const PLAYS_PER_INSERT = 8;
     const INSERTS_PER_BAND = 3;
 
-    // Text-only mode is a genuinely different, denser layout (a two-column
-    // table of #+name rows), not the same 8 image cells with the picture
-    // removed — confirmed against a photo of a real text-only wristband
-    // insert. Rows take far less room than a diagram cell, so an insert
-    // holds many more plays. ROWS_PER_COLUMN_TEXT is an estimate (no way to
-    // physically print-test in this environment) — needs a real print check
-    // before trusting the exact count; easy to retune afterward.
-    const ROWS_PER_COLUMN_TEXT = 14;
-    const COLUMNS_PER_INSERT_TEXT = 2;
-    const PLAYS_PER_INSERT_TEXT = ROWS_PER_COLUMN_TEXT * COLUMNS_PER_INSERT_TEXT;
+    // Text-only mode is a fixed 4-column x 10-row template (columns 1-2 are
+    // one #+name pair, columns 3-4 are the next 10 plays' #+name pair,
+    // continuing the numbering) — always this exact shape regardless of how
+    // many plays are populated, like a blank grid you fill in, not a list
+    // that shrinks to fit. Confirmed against a photo of a real text-only
+    // wristband insert, then refined to this precise spec.
+    const ROWS_PER_INSERT_TEXT = 10;
+    const PLAYS_PER_INSERT_TEXT = ROWS_PER_INSERT_TEXT * 2; // 20
     const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
 
     const insertGroups: PlayData[][] = [];
@@ -554,24 +552,25 @@ export function ExportModal({
       const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
 
       if (textOnly) {
-        const rows = group.map((play, i) => {
-          const playNumber = groupIndex * perInsert + i + 1;
-          return { playNumber, name: play.metadata.playName || 'Untitled' };
-        });
-        const mid = Math.ceil(rows.length / 2);
-        const columnHtml = (col: typeof rows) => `
-          <table class="wb-text-col"><tbody>
-            ${col.map((r) => `
-            <tr><td class="wb-num">${r.playNumber}</td><td class="wb-play-name">${r.name}</td></tr>`).join('')}
-          </tbody></table>`;
+        // Always exactly ROWS_PER_INSERT_TEXT rows — blank cells (no number,
+        // no name) when this insert has fewer than a full 20 plays, so the
+        // template's shape never changes.
+        const cell = (play: PlayData | undefined, num: number | '') => `
+            <td class="wb-num">${num}</td><td class="wb-play-name">${play ? (play.metadata.playName || 'Untitled') : ''}</td>`;
+        const rowsHtml = Array.from({ length: ROWS_PER_INSERT_TEXT }, (_, r) => {
+          const left = group[r];
+          const right = group[r + ROWS_PER_INSERT_TEXT];
+          const leftNum = left ? groupIndex * perInsert + r + 1 : '';
+          const rightNum = right ? groupIndex * perInsert + r + ROWS_PER_INSERT_TEXT + 1 : '';
+          return `
+            <tr>${cell(left, leftNum)}${cell(right, rightNum)}</tr>`;
+        }).join('');
 
         return `
       <div class="wb-insert wb-insert-text">
         <div class="wb-insert-label">${insertLabel}</div>
-        <div class="wb-text-columns">
-          ${columnHtml(rows.slice(0, mid))}
-          ${columnHtml(rows.slice(mid))}
-        </div>
+        <table class="wb-text-table"><tbody>${rowsHtml}
+        </tbody></table>
       </div>`;
       }
 
@@ -741,25 +740,26 @@ export function ExportModal({
       max-height: 100%;
     }
 
-    .wb-text-columns {
+    /* Fixed 4-column x 10-row grid, styled like an Excel table — full cell
+       borders on every row including blank ones, so the template's shape
+       reads the same whether it's fully populated or mostly empty. */
+    .wb-text-table {
       flex: 1;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 0.15in;
-      min-height: 0;
-    }
-
-    .wb-text-col {
       width: 100%;
+      height: 100%;
       border-collapse: collapse;
       table-layout: fixed;
     }
 
-    .wb-text-col td {
+    .wb-text-table tr {
+      height: 10%; /* 10 fixed rows, evenly filling the insert */
+    }
+
+    .wb-text-table td {
+      border: 1px solid #9ca3af;
       padding: 0.01in 0.03in;
       font-size: 8pt;
       line-height: 1.3;
-      border-bottom: 1px solid #e5e7eb;
     }
 
     .wb-num {
@@ -770,6 +770,7 @@ export function ExportModal({
     }
 
     .wb-play-name {
+      width: 1.7in;
       text-align: left;
       white-space: nowrap;
       overflow: hidden;

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -826,7 +826,7 @@ export function PlaybooksPage() {
 </html>`;
   };
 
-  const generateWristbandPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string): string => {
+  const generateWristbandPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string, textOnly = false): string => {
     // 4.5in x 2.2in matches the play window on Wristband Interactive Y23-style
     // QB wristbands, which hold 3 cut inserts arranged as a 4x2 grid of
     // numbered plays (8 per insert) — same layout as the printed inserts
@@ -834,14 +834,52 @@ export function PlaybooksPage() {
     const PLAYS_PER_INSERT = 8;
     const INSERTS_PER_BAND = 3;
 
+    // Text-only mode is a genuinely different, denser layout (a two-column
+    // table of #+name rows), not the same 8 image cells with the picture
+    // removed — confirmed against a photo of a real text-only wristband
+    // insert. Rows take far less room than a diagram cell, so an insert
+    // holds many more plays. ROWS_PER_COLUMN_TEXT is an estimate (no way to
+    // physically print-test in this environment) — needs a real print check
+    // before trusting the exact count; easy to retune afterward.
+    const ROWS_PER_COLUMN_TEXT = 14;
+    const COLUMNS_PER_INSERT_TEXT = 2;
+    const PLAYS_PER_INSERT_TEXT = ROWS_PER_COLUMN_TEXT * COLUMNS_PER_INSERT_TEXT;
+    const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
+
     const insertGroups: PlayInPlaybook[][] = [];
-    for (let i = 0; i < plays.length; i += PLAYS_PER_INSERT) {
-      insertGroups.push(plays.slice(i, i + PLAYS_PER_INSERT));
+    for (let i = 0; i < plays.length; i += perInsert) {
+      insertGroups.push(plays.slice(i, i + perInsert));
     }
 
     const inserts = insertGroups.map((group, groupIndex) => {
+      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
+      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
+      const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
+
+      if (textOnly) {
+        const rows = group.map((play, i) => {
+          const playNumber = groupIndex * perInsert + i + 1;
+          return { playNumber, name: play.name };
+        });
+        const mid = Math.ceil(rows.length / 2);
+        const columnHtml = (col: typeof rows) => `
+          <table class="wb-text-col"><tbody>
+            ${col.map((r) => `
+            <tr><td class="wb-num">${r.playNumber}</td><td class="wb-play-name">${r.name}</td></tr>`).join('')}
+          </tbody></table>`;
+
+        return `
+      <div class="wb-insert wb-insert-text">
+        <div class="wb-insert-label">${insertLabel}</div>
+        <div class="wb-text-columns">
+          ${columnHtml(rows.slice(0, mid))}
+          ${columnHtml(rows.slice(mid))}
+        </div>
+      </div>`;
+      }
+
       const cells = group.map((play, i) => {
-        const playNumber = groupIndex * PLAYS_PER_INSERT + i + 1;
+        const playNumber = groupIndex * perInsert + i + 1;
         return `
         <div class="wb-cell">
           <div class="wb-cell-header">
@@ -857,12 +895,9 @@ export function PlaybooksPage() {
         </div>`;
       }).join('');
 
-      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
-      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
-
       return `
       <div class="wb-insert">
-        <div class="wb-insert-label">Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}</div>
+        <div class="wb-insert-label">${insertLabel}</div>
         <div class="wb-cells">${cells}</div>
       </div>`;
     }).join('');
@@ -1019,6 +1054,42 @@ export function PlaybooksPage() {
       font-size: 7pt;
     }
 
+    .wb-text-columns {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.15in;
+      min-height: 0;
+    }
+
+    .wb-text-col {
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+    }
+
+    .wb-text-col td {
+      padding: 0.01in 0.03in;
+      font-size: 8pt;
+      line-height: 1.3;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .wb-num {
+      width: 0.28in;
+      font-weight: bold;
+      color: #1e40af;
+      text-align: right;
+    }
+
+    .wb-play-name {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 0; /* forces overflow/ellipsis to respect the table column width */
+    }
+
     .footer {
       margin-top: 0.15in;
       text-align: center;
@@ -1053,7 +1124,7 @@ export function PlaybooksPage() {
 </html>`;
   };
 
-  const handleExportPDF = async (format: 'simple' | 'detailed' | 'grid' | 'wristband') => {
+  const handleExportPDF = async (format: 'simple' | 'detailed' | 'grid' | 'wristband', wristbandTextOnly = false) => {
     if (!selectedPlaybook || playsInPlaybook.length === 0) {
       alert('Please select a playbook with plays to export.');
       return;
@@ -1069,7 +1140,7 @@ export function PlaybooksPage() {
       let htmlContent = '';
 
       if (format === 'wristband') {
-        htmlContent = generateWristbandPlaybookHTML(playsInPlaybook, selectedPlaybook.name);
+        htmlContent = generateWristbandPlaybookHTML(playsInPlaybook, selectedPlaybook.name, wristbandTextOnly);
       } else if (format === 'grid') {
         htmlContent = generateGridPlaybookHTML(playsInPlaybook, selectedPlaybook.name);
       } else {
@@ -1442,6 +1513,23 @@ export function PlaybooksPage() {
                                       )}
                                     </div>
                                     <div className="text-xs text-chalk/70">Sized for a 4.5"x2.2" QB wristband insert, cut and slide in</div>
+                                  </div>
+                                </button>
+                                <button
+                                  onClick={() => handleExportPDF('wristband', true)}
+                                  className="w-full flex items-center gap-3 px-4 py-2 text-left text-chalk hover:bg-board transition-colors"
+                                >
+                                  <Watch className="h-4 w-4 text-primary" />
+                                  <div className="flex-1">
+                                    <div className="font-medium flex items-center gap-2">
+                                      Wristband Sheet (Text Only)
+                                      {!entitlementLoading && !isPro && (
+                                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                                          <Lock className="h-3 w-3" /> Pro
+                                        </span>
+                                      )}
+                                    </div>
+                                    <div className="text-xs text-chalk/70">Play number + name only, no diagrams — fits more plays per insert</div>
                                   </div>
                                 </button>
                                 <div className="px-4 pt-1 pb-2" onClick={(e) => e.stopPropagation()}>

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -872,7 +872,11 @@ export function PlaybooksPage() {
         return `
       <div class="wb-insert wb-insert-text">
         <div class="wb-insert-label">${insertLabel}</div>
-        <table class="wb-text-table"><tbody>${rowsHtml}
+        <table class="wb-text-table">
+          <colgroup>
+            <col class="col-num" /><col class="col-name" /><col class="col-num" /><col class="col-name" />
+          </colgroup>
+          <tbody>${rowsHtml}
         </tbody></table>
       </div>`;
       }
@@ -1075,15 +1079,28 @@ export function PlaybooksPage() {
       line-height: 1.3;
     }
 
+    /* Column widths are set here, on <colgroup>'s <col> elements — the
+       authoritative, unambiguous way to size a table-layout:fixed table.
+       Setting width on the repeated .wb-num/.wb-play-name TD classes was
+       unreliable (the name column rendered far too narrow and truncated
+       aggressively — reported with a screenshot), since table-layout:fixed
+       only reads the first row's cells to fix column widths, easy to get
+       inconsistent results from cell-level CSS across 4 repeating columns. */
+    .col-num {
+      width: 10%;
+    }
+
+    .col-name {
+      width: 40%;
+    }
+
     .wb-num {
-      width: 0.28in;
       font-weight: bold;
       color: #1e40af;
       text-align: right;
     }
 
     .wb-play-name {
-      width: 1.7in;
       text-align: left;
       white-space: nowrap;
       overflow: hidden;

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -834,16 +834,14 @@ export function PlaybooksPage() {
     const PLAYS_PER_INSERT = 8;
     const INSERTS_PER_BAND = 3;
 
-    // Text-only mode is a genuinely different, denser layout (a two-column
-    // table of #+name rows), not the same 8 image cells with the picture
-    // removed — confirmed against a photo of a real text-only wristband
-    // insert. Rows take far less room than a diagram cell, so an insert
-    // holds many more plays. ROWS_PER_COLUMN_TEXT is an estimate (no way to
-    // physically print-test in this environment) — needs a real print check
-    // before trusting the exact count; easy to retune afterward.
-    const ROWS_PER_COLUMN_TEXT = 14;
-    const COLUMNS_PER_INSERT_TEXT = 2;
-    const PLAYS_PER_INSERT_TEXT = ROWS_PER_COLUMN_TEXT * COLUMNS_PER_INSERT_TEXT;
+    // Text-only mode is a fixed 4-column x 10-row template (columns 1-2 are
+    // one #+name pair, columns 3-4 are the next 10 plays' #+name pair,
+    // continuing the numbering) — always this exact shape regardless of how
+    // many plays are populated, like a blank grid you fill in, not a list
+    // that shrinks to fit. Confirmed against a photo of a real text-only
+    // wristband insert, then refined to this precise spec.
+    const ROWS_PER_INSERT_TEXT = 10;
+    const PLAYS_PER_INSERT_TEXT = ROWS_PER_INSERT_TEXT * 2; // 20
     const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
 
     const insertGroups: PlayInPlaybook[][] = [];
@@ -857,24 +855,25 @@ export function PlaybooksPage() {
       const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
 
       if (textOnly) {
-        const rows = group.map((play, i) => {
-          const playNumber = groupIndex * perInsert + i + 1;
-          return { playNumber, name: play.name };
-        });
-        const mid = Math.ceil(rows.length / 2);
-        const columnHtml = (col: typeof rows) => `
-          <table class="wb-text-col"><tbody>
-            ${col.map((r) => `
-            <tr><td class="wb-num">${r.playNumber}</td><td class="wb-play-name">${r.name}</td></tr>`).join('')}
-          </tbody></table>`;
+        // Always exactly ROWS_PER_INSERT_TEXT rows — blank cells (no number,
+        // no name) when this insert has fewer than a full 20 plays, so the
+        // template's shape never changes.
+        const cell = (play: PlayInPlaybook | undefined, num: number | '') => `
+            <td class="wb-num">${num}</td><td class="wb-play-name">${play ? play.name : ''}</td>`;
+        const rowsHtml = Array.from({ length: ROWS_PER_INSERT_TEXT }, (_, r) => {
+          const left = group[r];
+          const right = group[r + ROWS_PER_INSERT_TEXT];
+          const leftNum = left ? groupIndex * perInsert + r + 1 : '';
+          const rightNum = right ? groupIndex * perInsert + r + ROWS_PER_INSERT_TEXT + 1 : '';
+          return `
+            <tr>${cell(left, leftNum)}${cell(right, rightNum)}</tr>`;
+        }).join('');
 
         return `
       <div class="wb-insert wb-insert-text">
         <div class="wb-insert-label">${insertLabel}</div>
-        <div class="wb-text-columns">
-          ${columnHtml(rows.slice(0, mid))}
-          ${columnHtml(rows.slice(mid))}
-        </div>
+        <table class="wb-text-table"><tbody>${rowsHtml}
+        </tbody></table>
       </div>`;
       }
 
@@ -1054,25 +1053,26 @@ export function PlaybooksPage() {
       font-size: 7pt;
     }
 
-    .wb-text-columns {
+    /* Fixed 4-column x 10-row grid, styled like an Excel table — full cell
+       borders on every row including blank ones, so the template's shape
+       reads the same whether it's fully populated or mostly empty. */
+    .wb-text-table {
       flex: 1;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 0.15in;
-      min-height: 0;
-    }
-
-    .wb-text-col {
       width: 100%;
+      height: 100%;
       border-collapse: collapse;
       table-layout: fixed;
     }
 
-    .wb-text-col td {
+    .wb-text-table tr {
+      height: 10%; /* 10 fixed rows, evenly filling the insert */
+    }
+
+    .wb-text-table td {
+      border: 1px solid #9ca3af;
       padding: 0.01in 0.03in;
       font-size: 8pt;
       line-height: 1.3;
-      border-bottom: 1px solid #e5e7eb;
     }
 
     .wb-num {
@@ -1083,6 +1083,7 @@ export function PlaybooksPage() {
     }
 
     .wb-play-name {
+      width: 1.7in;
       text-align: left;
       white-space: nowrap;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- A coach requested a wristband export with just the play number + name, no diagram image.
- Confirmed against a reference photo of a real text-only wristband insert that this needed a denser, table-style layout, not the existing 8-image-cell grid with the picture removed. **Refined further per follow-up feedback**: a fixed **4-column x 10-row grid** — columns 1-2 are one #+name pair, columns 3-4 are the next 10 plays' #+name pair continuing the numbering — always exactly this shape (20 plays per insert) regardless of how many plays are populated. A playbook with only a few plays still shows the full 10-row grid with blank cells for unused slots, like a blank form rather than a list that shrinks to fit.
- Styled with full borders on every cell (including blank ones) for an Excel-table look, per the requested spec.
- `generateWristbandPlaybookHTML` (duplicated in `ExportModal.tsx` and `PlaybooksPage.tsx`, same pattern as every other export template) gets a `textOnly` parameter.
- Deliberately **no** attempt to replicate the original reference photo's situational headers (1st Down, 2nd Short, etc.) — this app only has a freeform `situation` text field per play, nothing structured enough to group by reliably. Confirmed with the user: one plain numbered list in the playbook's existing order.
- Two different UI entry points, matching how each surface already works: `ExportModal.tsx` gets a checkbox in its existing pre-print options screen; `PlaybooksPage.tsx` (whose Wristband Sheet button exports immediately, no options screen) gets a second menu item, "Wristband Sheet (Text Only)".
- Wristband stays Pro-gated in both places, same as before — text-only is just a variant of the same format, not a new gate.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx eslint` on both touched files — no new errors
- [x] `npm run smoke` — full suite green (172 passed, 1 pre-existing environmental skip)
- [x] Verified the grid logic in isolation: exactly 20 plays → 1 fully-populated insert with no blanks; 7 plays → still 10 rows with correctly-placed blank cells (13 blanks: 3 in column 1 for unused rows, all 10 in column 3); 23 plays → 2 inserts, second insert still fixed at 10 rows with the right 3 plays placed and the rest blank
- [x] Drove the actual export flow in a headless browser and confirmed the new CSS and markup render when the text-only option is selected (no browser tool available in this environment otherwise)
- [ ] **Real print/PDF-preview check at actual size** — please verify before relying on this for game day: confirm the 10 rows fit legibly within the 2.2in insert height and the grid lines print cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)