### PR TITLE
Remove dead jsPDF export path — closes the audit's last critical

### DIFF
--- a/.planning/audit/SYSTEM-AUDIT-2026-09-02.md
+++ b/.planning/audit/SYSTEM-AUDIT-2026-09-02.md
@@ -270,11 +270,20 @@ Owner decisions and what was executed on branch `chore/system-audit-cleanup`.
 | L-1/L-2 clutter | **Fixed.** Parent dir is now `project/` + `archive/` (with a README). `MARKETING.md` and `LEGAL_REVIEW_PACKET.md` → `docs/archive/` with dated names. README refreshed. |
 | Q-2 tsconfig, Q-3 staleness, Q-4 size | **Deferred** (see non-goals / open decision). |
 
-**Open decision — the last 4 vulnerabilities.** Both fixes are breaking:
-- `jspdf` 2.5.2 → 4.2.1 (two majors) — clears the **critical** and the nested dompurify. Touches single-play PDF, playbook PDF (detailed + grid), and wristband export: the Pro feature set. Needs real export testing, not just smoke.
-- `react-router-dom` 6.29 → 7.18 — clears 2 moderates, one of which (`deserializeErrors()` SSR hydration) **cannot apply** to this client-only SPA. The other (open redirect via backslash in `<Link>`/`useNavigate`) can.
+**RESOLVED 2026-09-03 — jspdf: removed, not upgraded.** ✅
 
-*Recommendation:* do jspdf first and alone, with manual verification of every export path; treat react-router as lower priority given the reduced real-world applicability.
+Investigating the upgrade showed the premise was wrong twice over, so the fix changed shape:
+
+1. **jsPDF never touched the Pro features.** Playbook PDFs (detailed + grid) and wristband export build HTML with `@media print` and call `window.open()` + `printWindow.print()` (`ExportModal.tsx:873-894`). They never imported jsPDF. My "touches the Pro feature set" claim was wrong.
+2. **jsPDF was never reachable at all.** Its only consumer was `handleExportToPDF` in `PlayDesigner.tsx`, passed to `ExportModal` as `onExport` — a prop that is declared in the interface but **never destructured and never called in any commit in repo history** (`git log --all -S "onExport("` → empty). It dates to the original Bolt scaffold commit `a44be90`. Confirmed empirically: a full single-play export fires `window.open()` and fetches **zero** jspdf/html2canvas chunks.
+
+So the critical CVE was never exploitable here — the vulnerable code could not execute. Rather than a two-major upgrade of an unused library, the dead code and both dependencies (`jspdf`, `html2canvas` — the latter imported by nothing in `src/`) were **deleted outright**. That removes the CVE permanently instead of deferring it to the next advisory, and drops ~590KB from the build.
+
+**Result: production vulnerabilities 9 → 2**, both moderate, both `react-router`. Guarded by a new smoke test asserting the export path prints via generated HTML and pulls in no PDF library.
+
+**Still open — `react-router-dom` 6.29 → 7.18.** Clears the last 2 moderates. One (`deserializeErrors()` SSR hydration) **cannot apply** to this client-only SPA; the other (open redirect via backslash in `<Link>`/`useNavigate`) can. A router major touches every route in the app, so it deserves its own change and its own testing pass.
+
+*Lesson worth keeping:* dead code that looks load-bearing is worse than no code — it cost this audit a mis-scored critical and nearly cost a needless major-version migration of a library the app doesn't use.
 
 ---
 *Audit performed 2026-09-02 by Claude Code (three parallel read-only discovery agents + synthesis); remediation 2026-09-03. All `path:line` citations verified at discovery time. One finding (S-1 blast radius) was found wrong on execution and is corrected in place above rather than silently removed.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,6 @@
         "clsx": "^2.1.0",
         "date-fns": "^3.3.1",
         "dompurify": "^3.4.13",
-        "html2canvas": "^1.4.1",
-        "jspdf": "^2.5.1",
         "lucide-react": "^0.344.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -289,15 +287,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2140,12 +2129,6 @@
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "dev": true
     },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
