### PR TITLE
Fix Add to Playbook dropdown clipping on leftmost Plays card

### DIFF
--- a/src/components/plays/AddToPlaybookButton.tsx
+++ b/src/components/plays/AddToPlaybookButton.tsx
@@ -9,6 +9,11 @@ import { supabase } from '../../lib/supabase';
 // Used to decide whether it fits below the button or needs to open upward.
 const DROPDOWN_MAX_HEIGHT_PX = 320;
 
+// Widest the dropdown gets (w-72, see the JSX below — the empty-state panel
+// is narrower at w-64, but sizing off the wider case only makes the flip
+// trigger a little earlier, never too late).
+const DROPDOWN_WIDTH_PX = 288;
+
 // Playbook interface
 interface Playbook {
   id: string;
@@ -42,6 +47,9 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [justAdded, setJustAdded] = useState<Set<string>>(new Set());
   const [openUpward, setOpenUpward] = useState(false);
+  // Compact triggers default to right-0 (grows leftward, see below);
+  // recomputed on open against actual viewport space.
+  const [anchorRight, setAnchorRight] = useState(compact);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Fetch user's playbooks when dropdown opens
@@ -56,16 +64,46 @@ export const AddToPlaybookButton: React.FC<AddToPlaybookButtonProps> = ({
       // Flip upward when there isn't room below (e.g. bottom-row cards in a
       // grid) — otherwise the dropdown renders past the viewport edge and
       // becomes unreachable.
-      const spaceBelow = window.innerHeight - containerRef.current.getBoundingClientRect().bottom;
+      const rect = containerRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
       setOpenUpward(spaceBelow < DROPDOWN_MAX_HEIGHT_PX);
+
+      // The real horizontal boundary isn't the browser viewport — PlaysPage
+      // wraps the whole grid in an `overflow-hidden` panel narrower than the
+      // window (`max-w-7xl mx-auto px-4`), and that's what actually clips
+      // the dropdown. Walk up to the nearest overflow-hidden ancestor (found
+      // generically, not by page-specific selector, since this component
+      // could end up reused elsewhere) and measure against its bounds,
+      // falling back to the viewport if there isn't one.
+      let node = containerRef.current.parentElement;
+      let clipBounds = { left: 0, right: window.innerWidth };
+      while (node) {
+        const { overflowX, overflow } = window.getComputedStyle(node);
+        if (overflowX === 'hidden' || overflow === 'hidden') {
+          clipBounds = node.getBoundingClientRect();
+          break;
+        }
+        node = node.parentElement;
+      }
+
+      // Compact triggers sit at the right end of a card's action cluster, so
+      // they default to growing leftward (anchored to the trigger's right
+      // edge) — anchored left it would run past the card and get clipped
+      // by the ancestor above. Non-compact triggers default the other way.
+      // Either default flips when it would instead run off the opposite
+      // edge of the clip boundary — e.g. a compact trigger on the leftmost
+      // card in a grid, which has no room to its left before that boundary.
+      const fitsGrowingLeft = rect.right - clipBounds.left >= DROPDOWN_WIDTH_PX;
+      const fitsGrowingRight = clipBounds.right - rect.left >= DROPDOWN_WIDTH_PX;
+      let nextAnchorRight = compact;
+      if (compact && !fitsGrowingLeft && fitsGrowingRight) nextAnchorRight = false;
+      if (!compact && !fitsGrowingRight && fitsGrowingLeft) nextAnchorRight = true;
+      setAnchorRight(nextAnchorRight);
     }
     setIsOpen((prev) => !prev);
   };
 
-  // Compact triggers sit at the right end of a card's action cluster, so the
-  // panel has to grow leftward — anchored left it would run past the card and
-  // be clipped by the page panel's overflow-hidden.
-  const horizontalAnchor = compact ? 'right-0' : 'left-0';
+  const horizontalAnchor = anchorRight ? 'right-0' : 'left-0';
   const dropdownPositionClass = openUpward
     ? `bottom-full ${horizontalAnchor} mb-2`
     : `top-full ${horizontalAnchor} mt-2`;

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2549,6 +2549,64 @@ test('My Plays: card shows a "Use as Template" link to /designer?template=<id>',
   await expect(page.locator('a[href="/designer?template=my-play-1"]')).toBeVisible();
 });
 
