### PR TITLE
Rename waypoint route button from "Route" to "Curved"

### DIFF
--- a/src/components/designer/DesignerToolbar.tsx
+++ b/src/components/designer/DesignerToolbar.tsx
@@ -21,7 +21,7 @@ interface DesignerToolbarProps {
   setDrawingMode: (mode: boolean) => void;
   drawMode: DrawMode;
   setDrawMode: (mode: DrawMode) => void;
-  /** Terminal decoration for the next route finished in Straight or Route
+  /** Terminal decoration for the next route finished in Straight or Curved
    *  mode — sticky until changed, independent of shape. */
   capStyle: CapStyle;
   setCapStyle: (style: CapStyle) => void;
@@ -296,13 +296,13 @@ export function DesignerToolbar({
           className={`${tool} ${activeDraw === 'waypoint' ? active : inactive}`}
         >
           <GitBranch className="h-4 w-4" />
-          <span className={label}>Route</span>
+          <span className={label}>Curved</span>
         </button>
 
         <div className={divider} />
 
         {/* Ending style: click to flip between arrowhead and a perpendicular
-            block cap. Independent of shape (Straight/Route above) — a route
+            block cap. Independent of shape (Straight/Curved above) — a route
             can now be curved AND end in a block cap, which wasn't possible
             when Block was its own separate mode. Sticky until changed, like
             drawMode. A single toggle button (rather than a two-button pill)


### PR DESCRIPTION
The route-shape toolbar has three buttons in a row: **Straight**, then the multi-segment/waypoint shape (labeled **Route**), then a cap-style toggle that also reads **Route** whenever it's in its default arrow state. Two adjacent controls sharing the same visible label made the second one look like a duplicate of the third, rather than what it actually is: shape (straight vs. curved) vs. ending style (arrow vs. block).

## Fix
Renamed the shape button's label to **Curved**. Notably, the toolbar's own status-bar text already called this mode "Curved route mode" (`DesignerToolbar.tsx:504`) — so this just brings the visible label in line with naming the code already used internally.

Left the button's `title`/tooltip attribute unchanged ("Multi-Segment Route...") since several smoke tests select it by exact title text, and the tooltip was never the source of confusion — only the always-visible label was.

## Before / after
```
Before:  Straight · Route · Route     (shape · shape · ending style)
After:   Straight · Curved · Route    (shape · shape · ending style)
```

## Test plan
- [x] `npm run verify` passes, 174/174 smoke
- [x] Visually confirmed in the real designer toolbar — the three controls now read as three distinct choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)