@@ -2511,17 +2494,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -2564,14 +2536,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.20",
@@ -2655,17 +2619,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2705,32 +2658,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/canvg/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "optional": true
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2798,17 +2725,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/core-js": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2822,14 +2738,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -3311,12 +3219,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3522,18 +3424,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3737,30 +3627,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/jspdf": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "fflate": "^0.8.1"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.5.4",
-        "html2canvas": "^1.0.0-rc.5"
-      }
-    },
-    "node_modules/jspdf/node_modules/dompurify": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
-      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4108,12 +3974,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4523,15 +4383,6 @@
         }
       ]
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4660,15 +4511,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -4804,15 +4646,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
       }
     },
     "node_modules/string-width": {
@@ -4958,15 +4791,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -5012,14 +4836,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -5314,14 +5130,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",
     "dompurify": "^3.4.13",
-    "html2canvas": "^1.4.1",
-    "jspdf": "^2.5.1",
     "lucide-react": "^0.344.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -19,7 +19,6 @@ interface PlayData {
 interface ExportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onExport?: (format: 'single' | 'multiple' | 'wristband') => void;
   canvasRef?: React.RefObject<any>;
   playMetadata?: PlayMetadata;
   onUpdateMetadata?: (metadata: PlayMetadata) => void;

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -461,27 +461,6 @@ export function PlayDesigner() {
     }
   }, [user, editingPlayId, playType, searchParams, navigate]);
 
