### PR TITLE
Add scoreboard-numeral treatment to homepage stats

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { Link } from 'react-router-dom';
 import { HeroPlayCard } from './HeroPlayCard';
+import { StatDigit } from './StatDigit';
 import { supabase } from '../lib/supabase';
 
 /** Faint graph-paper grid, like a coach's printed play sheet. */
@@ -77,7 +78,12 @@ export function Hero() {
                   Playbuilder Pro is the play designer for youth and flag football coaches — draw routes
                   on a real field, organize by situation, and print what your players need on game day.
                 </p>
-                <div className="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
+                <div className="mt-8 flex flex-wrap justify-center gap-8 sm:gap-12 lg:justify-start">
+                  <StatDigit value="2 MIN" label="To Draw a Play" />
+                  <StatDigit value="15" label="Free Saved Plays" />
+                  <StatDigit value="$39/yr" label="Unlimited Pro" />
+                </div>
+                <div className="mt-8 sm:flex sm:justify-center lg:justify-start">
                   {user ? (
                     <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                       <Link to="/plays" className="flex items-center justify-center px-8 py-3 border border-transparent text-base font-bold rounded-md text-white bg-primary hover:bg-primary-dark md:py-4 md:text-lg md:px-10">

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -7,11 +7,10 @@ import { BILLING_ENABLED, startProCheckout } from '../lib/billing';
 import { getSafeErrorMessage } from '../lib/errors';
 import { supabase } from '../lib/supabase';
 import { UpgradeConsentModal } from './billing/UpgradeConsentModal';
+import { StatDigit } from './StatDigit';
 
 const freeFeatures = [
   'All Play Designer tools',
-  `Up to ${FREE_LIMITS.plays} saved plays`,
-  `${FREE_LIMITS.playbooks} playbooks`,
   'Single-play PDF export',
   'Browse & publish community plays',
 ];
@@ -79,11 +78,14 @@ export function Pricing() {
           {/* Free */}
           <div className="relative bg-board rounded-2xl shadow-xl border border-chalk/10 p-8">
             <h3 className="text-xl font-bold text-chalk">Free</h3>
-            <div className="mt-4 flex items-baseline text-chalk">
-              <span className="text-4xl font-bold tracking-tight">$0</span>
-              <span className="ml-2 text-chalk/70">always</span>
+            <div className="mt-4">
+              <StatDigit value="$0" label="Always" tone="dark" />
             </div>
             <p className="mt-6 text-chalk/70">Everything you need to design and share plays.</p>
+            <div className="mt-6 flex gap-8">
+              <StatDigit value={String(FREE_LIMITS.plays)} label="Saved Plays" tone="dark" />
+              <StatDigit value={String(FREE_LIMITS.playbooks)} label="Playbooks" tone="dark" />
+            </div>
             <ul className="mt-6 space-y-4">
               {freeFeatures.map((f) => (
                 <li key={f} className="flex text-chalk/90">
@@ -121,9 +123,8 @@ export function Pricing() {
               </div>
             )}
             <h3 className="text-xl font-bold text-chalk">Pro</h3>
-            <div className="mt-4 flex items-baseline text-chalk">
-              <span className="text-4xl font-bold tracking-tight">$39</span>
-              <span className="ml-2 text-chalk/70">/ year</span>
+            <div className="mt-4">
+              <StatDigit value="$39" label="Per Year" tone="dark" />
             </div>
             <p className="mt-6 text-chalk/70">For coaches running a full team and game-day printing.</p>
             <ul className="mt-6 space-y-4">

--- a/src/components/StatDigit.tsx
+++ b/src/components/StatDigit.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type StatDigitProps = {
+  value: string;
+  label: string;
+  tone?: 'light' | 'dark';
+};
+
+/**
+ * A number treated like a jersey/scoreboard digit: oversized Anton numeral
+ * with a thin outline, a mono caption underneath, and a yard-line rule.
+ * Reserved for numbers that matter to the reader's decision (price, limits,
+ * time-to-value) — not a general-purpose stat/kpi tile.
+ */
+export function StatDigit({ value, label, tone = 'light' }: StatDigitProps) {
+  const isDark = tone === 'dark';
+  return (
+    <div className="flex flex-col items-center lg:items-start">
+      <span
+        className={`font-display text-4xl sm:text-5xl tabular-nums leading-none ${
+          isDark ? 'text-chalk' : 'text-board'
+        }`}
+        style={{ WebkitTextStroke: isDark ? '1px rgba(31,167,93,0.6)' : '1px rgba(16,29,46,0.15)' }}
+      >
+        {value}
+      </span>
+      <span className="mt-2 h-0.5 w-8 bg-primary" aria-hidden="true" />
+      <span
+        className={`mt-2 font-label text-xs uppercase tracking-widest ${
+          isDark ? 'text-chalk/50' : 'text-board/50'
+        }`}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/TopPlays.tsx
+++ b/src/components/TopPlays.tsx
@@ -47,7 +47,7 @@ export function TopPlays() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h2 className="text-3xl font-chalk font-bold text-chalk flex items-center gap-3">
+            <h2 className="text-3xl font-display text-chalk flex items-center gap-3">
               <Trophy className="h-8 w-8 text-primary" />
               Top Ranked Plays
             </h2>


### PR DESCRIPTION
## Summary
- Adds a `StatDigit` component: oversized Anton numerals with a screen-printed outline, mono caption, and a yard-line underline — treating the numbers that matter to a coach deciding to sign up (time-to-draw, free limits, price) as a deliberate typographic signature instead of plain inline text.
- Hero gets a proof strip (`2 MIN` / `15` / `$39/yr`) between the subhead and CTAs.
- Pricing's price headers and free-tier numeric limits (saved plays, playbooks) now share that same visual language across the Free/Pro cards.
- Fixes `TopPlays.tsx`'s "Top Ranked Plays" heading using the non-existent `font-chalk` Tailwind utility (silently fell back to system sans) → `font-display`.

No new colors/fonts introduced — built entirely from existing `tailwind.config.js` tokens. No content fabricated — all values (2 min, 15 plays, 2 playbooks, $39/yr) are already true and mostly already on the page elsewhere.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run typecheck` — no new errors
- [x] `npx eslint` on touched files — clean
- [x] `npm run smoke` — 173/173 passing (1 pre-existing unrelated skip)
- [x] Visually verified at desktop (1440px) and mobile (390px) widths — stat strip and Pricing numerals wrap cleanly, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)