+// Regression test: the compact "Add to Playbook" trigger always anchored its
+// dropdown to grow leftward (right-0) with no check for available space. The
+// grid's leftmost card sits right against the panel's own overflow-hidden
+// edge (PlaysPage.tsx wraps the grid in a narrower-than-viewport panel), so
+// growing 288px further left ran the dropdown past that edge and clipped its
+// text — reported live via a screenshot on playbuilderpro.com/plays.
+test('My Plays: leftmost card\'s Add to Playbook dropdown does not clip past the panel edge', async ({ page }) => {
+  const userJson = {
+    id: '77777777-7777-7777-7777-777777777777',
+    aud: 'authenticated', role: 'authenticated', email: 'coach@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600, token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/admin_users**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'free' }) }));
+  await page.route('**/rest/v1/playbooks**', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ id: 'pb-1', name: 'Offense', user_id: userJson.id, created_at: '', updated_at: '' }]),
+    }));
+  await page.route('**/rest/v1/playbook_plays**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/rest/v1/plays**', (route) => {
+    if (route.request().method() === 'HEAD') {
+      return route.fulfill({ status: 200, headers: { 'content-range': '*/6', 'access-control-expose-headers': 'content-range' }, body: '' });
+    }
+    const plays = Array.from({ length: 6 }, (_, i) => ({
+      id: `play-${i}`, name: `Play ${i}`, type: 'offense', thumbnail: null, is_public: false, upvotes: 0,
+    }));
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(plays) });
+  });
+
+  await page.setViewportSize({ width: 2000, height: 1180 });
+  await page.goto('/plays');
+  await expect(page.getByText('Play 0')).toBeVisible();
+
+  const panel = page.locator('div.bg-board-light.rounded-xl.border.overflow-hidden').first();
+  const panelBox = await panel.boundingBox();
+  expect(panelBox).not.toBeNull();
+
+  await page.locator('button[title="Add to Playbook"]').first().click();
+  const dropdown = page.getByText('Select Playbook').locator('..').locator('..');
+  await expect(dropdown).toBeVisible();
+  const dropdownBox = await dropdown.boundingBox();
+  expect(dropdownBox).not.toBeNull();
+
+  expect(dropdownBox!.x).toBeGreaterThanOrEqual(panelBox!.x - 1);
+});
+
 test('My Plays: a non-admin owner can delete their own play', async ({ page }) => {
   // Regression test: "Delete Play" used to be gated on isAdmin instead of
   // ownership, so a regular coach had no way to delete a play they made —


### PR DESCRIPTION
## Summary
- The compact "Add to Playbook" trigger (icon-only, card footer) always anchored its dropdown `right-0` (growing leftward), regardless of available space — a static heuristic based only on `compact` vs not.
- `PlaysPage.tsx:178` wraps the whole grid in an `overflow-hidden` panel narrower than the browser window (`max-w-7xl mx-auto px-4`). On the leftmost card in the grid, growing the ~288px-wide dropdown leftward runs it past that panel's left edge, clipping its text — exactly what was reported live via screenshot on `playbuilderpro.com/plays`.
- Fix measures against the nearest actual `overflow-hidden` ancestor (found generically via `getComputedStyle` walking up from the trigger, not a hardcoded selector — this component is only used in `PlaysPage.tsx` today but shouldn't assume that forever) instead of the full viewport, and flips the anchor direction when the default doesn't fit. Mirrors the existing vertical-flip pattern (`openUpward`) that already does the equivalent check against `window.innerHeight`.

## Verification
- Reproduced the exact bug with a Playwright script mocking a signed-in session + a 6-play grid at the screenshot's viewport width, confirming the pre-fix dropdown rendered left of the panel's edge; confirmed the fix keeps it inside.
- Added a permanent regression test to `tests/smoke/designer.spec.ts` ("leftmost card's Add to Playbook dropdown does not clip past the panel edge") — verified it fails against the pre-fix code and passes against the fix.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx eslint tests/smoke/designer.spec.ts src/components/plays/AddToPlaybookButton.tsx` — clean (0 errors; pre-existing warnings elsewhere in the file untouched)
- [x] `npm run build` — succeeds
- [x] `npm run smoke` — 173 passed (up from 172), 1 pre-existing skip, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)