### PR TITLE
Fix white pillarbox gap around play thumbnails

### DIFF
--- a/src/components/plays/PlayCard.tsx
+++ b/src/components/plays/PlayCard.tsx
@@ -64,7 +64,7 @@ export function PlayCard({
 
   // White ground: stored thumbnails are exported on white, so anything else
   // shows as a border around the image.
-  const frame = `relative block aspect-video bg-white border-b border-chalk/10 ${clip ? '' : 'rounded-t-lg overflow-hidden'}`;
+  const frame = `relative block aspect-play bg-white border-b border-chalk/10 ${clip ? '' : 'rounded-t-lg overflow-hidden'}`;
 
   const thumbnail = play.thumbnail ? (
     <img

--- a/src/components/plays/PlayLibrary.tsx
+++ b/src/components/plays/PlayLibrary.tsx
@@ -321,7 +321,7 @@ export function PlayLibrary() {
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {[1, 2, 3].map((i) => (
             <div key={i} className="bg-board-light rounded-lg border border-chalk/10 overflow-hidden animate-pulse">
-              <div className="aspect-video bg-chalk/10"></div>
+              <div className="aspect-play bg-chalk/10"></div>
               <div className="p-4">
                 <div className="h-5 bg-chalk/10 rounded w-2/3 mb-2"></div>
                 <div className="h-4 bg-chalk/10 rounded w-1/3"></div>

--- a/src/components/plays/PlaysPage.tsx
+++ b/src/components/plays/PlaysPage.tsx
@@ -258,7 +258,7 @@ export function PlaysPage() {
                     key={i}
                     className="animate-pulse bg-board-light rounded-lg border border-chalk/10"
                   >
-                    <div className="bg-board rounded-t-lg aspect-video"></div>
+                    <div className="bg-board rounded-t-lg aspect-play"></div>
                     <div className="p-4">
                       <div className="h-4 bg-board rounded w-2/3 mb-3"></div>
                       <div className="h-9 bg-board rounded w-1/2 ml-auto"></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,14 @@ export default {
         // (designer, dashboards, forms) stays on `font-sans` (Inter var).
         editorial: ['Fraunces', 'Georgia', 'serif'],
       },
+      aspectRatio: {
+        // Matches EXPORT_WIDTH/EXPORT_HEIGHT (1650x1275) in
+        // renderPlayScene.ts — reduces to 22/17. Every stored play thumbnail
+        // is rendered at this ratio; a mismatched container pillarboxes the
+        // diagram and the gap reads as an unstyled white margin. Keep this in
+        // sync if the export size ever changes.
+        play: '22 / 17',
+      },
     },
   },
   plugins: [typography],


### PR DESCRIPTION
Every play card (My Plays, community Play Library, playbook grids) framed its thumbnail in `aspect-video` (16:9 = 1.778), but every stored thumbnail is rendered at 1650×1275 (1.294 — `EXPORT_WIDTH`/`EXPORT_HEIGHT` in `renderPlayScene.ts`). With `object-contain`, the image fit by height and pillarboxed to ~73% of the frame width, leaving **~13.6% bare white on each side**.

Because the frame and the PNG's own field background are both white, that pillarbox fused invisibly with the diagram's own margin and read as one continuous white gap around every play diagram in the app — the "space between the sidelines and the card edge" reported.

## Fix
Adds an `aspect-play` token (`22 / 17`, matching the export ratio) to `tailwind.config.js` as the single source of truth, and applies it to `PlayCard`'s media frame plus the two loading skeletons that must match it — otherwise the card would visibly resize the moment its lazily-loaded thumbnail arrives (`PlayLibrary.tsx`'s IntersectionObserver-driven thumbnails made this a real risk, not a theoretical one).

## Deliberately not in scope
The ~1.3% margin baked into the thumbnail PNGs themselves (`SIDELINE_PADDING` in `renderPlayScene.ts`). Fixing that means re-rendering every stored thumbnail across all users — a live-data migration. The CSS-only fix removes ~95% of the reported gap with zero data risk. Cropping (`object-cover`) was never on the table either — `PlayCard.tsx` already documents why: it would cut routes off at the frame edge.

## Test plan
- [x] `npm run verify` — passes, 174/174 smoke
- [x] Visually confirmed on the community Play Library, My Plays, and at mobile width (390px) — diagrams now meet the frame edge with only a hairline margin
- [x] Confirmed the skeleton→loaded transition causes no card resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)