-  const handleExportToPDF = useCallback(async (_format: 'single' | 'multiple' | 'wristband') => {
-    try {
-      // Fixed-resolution render (1650x1275) so every play prints identically
-      // regardless of the screen it was designed on
-      const imgData = canvasRef.current?.exportImage?.();
-      if (!imgData) return;
-      // Loaded on demand — jsPDF only matters at export time, not for every
-      // visit to the designer.
-      const { jsPDF } = await import('jspdf');
-      const pdf = new jsPDF({ orientation: 'landscape', unit: 'mm' });
-      const pw = pdf.internal.pageSize.getWidth();
-      const ph = (1275 * pw) / 1650;
-      pdf.addImage(imgData, 'PNG', 0, 0, pw, ph);
-      pdf.save(`${currentPlayMetadata.playName || 'play'}.pdf`);
-      setShowExportModal(false);
-    } catch (err) {
-      console.error(err);
-      setError('Failed to export PDF.');
-    }
-  }, [currentPlayMetadata.playName]);
-
   if (loading) return (
     <div className="min-h-screen bg-board flex items-center justify-center">
       <div className="text-chalk">Loading…</div>
@@ -721,7 +700,6 @@ export function PlayDesigner() {
         <ExportModal
           isOpen={showExportModal}
           onClose={() => setShowExportModal(false)}
-          onExport={handleExportToPDF}
           canvasRef={canvasRef}
           playMetadata={currentPlayMetadata}
           onUpdateMetadata={setCurrentPlayMetadata}

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2335,6 +2335,53 @@ test('export gates (B-2): playbook PDF formats are Pro-locked, single-play stays
   await expect(page.getByRole('button', { name: /Print Play/ })).toBeVisible();
 });
 
+test('single-play export prints via a generated window, pulling in no PDF library', async ({ page }) => {
+  // Every export path — including the free single-play sheet — builds HTML and
+  // hands it to window.print(). It does NOT generate the PDF in-app.
+  //
+  // This is a regression guard for a real trap: PlayDesigner carried a
+  // jsPDF-based `handleExportToPDF` from the original scaffold that was passed
+  // to ExportModal as `onExport` and never once called, in any commit. It kept
+  // jspdf + html2canvas (~590KB) in the dependency tree, and a security audit
+  // read it as the live export path and mis-scored a critical jsPDF CVE as
+  // reachable. Dead code that *looks* load-bearing is worse than no code, so
+  // assert the real mechanism rather than trusting the imports.
+  const opened: string[] = [];
+  await page.exposeFunction('__recordPrintDoc', (html: string) => { opened.push(html); });
+  await page.addInitScript(() => {
+    window.open = () => {
+      let buf = '';
+      return {
+        document: {
+          open() {}, close() {},
+          write(html: string) {
+            buf += html;
+            (window as unknown as { __recordPrintDoc: (h: string) => void }).__recordPrintDoc(buf);
+          },
+        },
+        focus() {}, print() {}, closed: false,
+      } as unknown as Window;
+    };
+  });
+
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+  await page.getByText('Single Play Sheet').click();
+  await page.getByRole('button', { name: /Print Play/ }).first().click();
+
+  // The print document is real, generated HTML — not a PDF blob.
+  await expect.poll(() => opened.length, { timeout: 5000 }).toBeGreaterThan(0);
+  expect(opened.join('')).toContain('@media print');
+
+  // No PDF/canvas-rasterizing library may be pulled into this flow.
+  const heavy = await page.evaluate(() =>
+    performance.getEntriesByType('resource')
+      .map((e) => e.name)
+      .filter((n) => /jspdf|html2canvas/i.test(n)),
+  );
+  expect(heavy).toEqual([]);
+});
+
 test('export gates (B-2): Pro accounts see playbook formats unlocked', async ({ page }) => {
   const userJson = {
     id: '22222222-2222-2222-2222-222222222222',


### PR DESCRIPTION
Resolves the open decision from `.planning/audit/SYSTEM-AUDIT-2026-09-02.md`. **Production vulnerabilities: 9 → 2.**

## The fix changed shape once I looked

The plan was `jspdf` 2.5.2 → 4.2.1 to clear a critical (Local File Inclusion / Path Traversal) plus a nested vulnerable `dompurify` 2.5.9. Investigating it showed my audit was wrong on two counts:

**1. jsPDF never touched the Pro export features.** Playbook PDFs (detailed + grid) and wristband export build HTML with `@media print` and call `window.open()` + `printWindow.print()` ([ExportModal.tsx:873-894](../blob/main/src/components/designer/ExportModal.tsx#L873-L894)). They never imported jsPDF. The audit's "touches the Pro feature set" claim was simply wrong.

**2. jsPDF was never reachable at all.** Its only consumer was `handleExportToPDF` in `PlayDesigner.tsx`, passed to `ExportModal` as `onExport` — a prop **declared in the interface but never destructured and never called in any commit in repo history** (`git log --all -S "onExport("` → empty). It came from the original Bolt scaffold (`a44be90`) and was never wired up.

Confirmed empirically, not by reading: a complete single-play export fires `window.open()` and fetches **zero** jspdf/html2canvas chunks.

**So the critical CVE was never exploitable here** — the vulnerable code could not execute.

## What this does instead

Deletes the dead function and drops **both** dependencies rather than migrating two major versions of a library nothing calls. `html2canvas` goes too: nothing in `src/` ever imported it, it was along for the ride as a jspdf optional dep.

Removing beats upgrading here because it eliminates the CVE **permanently** rather than deferring it to the next advisory — and sheds ~590KB of never-loaded chunks from the build.

## Guard against regression
New smoke test asserts the export path prints via generated HTML and pulls in no PDF library. This dead code already cost one mis-scored critical; it shouldn't be able to come back quietly.

## Still open (deliberately)
`react-router-dom` 6.29 → 7.18 clears the last 2 moderates. One (`deserializeErrors()` SSR hydration) **can't apply** to this client-only SPA; the other (open redirect via backslash in `<Link>`/`useNavigate`) can. A router major touches every route, so it deserves its own change.

## Test plan
- [x] `npm run verify` passes end to end, exit 0
- [x] **174/174** smoke (173 + the new guard)
- [x] Export flow driven in a real browser; `window.open()` confirmed firing, zero PDF-lib chunks fetched
- [x] `dist/` confirmed free of jspdf/html2canvas chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)