### PR TITLE
Unify all print exports: black/white chrome, wristband reference restyle

### DIFF
--- a/src/components/designer/ExportModal.tsx
+++ b/src/components/designer/ExportModal.tsx
@@ -6,7 +6,11 @@ import type { PlayMetadata } from '../../types/play';
 import { useEntitlement } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { escapeHtml, paperPageSize, teamBrandHTML, playTitleHTML, type UserPreferences } from '../../lib/userPreferences';
-import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
+import {
+  EXPORT_ACCENT_RULE, EXPORT_INK, EXPORT_HAIRLINE, EXPORT_WASH, UNTITLED_PLAY,
+  formatPlayType, exportFooterHTML, NOTES_BLOCK_CSS, notesBlockHTML, generateWristbandHTML,
+} from '../../lib/exportStyles';
+import { WRISTBAND_PRODUCT_NAME, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 const PRO_ONLY_FORMATS = new Set(['detailed-playbook', 'grid-playbook', 'wristband-playbook']);
@@ -85,7 +89,7 @@ export function ExportModal({
 <html>
 <head>
   <meta charset="utf-8">
-  <title>${playData.metadata.playName || 'Football Play'}</title>
+  <title>${escapeHtml(playData.metadata.playName || UNTITLED_PLAY)}</title>
   <style>
     @page {
       size: ${paperPageSize(preferences?.paper_size ?? 'letter')};
@@ -116,77 +120,57 @@ export function ExportModal({
     .header {
       margin-bottom: 30px;
       padding-bottom: 15px;
-      border-bottom: 2px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
 
     .play-info {
       text-align: center;
       margin-top: 10px;
       font-size: 11pt;
-      color: #64748b;
+      color: ${EXPORT_INK};
     }
-    
+
     .main-content {
       flex: 1;
       display: flex;
       flex-direction: column;
     }
-    
+
     .canvas-container {
       text-align: center;
       margin: 20px 0;
       padding: 20px;
       background: white;
-      border: 2px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 8px;
       flex: 1;
       display: flex;
       align-items: center;
       justify-content: center;
     }
-    
+
     .canvas-image {
       max-width: 100%;
       max-height: 400px;
       height: auto;
       border-radius: 4px;
     }
-    
-    .notes-section {
-      margin-top: 20px;
-      padding: 15px;
-      background: #f8fafc;
-      border-radius: 8px;
-      border: 1px solid #e2e8f0;
-    }
-    
-    .notes-title {
-      font-weight: bold;
-      font-size: 14pt;
-      color: #1e293b;
-      margin-bottom: 10px;
-    }
-    
-    .notes-content {
-      font-size: 11pt;
-      line-height: 1.6;
-      color: #374151;
-    }
-    
+    ${NOTES_BLOCK_CSS}
+
     .metadata-row {
       margin-bottom: 5px;
     }
-    
+
     .metadata-label {
       font-weight: bold;
-      color: #374151;
+      color: ${EXPORT_INK};
     }
 
     .free-footer {
       margin-top: 15px;
       text-align: center;
       font-size: 8pt;
-      color: #9ca3af;
+      color: #999;
     }
 
     @media print {
@@ -198,30 +182,25 @@ export function ExportModal({
   <div class="page">
     ${teamBrandHTML(preferences)}
     <div class="header">
-      ${playTitleHTML(playData.metadata.playName || 'Untitled Play', '28pt')}
+      ${playTitleHTML(playData.metadata.playName || UNTITLED_PLAY, '28pt')}
       <div class="play-info">
-        ${playData.metadata.formation ? `<div class="metadata-row"><span class="metadata-label">Formation:</span> ${playData.metadata.formation}</div>` : ''}
-        ${playData.metadata.playType ? `<div class="metadata-row"><span class="metadata-label">Type:</span> ${playData.metadata.playType}</div>` : ''}
-        ${playData.metadata.situation ? `<div class="metadata-row"><span class="metadata-label">Situation:</span> ${playData.metadata.situation}</div>` : ''}
-        ${playData.metadata.difficulty ? `<div class="metadata-row"><span class="metadata-label">Difficulty:</span> ${playData.metadata.difficulty}</div>` : ''}
+        ${playData.metadata.formation ? `<div class="metadata-row"><span class="metadata-label">Formation:</span> ${escapeHtml(playData.metadata.formation)}</div>` : ''}
+        ${playData.metadata.playType ? `<div class="metadata-row"><span class="metadata-label">Type:</span> ${escapeHtml(formatPlayType(playData.metadata.playType))}</div>` : ''}
+        ${playData.metadata.situation ? `<div class="metadata-row"><span class="metadata-label">Situation:</span> ${escapeHtml(playData.metadata.situation)}</div>` : ''}
+        ${playData.metadata.difficulty ? `<div class="metadata-row"><span class="metadata-label">Difficulty:</span> ${escapeHtml(formatPlayType(playData.metadata.difficulty))}</div>` : ''}
       </div>
     </div>
-    
+
     <div class="main-content">
       <div class="canvas-container">
         <img src="${playData.canvasDataURL}" alt="Football Play Diagram" class="canvas-image" />
       </div>
-      
-      <div class="notes-section">
-        <div class="notes-title">Notes & Execution</div>
-        <div class="notes-content">
-          ${playData.metadata.description || 'No notes provided for this play.'}
-          
-          ${playData.metadata.personnel ? `<br><br><strong>Personnel:</strong> ${playData.metadata.personnel}` : ''}
-          ${playData.metadata.yardage ? `<br><strong>Expected Yardage:</strong> ${playData.metadata.yardage}` : ''}
-          ${playData.metadata.tags && playData.metadata.tags.length > 0 ? `<br><strong>Tags:</strong> ${playData.metadata.tags.join(', ')}` : ''}
-        </div>
-      </div>
+
+      ${notesBlockHTML(playData.metadata.description, [
+        { label: 'Personnel', value: playData.metadata.personnel },
+        { label: 'Expected Yardage', value: playData.metadata.yardage },
+        { label: 'Tags', value: playData.metadata.tags?.length ? playData.metadata.tags.join(', ') : null },
+      ])}
     </div>
     ${!isPro ? '<div class="free-footer">Made with playbuilderpro.com</div>' : ''}
   </div>
@@ -233,24 +212,22 @@ export function ExportModal({
     const playPages = plays.map(play => `
       <div class="play-page">
         <div class="play-header">
-          ${playTitleHTML(play.metadata.playName || 'Untitled Play', '16pt')}
+          ${playTitleHTML(play.metadata.playName || UNTITLED_PLAY, '16pt')}
           <div class="play-meta">
-            ${play.metadata.formation ? `<span>Formation: ${play.metadata.formation}</span>` : ''}
-            ${play.metadata.playType ? `<span>Type: ${play.metadata.playType}</span>` : ''}
+            ${play.metadata.formation ? `<span>Formation: ${escapeHtml(play.metadata.formation)}</span>` : ''}
+            ${play.metadata.playType ? `<span>Type: ${escapeHtml(formatPlayType(play.metadata.playType))}</span>` : ''}
           </div>
         </div>
-        
+
         <div class="play-content">
           <div class="play-diagram">
-            <img src="${play.canvasDataURL}" alt="${play.metadata.playName}" class="play-image" />
+            <img src="${play.canvasDataURL}" alt="${escapeHtml(play.metadata.playName || UNTITLED_PLAY)}" class="play-image" />
           </div>
-          
-          <div class="play-notes">
-            <h4>Notes</h4>
-            <p>${play.metadata.description || 'No notes provided.'}</p>
-            ${play.metadata.situation ? `<p><strong>Situation:</strong> ${play.metadata.situation}</p>` : ''}
-            ${play.metadata.personnel ? `<p><strong>Personnel:</strong> ${play.metadata.personnel}</p>` : ''}
-          </div>
+
+          ${notesBlockHTML(play.metadata.description, [
+            { label: 'Situation', value: play.metadata.situation },
+            { label: 'Personnel', value: play.metadata.personnel },
+          ])}
         </div>
       </div>
     `).join('');
@@ -266,104 +243,89 @@ export function ExportModal({
       size: ${paperPageSize(preferences?.paper_size ?? 'letter')};
       margin: 0.5in;
     }
-    
+
     * {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
     }
-    
+
     body {
       font-family: Arial, sans-serif;
       font-size: 10pt;
       line-height: 1.3;
-      color: #000;
+      color: ${EXPORT_INK};
       background: white;
     }
-    
+
     .playbook-header {
       text-align: center;
       margin-bottom: 30px;
       padding-bottom: 15px;
-      border-bottom: 3px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
-    
+
     .playbook-title {
       font-size: 24pt;
       font-weight: bold;
-      color: #1e40af;
+      color: ${EXPORT_INK};
       margin-bottom: 5px;
     }
-    
+
     .playbook-subtitle {
       font-size: 12pt;
-      color: #64748b;
+      color: #555;
     }
-    
+
     .play-page {
       margin-bottom: 40px;
       page-break-inside: avoid;
-      border: 1px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 8px;
       padding: 15px;
-      background: #fafafa;
+      background: ${EXPORT_WASH};
     }
-    
+
     .play-header {
       margin-bottom: 15px;
       padding-bottom: 10px;
-      border-bottom: 1px solid #d1d5db;
+      border-bottom: 1px solid #ccc;
     }
 
     .play-meta {
       text-align: center;
       margin-top: 6px;
       font-size: 9pt;
-      color: #6b7280;
+      color: #555;
     }
 
     .play-meta span {
       margin: 0 8px;
     }
-    
+
     .play-content {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 20px;
       align-items: start;
     }
-    
+
     .play-diagram {
       text-align: center;
     }
-    
+
     .play-image {
       max-width: 100%;
       height: auto;
       max-height: 250px;
-      border: 1px solid #d1d5db;
+      border: 1px solid #ccc;
       border-radius: 4px;
     }
-    
-    .play-notes {
-      padding: 10px;
-      background: white;
-      border-radius: 4px;
-      border: 1px solid #e5e7eb;
-    }
-    
-    .play-notes h4 {
-      font-size: 12pt;
-      color: #374151;
-      margin-bottom: 8px;
-    }
-    
-    .play-notes p {
-      margin-bottom: 8px;
-      font-size: 9pt;
-      line-height: 1.4;
-    }
-    
+    ${NOTES_BLOCK_CSS}
+    /* Notes sits beside the diagram in a grid column here, not stacked
+       full-width below it — the shared block's top margin doesn't apply. */
+    .play-content .pb-notes { margin-top: 0; }
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
       .play-page { page-break-inside: avoid; }
@@ -376,12 +338,10 @@ export function ExportModal({
     <div class="playbook-title">${preferences?.team_name ? `${escapeHtml(preferences.team_name)} Playbook` : 'Football Playbook'}</div>
     <div class="playbook-subtitle">Detailed Play Collection</div>
   </div>
-  
+
   ${playPages}
-  
-  <div style="margin-top: 30px; text-align: center; font-size: 8pt; color: #6b7280; border-top: 1px solid #e5e7eb; padding-top: 10px;">
-    Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()} | Total Plays: ${plays.length}
-  </div>
+
+  ${exportFooterHTML(plays.length, '30px')}
 </body>
 </html>`;
   };
@@ -389,13 +349,13 @@ export function ExportModal({
   const generatePlaybookGridHTML = (plays: PlayData[]): string => {
     const playItems = plays.map(play => `
       <div class="grid-item">
-        <div class="grid-play-name">${playTitleHTML(play.metadata.playName || 'Untitled', '11pt')}</div>
+        <div class="grid-play-name">${playTitleHTML(play.metadata.playName || UNTITLED_PLAY, '11pt')}</div>
         <div class="grid-play-image">
-          <img src="${play.canvasDataURL}" alt="${play.metadata.playName}" />
+          <img src="${play.canvasDataURL}" alt="${escapeHtml(play.metadata.playName || UNTITLED_PLAY)}" />
         </div>
         <div class="grid-play-info">
-          ${play.metadata.formation ? `<div>Formation: ${play.metadata.formation}</div>` : ''}
-          ${play.metadata.playType ? `<div>Type: ${play.metadata.playType}</div>` : ''}
+          ${play.metadata.formation ? `<div>Formation: ${escapeHtml(play.metadata.formation)}</div>` : ''}
+          ${play.metadata.playType ? `<div>Type: ${escapeHtml(formatPlayType(play.metadata.playType))}</div>` : ''}
         </div>
       </div>
     `).join('');
@@ -422,45 +382,45 @@ export function ExportModal({
       font-family: Arial, sans-serif;
       font-size: 9pt;
       line-height: 1.2;
-      color: #000;
+      color: ${EXPORT_INK};
       background: white;
     }
-    
+
     .playbook-header {
       text-align: center;
       margin-bottom: 25px;
       padding-bottom: 15px;
-      border-bottom: 3px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
-    
+
     .playbook-title {
       font-size: 20pt;
       font-weight: bold;
-      color: #1e40af;
+      color: ${EXPORT_INK};
       margin-bottom: 5px;
     }
-    
+
     .playbook-subtitle {
       font-size: 11pt;
-      color: #64748b;
+      color: #555;
     }
-    
+
     .plays-grid {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       gap: 15px;
       margin-bottom: 20px;
     }
-    
+
     .grid-item {
-      border: 1px solid #d1d5db;
+      border: 1px solid #ccc;
       border-radius: 6px;
       padding: 10px;
-      background: #fafafa;
+      background: ${EXPORT_WASH};
       text-align: center;
       page-break-inside: avoid;
     }
-    
+
     .grid-play-name {
       margin-bottom: 8px;
       min-height: 30px;
@@ -468,11 +428,11 @@ export function ExportModal({
       align-items: center;
       justify-content: center;
     }
-    
+
     .grid-play-image {
       margin-bottom: 8px;
       background: white;
-      border: 1px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 4px;
       padding: 5px;
       height: 120px;
@@ -480,24 +440,24 @@ export function ExportModal({
       align-items: center;
       justify-content: center;
     }
-    
+
     .grid-play-image img {
       max-width: 100%;
       max-height: 100%;
       height: auto;
       width: auto;
     }
-    
+
     .grid-play-info {
       font-size: 8pt;
-      color: #6b7280;
+      color: #555;
       line-height: 1.3;
     }
-    
+
     .grid-play-info div {
       margin-bottom: 2px;
     }
-    
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
       .grid-item { page-break-inside: avoid; }
@@ -510,314 +470,25 @@ export function ExportModal({
     <div class="playbook-title">${preferences?.team_name ? `${escapeHtml(preferences.team_name)} Playbook` : 'Football Playbook'}</div>
     <div class="playbook-subtitle">Quick Reference Grid</div>
   </div>
-  
+
   <div class="plays-grid">
     ${playItems}
   </div>
-  
-  <div style="margin-top: 20px; text-align: center; font-size: 8pt; color: #6b7280; border-top: 1px solid #e5e7eb; padding-top: 10px;">
-    Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()} | Total Plays: ${plays.length}
-  </div>
+
+  ${exportFooterHTML(plays.length, '20px')}
 </body>
 </html>`;
   };
 
-  const generateWristbandPlaybookHTML = (plays: PlayData[], textOnly = false): string => {
-    // 4.5in x 2.2in matches the play window on Wristband Interactive Y23-style
-    // QB wristbands, which hold 3 cut inserts arranged as a 4x2 grid of
-    // numbered plays (8 per insert) — same layout as the printed inserts
-    // that ship with those wristbands.
-    const PLAYS_PER_INSERT = 8;
-    const INSERTS_PER_BAND = 3;
-
-    // Text-only mode is a fixed 4-column x 10-row template (columns 1-2 are
-    // one #+name pair, columns 3-4 are the next 10 plays' #+name pair,
-    // continuing the numbering) — always this exact shape regardless of how
-    // many plays are populated, like a blank grid you fill in, not a list
-    // that shrinks to fit. Confirmed against a photo of a real text-only
-    // wristband insert, then refined to this precise spec.
-    const ROWS_PER_INSERT_TEXT = 10;
-    const PLAYS_PER_INSERT_TEXT = ROWS_PER_INSERT_TEXT * 2; // 20
-    const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
-
-    const insertGroups: PlayData[][] = [];
-    for (let i = 0; i < plays.length; i += perInsert) {
-      insertGroups.push(plays.slice(i, i + perInsert));
-    }
-
-    const inserts = insertGroups.map((group, groupIndex) => {
-      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
-      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
-      const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
-
-      if (textOnly) {
-        // Always exactly ROWS_PER_INSERT_TEXT rows — blank cells (no number,
-        // no name) when this insert has fewer than a full 20 plays, so the
-        // template's shape never changes.
-        const cell = (play: PlayData | undefined, num: number | '') => `
-            <td class="wb-num">${num}</td><td class="wb-play-name">${play ? (play.metadata.playName || 'Untitled') : ''}</td>`;
-        const rowsHtml = Array.from({ length: ROWS_PER_INSERT_TEXT }, (_, r) => {
-          const left = group[r];
-          const right = group[r + ROWS_PER_INSERT_TEXT];
-          const leftNum = left ? groupIndex * perInsert + r + 1 : '';
-          const rightNum = right ? groupIndex * perInsert + r + ROWS_PER_INSERT_TEXT + 1 : '';
-          return `
-            <tr>${cell(left, leftNum)}${cell(right, rightNum)}</tr>`;
-        }).join('');
-
-        return `
-      <div class="wb-insert wb-insert-text">
-        <div class="wb-insert-label">${insertLabel}</div>
-        <table class="wb-text-table">
-          <colgroup>
-            <col class="col-num" /><col class="col-name" /><col class="col-num" /><col class="col-name" />
-          </colgroup>
-          <tbody>${rowsHtml}
-        </tbody></table>
-      </div>`;
-      }
-
-      const cells = group.map((play, i) => {
-        const playNumber = groupIndex * perInsert + i + 1;
-        return `
-        <div class="wb-cell">
-          <div class="wb-cell-header">
-            <div class="wb-number">${playNumber}</div>
-            <div class="wb-name">${play.metadata.playName || 'Untitled'}</div>
-          </div>
-          <div class="wb-thumb"><img src="${play.canvasDataURL}" alt="" /></div>
-        </div>`;
-      }).join('');
-
-      return `
-      <div class="wb-insert">
-        <div class="wb-insert-label">${insertLabel}</div>
-        <div class="wb-cells">${cells}</div>
-      </div>`;
-    }).join('');
-
-    return `
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>Playbook - Wristband Inserts</title>
-  <style>
-    @page {
-      size: ${(preferences?.paper_size ?? 'letter') === 'a4' ? 'A4 landscape' : '11in 8.5in'};
-      margin: 0.4in;
-    }
-
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: Arial, sans-serif;
-      color: #000;
-      background: white;
-    }
-
-    .playbook-header {
-      text-align: center;
-      margin-bottom: 0.15in;
-      padding-bottom: 0.1in;
-      border-bottom: 3px solid #2563eb;
-    }
-
-    .playbook-title {
-      font-size: 16pt;
-      font-weight: bold;
-      color: #1e40af;
-      margin-bottom: 2px;
-    }
-
-    .playbook-subtitle {
-      font-size: 9pt;
-      color: #64748b;
-    }
-
-    .wb-compat {
-      font-size: 6.5pt;
-      color: #9ca3af;
-      margin-top: 2px;
-    }
-
-    .wb-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 4.5in);
-      gap: 0.2in;
-      justify-content: center;
-    }
-
-    .wb-insert {
-      width: 4.5in;
-      height: 2.2in;
-      border: 1px dashed #9ca3af;
-      border-radius: 4px;
-      padding: 0.06in 0.1in;
-      background: #fafafa;
-      page-break-inside: avoid;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .wb-insert-label {
-      font-size: 6.5pt;
-      color: #6b7280;
-      text-align: center;
-      margin-bottom: 0.03in;
-      flex-shrink: 0;
-    }
-
-    .wb-cells {
-      flex: 1;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-template-rows: repeat(2, 1fr);
-      gap: 0.04in;
-      min-height: 0;
-    }
-
-    .wb-cell {
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-      min-width: 0;
-      border: 1px solid #e5e7eb;
-      border-radius: 2px;
-      overflow: hidden;
-      background: white;
-    }
-
-    .wb-cell-header {
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      gap: 2px;
-      padding: 1px 2px;
-      background: #eef2ff;
-      min-width: 0;
-    }
-
-    .wb-number {
-      flex-shrink: 0;
-      width: 0.15in;
-      height: 0.15in;
-      border-radius: 50%;
-      background: #1e40af;
-      color: white;
-      font-weight: bold;
-      font-size: 5.5pt;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .wb-name {
-      flex: 1;
-      min-width: 0;
-      font-weight: bold;
-      color: #1e40af;
-      font-size: 5.5pt;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .wb-thumb {
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: white;
-      overflow: hidden;
-    }
-
-    .wb-thumb img {
-      max-width: 100%;
-      max-height: 100%;
-    }
-
-    /* Fixed 4-column x 10-row grid, styled like an Excel table — full cell
-       borders on every row including blank ones, so the template's shape
-       reads the same whether it's fully populated or mostly empty. */
-    .wb-text-table {
-      flex: 1;
-      width: 100%;
-      height: 100%;
-      border-collapse: collapse;
-      table-layout: fixed;
-    }
-
-    .wb-text-table tr {
-      height: 10%; /* 10 fixed rows, evenly filling the insert */
-    }
-
-    .wb-text-table td {
-      border: 1px solid #9ca3af;
-      padding: 0.01in 0.03in;
-      font-size: 8pt;
-      line-height: 1.3;
-    }
-
-    /* Column widths are set here, on <colgroup>'s <col> elements — the
-       authoritative, unambiguous way to size a table-layout:fixed table.
-       Setting width on the repeated .wb-num/.wb-play-name TD classes was
-       unreliable (the name column rendered far too narrow and truncated
-       aggressively — reported with a screenshot), since table-layout:fixed
-       only reads the first row's cells to fix column widths, easy to get
-       inconsistent results from cell-level CSS across 4 repeating columns. */
-    .col-num {
-      width: 10%;
-    }
-
-    .col-name {
-      width: 40%;
-    }
-
-    .wb-num {
-      font-weight: bold;
-      color: #1e40af;
-      text-align: right;
-    }
-
-    .wb-play-name {
-      text-align: left;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 0; /* forces overflow/ellipsis to respect the table column width */
-    }
-
-    @media print {
-      body { -webkit-print-color-adjust: exact !important; }
-      .wb-insert { page-break-inside: avoid; }
-    }
-  </style>
-</head>
-<body>
-  <div class="playbook-header">
-    ${teamBrandHTML(preferences)}
-    <div class="playbook-title">${preferences?.team_name ? `${escapeHtml(preferences.team_name)} Playbook` : 'Football Playbook'}</div>
-    <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along dashed lines</div>
-    <div class="wb-compat">Compatible with ${WRISTBAND_PRODUCT_NAME} (${WRISTBAND_PRODUCT_URL}) and any wristband with a ${WRISTBAND_WINDOW_SIZE} play window.${SHOW_AFFILIATE_DISCLOSURE ? ' As an Amazon Associate we earn from qualifying purchases.' : ''}</div>
-  </div>
-
-  <div class="wb-grid">
-    ${inserts}
-  </div>
-
-  <div style="margin-top: 0.15in; text-align: center; font-size: 8pt; color: #6b7280; border-top: 1px solid #e5e7eb; padding-top: 0.08in;">
-    Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()} | Total Plays: ${plays.length}
-  </div>
-</body>
-</html>`;
-  };
+  const generateWristbandPlaybookHTML = (plays: PlayData[], textOnly = false): string =>
+    generateWristbandHTML({
+      plays,
+      getName: (play) => play.metadata.playName,
+      getImage: (play) => play.canvasDataURL,
+      title: preferences?.team_name ? `${preferences.team_name} Playbook` : 'Football Playbook',
+      textOnly,
+      preferences,
+    });
 
   const handleFormatClick = (formatId: string) => {
     if (PRO_ONLY_FORMATS.has(formatId) && !entitlementLoading && !isPro) {

--- a/src/components/playbooks/PlaybooksPage.tsx
+++ b/src/components/playbooks/PlaybooksPage.tsx
@@ -30,10 +30,14 @@ import { FREE_LIMITS, isNearFreeLimit, rowIsPro } from '../../lib/entitlements';
 import { UpgradePrompt } from '../UpgradePrompt';
 import { UsageWarningBanner } from '../UsageWarningBanner';
 import { PlayCard } from '../plays/PlayCard';
-import { getUserPreferences, paperPageSize, teamBrandHTML, playTitleHTML, type UserPreferences } from '../../lib/userPreferences';
+import { getUserPreferences, escapeHtml, paperPageSize, teamBrandHTML, playTitleHTML, type UserPreferences } from '../../lib/userPreferences';
+import {
+  EXPORT_ACCENT_RULE, EXPORT_INK, EXPORT_HAIRLINE, EXPORT_WASH, UNTITLED_PLAY,
+  formatPlayType, exportFooterHTML, NOTES_BLOCK_CSS, notesBlockHTML, generateWristbandHTML,
+} from '../../lib/exportStyles';
 import { usePageMeta } from '../../lib/seo';
 import { PlaybookPackLibrary } from './PlaybookPackLibrary';
-import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
+import { WRISTBAND_PRODUCT_NAME, WRISTBAND_WINDOW_SIZE, wristbandProductLink, SHOW_AFFILIATE_DISCLOSURE } from '../../lib/wristbandProducts';
 
 interface Playbook {
   id: string;
@@ -396,25 +400,27 @@ export function PlaybooksPage() {
 <html>
 <head>
   <meta charset="utf-8">
-  <title>${play.name}</title>
+  <title>${escapeHtml(play.name || UNTITLED_PLAY)}</title>
   <style>
     @page {
       size: ${paperPageSize(prefs?.paper_size ?? 'letter')};
       margin: 0.75in;
     }
-    
+
     * {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
     }
-    
+
     body {
       font-family: Arial, sans-serif;
+      font-size: 12pt;
+      line-height: 1.4;
       background: white;
-      color: #000;
+      color: ${EXPORT_INK};
     }
-    
+
     .page {
       width: 100%;
       min-height: 9.5in;
@@ -424,7 +430,7 @@ export function PlaybooksPage() {
       justify-content: center;
       text-align: center;
     }
-    
+
     .play-title {
       margin-bottom: 40px;
     }
@@ -436,16 +442,15 @@ export function PlaybooksPage() {
       justify-content: center;
       margin: 20px 0;
     }
-    
+
     .diagram-image {
       max-width: 100%;
       max-height: 600px;
       height: auto;
-      border: 2px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 8px;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.1);
     }
-    
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
     }
@@ -454,11 +459,11 @@ export function PlaybooksPage() {
 <body>
   <div class="page">
     ${teamBrandHTML(prefs)}
-    <div class="play-title">${playTitleHTML(play.name, '32pt')}</div>
+    <div class="play-title">${playTitleHTML(play.name || UNTITLED_PLAY, '28pt')}</div>
     <div class="diagram-container">
-      ${play.thumbnail ? 
-        `<img src="${play.thumbnail}" alt="${play.name}" class="diagram-image" />` :
-        `<div style="width: 400px; height: 300px; border: 2px dashed #ccc; display: flex; align-items: center; justify-content: center; color: #666;">No diagram available</div>`
+      ${play.thumbnail ?
+        `<img src="${play.thumbnail}" alt="${escapeHtml(play.name || UNTITLED_PLAY)}" class="diagram-image" />` :
+        `<div style="width: 400px; height: 300px; border: 1px dashed #999; display: flex; align-items: center; justify-content: center; color: #666;">No diagram available</div>`
       }
     </div>
   </div>
@@ -472,118 +477,92 @@ export function PlaybooksPage() {
 <html>
 <head>
   <meta charset="utf-8">
-  <title>${play.name}</title>
+  <title>${escapeHtml(play.name || UNTITLED_PLAY)}</title>
   <style>
     @page {
       size: ${paperPageSize(prefs?.paper_size ?? 'letter')};
       margin: 0.75in;
     }
-    
+
     * {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
     }
-    
+
     body {
       font-family: Arial, sans-serif;
       font-size: 12pt;
       line-height: 1.4;
-      color: #000;
+      color: ${EXPORT_INK};
       background: white;
     }
-    
+
     .page {
       width: 100%;
       min-height: 9.5in;
     }
-    
+
     .header {
       text-align: center;
       margin-bottom: 30px;
       padding-bottom: 20px;
-      border-bottom: 3px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
-    
+
     .play-title {
       margin-bottom: 10px;
     }
 
-    .play-type {
-      font-size: 14pt;
-      color: #64748b;
-      text-transform: capitalize;
-    }
-    
     .content {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 30px;
       margin-bottom: 30px;
     }
-    
+
     .diagram-section {
       text-align: center;
     }
-    
+
     .diagram-image {
       max-width: 100%;
       height: auto;
       max-height: 350px;
-      border: 2px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 8px;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.1);
     }
-    
+
     .metadata-section {
       padding: 20px;
-      background: #f8fafc;
+      background: ${EXPORT_WASH};
       border-radius: 8px;
-      border: 1px solid #e2e8f0;
+      border: 1px solid #ccc;
     }
-    
+
     .metadata-title {
       font-size: 16pt;
       font-weight: bold;
-      color: #1e293b;
+      color: ${EXPORT_INK};
       margin-bottom: 15px;
     }
-    
+
     .metadata-item {
       margin-bottom: 12px;
     }
-    
+
     .metadata-label {
       font-weight: bold;
-      color: #475569;
+      color: ${EXPORT_INK};
       display: block;
       margin-bottom: 3px;
     }
-    
+
     .metadata-value {
-      color: #1e293b;
+      color: ${EXPORT_INK};
     }
-    
-    .description-section {
-      margin-top: 30px;
-      padding: 20px;
-      background: #fffbeb;
-      border-left: 4px solid #f59e0b;
-      border-radius: 0 8px 8px 0;
-    }
-    
-    .description-title {
-      font-weight: bold;
-      font-size: 14pt;
-      color: #92400e;
-      margin-bottom: 10px;
-    }
-    
-    .description-text {
-      color: #451a03;
-      line-height: 1.6;
-    }
-    
+    ${NOTES_BLOCK_CSS}
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
     }
@@ -593,76 +572,75 @@ export function PlaybooksPage() {
   <div class="page">
     ${teamBrandHTML(prefs)}
     <div class="header">
-      <div class="play-title">${playTitleHTML(play.name, '28pt')}</div>
-      <div class="play-type">${play.type} Play</div>
+      <div class="play-title">${playTitleHTML(play.name || UNTITLED_PLAY, '28pt')}</div>
     </div>
-    
+
     <div class="content">
       <div class="diagram-section">
-        ${play.thumbnail ? 
-          `<img src="${play.thumbnail}" alt="${play.name}" class="diagram-image" />` :
-          `<div style="width: 100%; height: 300px; border: 2px dashed #ccc; display: flex; align-items: center; justify-content: center; color: #666; background: #f9f9f9;">No diagram available</div>`
+        ${play.thumbnail ?
+          `<img src="${play.thumbnail}" alt="${escapeHtml(play.name || UNTITLED_PLAY)}" class="diagram-image" />` :
+          `<div style="width: 100%; height: 300px; border: 1px dashed #999; display: flex; align-items: center; justify-content: center; color: #666;">No diagram available</div>`
         }
       </div>
-      
+
       <div class="metadata-section">
         <div class="metadata-title">Play Details</div>
-        
+
         ${play.metadata?.formation ? `
           <div class="metadata-item">
             <span class="metadata-label">Formation:</span>
-            <span class="metadata-value">${play.metadata.formation}</span>
+            <span class="metadata-value">${escapeHtml(play.metadata.formation)}</span>
           </div>
         ` : ''}
-        
+
+        <div class="metadata-item">
+          <span class="metadata-label">Type:</span>
+          <span class="metadata-value">${escapeHtml(formatPlayType(play.type))}</span>
+        </div>
+
         ${play.metadata?.situation ? `
           <div class="metadata-item">
             <span class="metadata-label">Situation:</span>
-            <span class="metadata-value">${play.metadata.situation}</span>
+            <span class="metadata-value">${escapeHtml(play.metadata.situation)}</span>
           </div>
         ` : ''}
-        
+
         ${play.metadata?.yardage ? `
           <div class="metadata-item">
             <span class="metadata-label">Expected Yardage:</span>
-            <span class="metadata-value">${play.metadata.yardage}</span>
+            <span class="metadata-value">${escapeHtml(play.metadata.yardage)}</span>
           </div>
         ` : ''}
-        
+
         ${play.metadata?.personnel ? `
           <div class="metadata-item">
             <span class="metadata-label">Personnel:</span>
-            <span class="metadata-value">${play.metadata.personnel}</span>
+            <span class="metadata-value">${escapeHtml(play.metadata.personnel)}</span>
           </div>
         ` : ''}
-        
+
         ${play.metadata?.difficulty ? `
           <div class="metadata-item">
             <span class="metadata-label">Difficulty:</span>
-            <span class="metadata-value">${play.metadata.difficulty}</span>
+            <span class="metadata-value">${escapeHtml(formatPlayType(play.metadata.difficulty))}</span>
           </div>
         ` : ''}
-        
+
         <div class="metadata-item">
           <span class="metadata-label">Created:</span>
           <span class="metadata-value">${new Date(play.created_at).toLocaleDateString()}</span>
         </div>
-        
+
         ${play.metadata?.tags && play.metadata.tags.length > 0 ? `
           <div class="metadata-item">
             <span class="metadata-label">Tags:</span>
-            <span class="metadata-value">${play.metadata.tags.join(', ')}</span>
+            <span class="metadata-value">${escapeHtml(play.metadata.tags.join(', '))}</span>
           </div>
         ` : ''}
       </div>
     </div>
-    
-    ${play.description || play.metadata?.description ? `
-      <div class="description-section">
-        <div class="description-title">Description & Notes</div>
-        <div class="description-text">${(play.description || play.metadata?.description || '').replace(/\n/g, '<br>')}</div>
-      </div>
-    ` : ''}
+
+    ${notesBlockHTML(play.description || play.metadata?.description)}
   </div>
 </body>
 </html>`;
@@ -671,16 +649,16 @@ export function PlaybooksPage() {
   const generateGridPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string): string => {
     const playItems = plays.map(play => `
       <div class="grid-item">
-        <div class="grid-play-name">${playTitleHTML(play.name, '11pt')}</div>
+        <div class="grid-play-name">${playTitleHTML(play.name || UNTITLED_PLAY, '11pt')}</div>
         <div class="grid-play-image">
-          ${play.thumbnail ? 
-            `<img src="${play.thumbnail}" alt="${play.name}" />` :
+          ${play.thumbnail ?
+            `<img src="${play.thumbnail}" alt="${escapeHtml(play.name || UNTITLED_PLAY)}" />` :
             `<div class="no-image">No Image</div>`
           }
         </div>
         <div class="grid-play-info">
-          <div class="play-type">${play.type}</div>
-          ${play.metadata?.formation ? `<div>Formation: ${play.metadata.formation}</div>` : ''}
+          <div class="play-type">${escapeHtml(formatPlayType(play.type))}</div>
+          ${play.metadata?.formation ? `<div>Formation: ${escapeHtml(play.metadata.formation)}</div>` : ''}
         </div>
       </div>
     `).join('');
@@ -690,62 +668,62 @@ export function PlaybooksPage() {
 <html>
 <head>
   <meta charset="utf-8">
-  <title>${playbookName} - Grid View</title>
+  <title>${escapeHtml(playbookName)} - Grid View</title>
   <style>
     @page {
       size: ${paperPageSize(prefs?.paper_size ?? 'letter')};
       margin: 0.5in;
     }
-    
+
     * {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
     }
-    
+
     body {
       font-family: Arial, sans-serif;
       font-size: 9pt;
       line-height: 1.2;
-      color: #000;
+      color: ${EXPORT_INK};
       background: white;
     }
-    
+
     .header {
       text-align: center;
       margin-bottom: 25px;
       padding-bottom: 15px;
-      border-bottom: 3px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
-    
+
     .playbook-title {
       font-size: 24pt;
       font-weight: bold;
-      color: #1e40af;
+      color: ${EXPORT_INK};
       margin-bottom: 5px;
     }
-    
+
     .playbook-subtitle {
       font-size: 12pt;
-      color: #64748b;
+      color: #555;
     }
-    
+
     .plays-grid {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       gap: 15px;
       margin-bottom: 20px;
     }
-    
+
     .grid-item {
-      border: 1px solid #d1d5db;
+      border: 1px solid #ccc;
       border-radius: 6px;
       padding: 10px;
-      background: #fafafa;
+      background: ${EXPORT_WASH};
       text-align: center;
       page-break-inside: avoid;
     }
-    
+
     .grid-play-name {
       margin-bottom: 8px;
       min-height: 30px;
@@ -757,7 +735,7 @@ export function PlaybooksPage() {
     .grid-play-image {
       margin-bottom: 8px;
       background: white;
-      border: 1px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 4px;
       padding: 5px;
       height: 120px;
@@ -765,43 +743,33 @@ export function PlaybooksPage() {
       align-items: center;
       justify-content: center;
     }
-    
+
     .grid-play-image img {
       max-width: 100%;
       max-height: 100%;
       height: auto;
       width: auto;
     }
-    
+
     .no-image {
-      color: #9ca3af;
+      color: #999;
       font-size: 8pt;
     }
-    
+
     .grid-play-info {
       font-size: 8pt;
-      color: #6b7280;
+      color: #555;
       line-height: 1.3;
     }
-    
+
     .grid-play-info div {
       margin-bottom: 2px;
     }
-    
+
     .play-type {
-      text-transform: capitalize;
       font-weight: 500;
     }
-    
-    .footer {
-      margin-top: 20px;
-      text-align: center;
-      font-size: 8pt;
-      color: #6b7280;
-      border-top: 1px solid #e5e7eb;
-      padding-top: 10px;
-    }
-    
+
     @media print {
       body { -webkit-print-color-adjust: exact !important; }
       .grid-item { page-break-inside: avoid; }
@@ -811,336 +779,28 @@ export function PlaybooksPage() {
 <body>
   <div class="header">
     ${teamBrandHTML(prefs)}
-    <div class="playbook-title">${playbookName}</div>
+    <div class="playbook-title">${escapeHtml(playbookName)}</div>
     <div class="playbook-subtitle">Complete Playbook Grid</div>
   </div>
-  
+
   <div class="plays-grid">
     ${playItems}
   </div>
-  
-  <div class="footer">
-    Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()} | Total Plays: ${plays.length}
-  </div>
+
+  ${exportFooterHTML(plays.length, '20px')}
 </body>
 </html>`;
   };
 
-  const generateWristbandPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string, textOnly = false): string => {
-    // 4.5in x 2.2in matches the play window on Wristband Interactive Y23-style
-    // QB wristbands, which hold 3 cut inserts arranged as a 4x2 grid of
-    // numbered plays (8 per insert) — same layout as the printed inserts
-    // that ship with those wristbands.
-    const PLAYS_PER_INSERT = 8;
-    const INSERTS_PER_BAND = 3;
-
-    // Text-only mode is a fixed 4-column x 10-row template (columns 1-2 are
-    // one #+name pair, columns 3-4 are the next 10 plays' #+name pair,
-    // continuing the numbering) — always this exact shape regardless of how
-    // many plays are populated, like a blank grid you fill in, not a list
-    // that shrinks to fit. Confirmed against a photo of a real text-only
-    // wristband insert, then refined to this precise spec.
-    const ROWS_PER_INSERT_TEXT = 10;
-    const PLAYS_PER_INSERT_TEXT = ROWS_PER_INSERT_TEXT * 2; // 20
-    const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
-
-    const insertGroups: PlayInPlaybook[][] = [];
-    for (let i = 0; i < plays.length; i += perInsert) {
-      insertGroups.push(plays.slice(i, i + perInsert));
-    }
-
-    const inserts = insertGroups.map((group, groupIndex) => {
-      const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
-      const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
-      const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
-
-      if (textOnly) {
-        // Always exactly ROWS_PER_INSERT_TEXT rows — blank cells (no number,
-        // no name) when this insert has fewer than a full 20 plays, so the
-        // template's shape never changes.
-        const cell = (play: PlayInPlaybook | undefined, num: number | '') => `
-            <td class="wb-num">${num}</td><td class="wb-play-name">${play ? play.name : ''}</td>`;
-        const rowsHtml = Array.from({ length: ROWS_PER_INSERT_TEXT }, (_, r) => {
-          const left = group[r];
-          const right = group[r + ROWS_PER_INSERT_TEXT];
-          const leftNum = left ? groupIndex * perInsert + r + 1 : '';
-          const rightNum = right ? groupIndex * perInsert + r + ROWS_PER_INSERT_TEXT + 1 : '';
-          return `
-            <tr>${cell(left, leftNum)}${cell(right, rightNum)}</tr>`;
-        }).join('');
-
-        return `
-      <div class="wb-insert wb-insert-text">
-        <div class="wb-insert-label">${insertLabel}</div>
-        <table class="wb-text-table">
-          <colgroup>
-            <col class="col-num" /><col class="col-name" /><col class="col-num" /><col class="col-name" />
-          </colgroup>
-          <tbody>${rowsHtml}
-        </tbody></table>
-      </div>`;
-      }
-
-      const cells = group.map((play, i) => {
-        const playNumber = groupIndex * perInsert + i + 1;
-        return `
-        <div class="wb-cell">
-          <div class="wb-cell-header">
-            <div class="wb-number">${playNumber}</div>
-            <div class="wb-name">${play.name}</div>
-          </div>
-          <div class="wb-thumb">
-            ${play.thumbnail ?
-              `<img src="${play.thumbnail}" alt="" />` :
-              `<div class="no-image">&mdash;</div>`
-            }
-          </div>
-        </div>`;
-      }).join('');
-
-      return `
-      <div class="wb-insert">
-        <div class="wb-insert-label">${insertLabel}</div>
-        <div class="wb-cells">${cells}</div>
-      </div>`;
-    }).join('');
-
-    return `
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>${playbookName} - Wristband Inserts</title>
-  <style>
-    @page {
-      size: ${(prefs?.paper_size ?? 'letter') === 'a4' ? 'A4 landscape' : '11in 8.5in'};
-      margin: 0.4in;
-    }
-
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: Arial, sans-serif;
-      color: #000;
-      background: white;
-    }
-
-    .header {
-      text-align: center;
-      margin-bottom: 0.15in;
-      padding-bottom: 0.1in;
-      border-bottom: 3px solid #2563eb;
-    }
-
-    .playbook-title {
-      font-size: 16pt;
-      font-weight: bold;
-      color: #1e40af;
-      margin-bottom: 2px;
-    }
-
-    .playbook-subtitle {
-      font-size: 9pt;
-      color: #64748b;
-    }
-
-    .wb-compat {
-      font-size: 6.5pt;
-      color: #9ca3af;
-      margin-top: 2px;
-    }
-
-    .wb-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 4.5in);
-      gap: 0.2in;
-      justify-content: center;
-    }
-
-    .wb-insert {
-      width: 4.5in;
-      height: 2.2in;
-      border: 1px dashed #9ca3af;
-      border-radius: 4px;
-      padding: 0.06in 0.1in;
-      background: #fafafa;
-      page-break-inside: avoid;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .wb-insert-label {
-      font-size: 6.5pt;
-      color: #6b7280;
-      text-align: center;
-      margin-bottom: 0.03in;
-      flex-shrink: 0;
-    }
-
-    .wb-cells {
-      flex: 1;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-template-rows: repeat(2, 1fr);
-      gap: 0.04in;
-      min-height: 0;
-    }
-
-    .wb-cell {
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-      min-width: 0;
-      border: 1px solid #e5e7eb;
-      border-radius: 2px;
-      overflow: hidden;
-      background: white;
-    }
-
-    .wb-cell-header {
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      gap: 2px;
-      padding: 1px 2px;
-      background: #eef2ff;
-      min-width: 0;
-    }
-
-    .wb-number {
-      flex-shrink: 0;
-      width: 0.15in;
-      height: 0.15in;
-      border-radius: 50%;
-      background: #1e40af;
-      color: white;
-      font-weight: bold;
-      font-size: 5.5pt;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .wb-name {
-      flex: 1;
-      min-width: 0;
-      font-weight: bold;
-      color: #1e40af;
-      font-size: 5.5pt;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .wb-thumb {
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: white;
-      overflow: hidden;
-    }
-
-    .wb-thumb img {
-      max-width: 100%;
-      max-height: 100%;
-    }
-
-    .no-image {
-      color: #9ca3af;
-      font-size: 7pt;
-    }
-
-    /* Fixed 4-column x 10-row grid, styled like an Excel table — full cell
-       borders on every row including blank ones, so the template's shape
-       reads the same whether it's fully populated or mostly empty. */
-    .wb-text-table {
-      flex: 1;
-      width: 100%;
-      height: 100%;
-      border-collapse: collapse;
-      table-layout: fixed;
-    }
-
-    .wb-text-table tr {
-      height: 10%; /* 10 fixed rows, evenly filling the insert */
-    }
-
-    .wb-text-table td {
-      border: 1px solid #9ca3af;
-      padding: 0.01in 0.03in;
-      font-size: 8pt;
-      line-height: 1.3;
-    }
-
-    /* Column widths are set here, on <colgroup>'s <col> elements — the
-       authoritative, unambiguous way to size a table-layout:fixed table.
-       Setting width on the repeated .wb-num/.wb-play-name TD classes was
-       unreliable (the name column rendered far too narrow and truncated
-       aggressively — reported with a screenshot), since table-layout:fixed
-       only reads the first row's cells to fix column widths, easy to get
-       inconsistent results from cell-level CSS across 4 repeating columns. */
-    .col-num {
-      width: 10%;
-    }
-
-    .col-name {
-      width: 40%;
-    }
-
-    .wb-num {
-      font-weight: bold;
-      color: #1e40af;
-      text-align: right;
-    }
-
-    .wb-play-name {
-      text-align: left;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 0; /* forces overflow/ellipsis to respect the table column width */
-    }
-
-    .footer {
-      margin-top: 0.15in;
-      text-align: center;
-      font-size: 8pt;
-      color: #6b7280;
-      border-top: 1px solid #e5e7eb;
-      padding-top: 0.08in;
-    }
-
-    @media print {
-      body { -webkit-print-color-adjust: exact !important; }
-      .wb-insert { page-break-inside: avoid; }
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    ${teamBrandHTML(prefs)}
-    <div class="playbook-title">${playbookName}</div>
-    <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along dashed lines</div>
-    <div class="wb-compat">Compatible with ${WRISTBAND_PRODUCT_NAME} (${WRISTBAND_PRODUCT_URL}) and any wristband with a ${WRISTBAND_WINDOW_SIZE} play window.${SHOW_AFFILIATE_DISCLOSURE ? ' As an Amazon Associate we earn from qualifying purchases.' : ''}</div>
-  </div>
-
-  <div class="wb-grid">
-    ${inserts}
-  </div>
-
-  <div class="footer">
-    Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()} | Total Plays: ${plays.length}
-  </div>
-</body>
-</html>`;
-  };
+  const generateWristbandPlaybookHTML = (plays: PlayInPlaybook[], playbookName: string, textOnly = false): string =>
+    generateWristbandHTML({
+      plays,
+      getName: (play) => play.name,
+      getImage: (play) => play.thumbnail,
+      title: playbookName,
+      textOnly,
+      preferences: prefs,
+    });
 
   const handleExportPDF = async (format: 'simple' | 'detailed' | 'grid' | 'wristband', wristbandTextOnly = false) => {
     if (!selectedPlaybook || playsInPlaybook.length === 0) {
@@ -1163,22 +823,28 @@ export function PlaybooksPage() {
         htmlContent = generateGridPlaybookHTML(playsInPlaybook, selectedPlaybook.name);
       } else {
         // For simple and detailed, create multiple pages
-        const pageContents = playsInPlaybook.map(play => 
+        const pageContents = playsInPlaybook.map(play =>
           format === 'simple' ? generateSimplePlayHTML(play) : generateDetailedPlayHTML(play)
         );
-        
-        // Combine all pages into one document
+
+        // Combine all pages into one document. Every page came from the same
+        // generator, so its <style> block is identical across all of them —
+        // lift the FIRST page's style into the wrapper's <head> rather than
+        // discarding it. This used to extract only each page's <body> and
+        // drop every <style> tag entirely, so multi-play Simple/Detailed
+        // exports printed with no styling at all: no header rule, no notes
+        // box, no metadata panel — just inline-styled fragments (team brand,
+        // title) survived, because those two are the only bits styled with
+        // `style=""` instead of a class.
+        const sharedStyle = pageContents[0]?.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
         htmlContent = `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>${selectedPlaybook.name}</title>
+  <title>${escapeHtml(selectedPlaybook.name)}</title>
   <style>
-    @page {
-      size: ${paperPageSize(prefs?.paper_size ?? 'letter')};
-      margin: 0.75in;
-    }
+    ${sharedStyle}
     .page-break {
       page-break-before: always;
     }

--- a/src/components/vs/VsExportModal.tsx
+++ b/src/components/vs/VsExportModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { X, Download, Printer, Layers } from 'lucide-react';
 import { renderOverlayScene, EXPORT_WIDTH, EXPORT_HEIGHT, type SceneLayer } from '../../lib/renderPlayScene';
 import { paperPageSize, escapeHtml } from '../../lib/userPreferences';
+import { EXPORT_ACCENT_RULE, EXPORT_INK, EXPORT_HAIRLINE } from '../../lib/exportStyles';
 
 // ---------------------------------------------
 // Export options for the read-only "vs. defense" view (B-36 follow-up #1):
@@ -71,7 +72,7 @@ function buildPrintHTML(pagesHTML: string, docTitle: string): string {
   <style>
     @page { size: ${paperPageSize('letter')}; margin: 0.5in; }
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: Arial, sans-serif; color: #000; background: white; }
+    body { font-family: Arial, sans-serif; color: ${EXPORT_INK}; background: white; }
     .matchup-page {
       min-height: 9.5in;
       display: flex;
@@ -84,21 +85,21 @@ function buildPrintHTML(pagesHTML: string, docTitle: string): string {
       text-align: center;
       margin-bottom: 20px;
       padding-bottom: 12px;
-      border-bottom: 2px solid #2563eb;
+      border-bottom: ${EXPORT_ACCENT_RULE};
     }
     .matchup-title {
       font-size: 22pt;
       font-weight: bold;
-      color: #1e40af;
+      color: ${EXPORT_INK};
       text-transform: uppercase;
       letter-spacing: 1px;
     }
-    .matchup-subtitle { font-size: 13pt; color: #64748b; margin-top: 4px; }
+    .matchup-subtitle { font-size: 13pt; color: #555; margin-top: 4px; }
     .matchup-image { flex: 1; display: flex; align-items: center; justify-content: center; }
     .matchup-image img {
       max-width: 100%;
       max-height: 100%;
-      border: 2px solid #e5e7eb;
+      border: 1px solid ${EXPORT_HAIRLINE};
       border-radius: 8px;
     }
     @media print {

--- a/src/lib/exportStyles.ts
+++ b/src/lib/exportStyles.ts
@@ -426,7 +426,7 @@ export function generateWristbandHTML<T>(opts: {
   <div class="playbook-header">
     ${teamBrandHTML(preferences)}
     <div class="playbook-title">${escapeHtml(title)}</div>
-    <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along dashed lines</div>
+    <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along ${textOnly ? 'the outer border' : 'dashed lines'}</div>
   </div>
 
   <div class="wb-grid">

--- a/src/lib/exportStyles.ts
+++ b/src/lib/exportStyles.ts
@@ -1,5 +1,4 @@
 import { escapeHtml, teamBrandHTML, type UserPreferences } from './userPreferences';
-import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, SHOW_AFFILIATE_DISCLOSURE } from './wristbandProducts';
 
 /**
  * Shared print-export design tokens — a classic black & white coach-sheet
@@ -236,12 +235,6 @@ export function generateWristbandHTML<T>(opts: {
       color: ${EXPORT_MUTED};
     }
 
-    .wb-compat {
-      font-size: 6.5pt;
-      color: #888;
-      margin-top: 2px;
-    }
-
     .wb-grid {
       display: grid;
       grid-template-columns: repeat(2, 4.5in);
@@ -434,7 +427,6 @@ export function generateWristbandHTML<T>(opts: {
     ${teamBrandHTML(preferences)}
     <div class="playbook-title">${escapeHtml(title)}</div>
     <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along dashed lines</div>
-    <div class="wb-compat">Compatible with ${WRISTBAND_PRODUCT_NAME} (${WRISTBAND_PRODUCT_URL}) and any wristband with a ${WRISTBAND_WINDOW_SIZE} play window.${SHOW_AFFILIATE_DISCLOSURE ? ' As an Amazon Associate we earn from qualifying purchases.' : ''}</div>
   </div>
 
   <div class="wb-grid">

--- a/src/lib/exportStyles.ts
+++ b/src/lib/exportStyles.ts
@@ -1,0 +1,447 @@
+import { escapeHtml, teamBrandHTML, type UserPreferences } from './userPreferences';
+import { WRISTBAND_PRODUCT_NAME, WRISTBAND_PRODUCT_URL, WRISTBAND_WINDOW_SIZE, SHOW_AFFILIATE_DISCLOSURE } from './wristbandProducts';
+
+/**
+ * Shared print-export design tokens — a classic black & white coach-sheet
+ * look, replacing the ad-hoc blue theme (#2563eb/#1e40af) that had drifted
+ * to a different shade in nearly every generator. Diagrams keep their own
+ * colors; this only governs chrome: rules, titles, footers, notes boxes.
+ * Every print/export HTML document in the app should import from here
+ * rather than hand-rolling its own values, or the next format added will
+ * drift again exactly like the last several did.
+ */
+export const EXPORT_INK = '#000';
+export const EXPORT_MUTED = '#555';
+export const EXPORT_HAIRLINE = '#999';
+/** Notes/metadata box background — replaces #f8fafc, #fafafa, #fffbeb. */
+export const EXPORT_WASH = '#f2f2f2';
+export const EXPORT_ACCENT_RULE = `3px solid ${EXPORT_INK}`;
+
+export const UNTITLED_PLAY = 'Untitled Play';
+
+/** 'offense' | 'defense' | 'special_teams' -> 'Offense' | 'Defense' |
+ *  'Special Teams'. The card UI already strips the underscore
+ *  (PlaybooksPage's `{play.type.replace('_', ' ')}`); no export generator
+ *  did, so "Special Teams" printed as "Special_teams" everywhere it appeared
+ *  in exported HTML. */
+export function formatPlayType(type: string | undefined | null): string {
+  if (!type) return '';
+  return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Escape, then turn newlines into <br>. The one notes/description pipeline
+ *  for every export — previously every generator but one interpolated the
+ *  coach's own text raw (no escaping, no line breaks), so multi-line notes
+ *  printed as a single collapsed line. */
+export function formatNotesHTML(text: string | undefined | null): string {
+  if (!text) return '';
+  return escapeHtml(text).replace(/\n/g, '<br>');
+}
+
+/** "Generated on <date> at <time> | Total Plays: N" — previously three
+ *  independent inline-styled copies plus two generators with no footer at
+ *  all. Does not include the free-plan "Made with playbuilderpro.com"
+ *  credit; that one stays specific to the single-play sheet (it's the
+ *  format's Pro/free distinction, not chrome to unify away). */
+export function exportFooterHTML(totalPlays: number, marginTop = '20px'): string {
+  const now = new Date();
+  return `<div style="margin-top: ${marginTop}; text-align: center; font-size: 8pt; color: ${EXPORT_MUTED}; border-top: 1px solid ${EXPORT_HAIRLINE}; padding-top: 10px;">Generated on ${now.toLocaleDateString()} at ${now.toLocaleTimeString()} | Total Plays: ${totalPlays}</div>`;
+}
+
+/** One notes/description block shared by every format that has one (single
+ *  play, detailed playbook — both surfaces). Previously each had its own
+ *  bespoke styling: slate box, white card, and — the one place that even
+ *  converted newlines — an amber box unlike anything else in the app. Emit
+ *  this CSS once into a document's <style>, then call notesBlockHTML() for
+ *  the markup. */
+export const NOTES_BLOCK_CSS = `
+    .pb-notes {
+      margin-top: 20px;
+      padding: 15px;
+      background: white;
+      border: 1px solid ${EXPORT_HAIRLINE};
+      border-radius: 4px;
+    }
+    .pb-notes-title {
+      font-weight: bold;
+      font-size: 13pt;
+      color: ${EXPORT_INK};
+      margin-bottom: 8px;
+    }
+    .pb-notes-body {
+      font-size: 10.5pt;
+      line-height: 1.6;
+      color: ${EXPORT_INK};
+    }`;
+
+export function notesBlockHTML(
+  description: string | undefined | null,
+  extras: Array<{ label: string; value: string | undefined | null }> = [],
+): string {
+  const body = formatNotesHTML(description) || 'No notes provided for this play.';
+  const extrasHtml = extras
+    .filter((e) => e.value)
+    .map((e) => `<br><strong>${escapeHtml(e.label)}:</strong> ${escapeHtml(String(e.value))}`)
+    .join('');
+  return `<div class="pb-notes"><div class="pb-notes-title">Notes</div><div class="pb-notes-body">${body}${extrasHtml}</div></div>`;
+}
+
+type WristbandPrefs = (Pick<UserPreferences, 'team_name' | 'team_logo_url'> & { paper_size?: string }) | null;
+
+/**
+ * Wristband insert sheet — the ONE implementation shared by the Designer
+ * (ExportModal.tsx) and Playbooks (PlaybooksPage.tsx) print surfaces. It
+ * used to be ~300 lines duplicated verbatim in both files (a fix to one,
+ * like the <colgroup> column-width commit, had to be hand-repeated in the
+ * other); `getName`/`getImage` accessors are the only seam left, since the
+ * two callers' play shapes differ (`canvasDataURL` vs `thumbnail`, `metadata
+ * .playName` vs bare `name`).
+ *
+ * Text-only layout matches the reference coach-sheet supplied for this
+ * change: black header bar ("Play #" / "Play"), bold outer border, thin
+ * inner rules, alternating grey/white row shading, bold centered numbers
+ * with a trailing period. Diagram-mode layout is unchanged except recolored
+ * from blue to black.
+ */
+export function generateWristbandHTML<T>(opts: {
+  plays: T[];
+  getName: (play: T) => string;
+  /** '' (or any falsy) renders the no-diagram placeholder — used by
+   *  Playbooks plays that were saved before thumbnails existed. */
+  getImage: (play: T) => string;
+  title: string;
+  textOnly: boolean;
+  preferences: WristbandPrefs;
+}): string {
+  const { plays, getName, getImage, title, textOnly, preferences } = opts;
+
+  // 4.5in x 2.2in matches the play window on Wristband Interactive Y23-style
+  // QB wristbands, which hold 3 cut inserts arranged as a 4x2 grid of
+  // numbered plays (8 per insert) — same layout as the printed inserts that
+  // ship with those wristbands.
+  const PLAYS_PER_INSERT = 8;
+  const INSERTS_PER_BAND = 3;
+
+  // Text-only mode is a fixed 4-column x 10-row template (columns 1-2 are
+  // one #+name pair, columns 3-4 are the next 10 plays' #+name pair,
+  // continuing the numbering) — always this exact shape regardless of how
+  // many plays are populated, like a blank grid you fill in, not a list
+  // that shrinks to fit. Confirmed against a photo of a real text-only
+  // wristband insert, then refined to this precise spec.
+  const ROWS_PER_INSERT_TEXT = 10;
+  const PLAYS_PER_INSERT_TEXT = ROWS_PER_INSERT_TEXT * 2; // 20
+  const perInsert = textOnly ? PLAYS_PER_INSERT_TEXT : PLAYS_PER_INSERT;
+
+  const insertGroups: T[][] = [];
+  for (let i = 0; i < plays.length; i += perInsert) {
+    insertGroups.push(plays.slice(i, i + perInsert));
+  }
+
+  const inserts = insertGroups.map((group, groupIndex) => {
+    const bandNumber = Math.floor(groupIndex / INSERTS_PER_BAND) + 1;
+    const slotNumber = (groupIndex % INSERTS_PER_BAND) + 1;
+    const insertLabel = `Wristband ${bandNumber} &middot; Insert ${slotNumber} of ${INSERTS_PER_BAND}`;
+
+    if (textOnly) {
+      // Always exactly ROWS_PER_INSERT_TEXT rows — blank cells (no number,
+      // no name) when this insert has fewer than a full 20 plays, so the
+      // template's shape never changes. Number renders with a trailing
+      // period ("1.") only when the row is populated.
+      const cell = (play: T | undefined, num: number | '') => `
+            <td class="wb-num">${num === '' ? '' : `${num}.`}</td><td class="wb-play-name">${play ? escapeHtml(getName(play) || UNTITLED_PLAY) : ''}</td>`;
+      const rowsHtml = Array.from({ length: ROWS_PER_INSERT_TEXT }, (_, r) => {
+        const left = group[r];
+        const right = group[r + ROWS_PER_INSERT_TEXT];
+        const leftNum = left ? groupIndex * perInsert + r + 1 : '';
+        const rightNum = right ? groupIndex * perInsert + r + ROWS_PER_INSERT_TEXT + 1 : '';
+        return `
+            <tr>${cell(left, leftNum)}${cell(right, rightNum)}</tr>`;
+      }).join('');
+
+      return `
+      <div class="wb-insert wb-insert-text">
+        <div class="wb-insert-label">${insertLabel}</div>
+        <table class="wb-text-table">
+          <colgroup>
+            <col class="col-num" /><col class="col-name" /><col class="col-num" /><col class="col-name" />
+          </colgroup>
+          <thead>
+            <tr><th class="wb-h-num">Play #</th><th class="wb-h-name">Play</th><th class="wb-h-num">Play #</th><th class="wb-h-name">Play</th></tr>
+          </thead>
+          <tbody>${rowsHtml}
+        </tbody></table>
+      </div>`;
+    }
+
+    const cells = group.map((play, i) => {
+      const playNumber = groupIndex * perInsert + i + 1;
+      const image = getImage(play);
+      return `
+        <div class="wb-cell">
+          <div class="wb-cell-header">
+            <div class="wb-number">${playNumber}</div>
+            <div class="wb-name">${escapeHtml(getName(play) || UNTITLED_PLAY)}</div>
+          </div>
+          <div class="wb-thumb">${image ? `<img src="${image}" alt="" />` : '<div class="no-image">&mdash;</div>'}</div>
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="wb-insert">
+        <div class="wb-insert-label">${insertLabel}</div>
+        <div class="wb-cells">${cells}</div>
+      </div>`;
+  }).join('');
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(title)} - Wristband Inserts</title>
+  <style>
+    @page {
+      size: ${(preferences?.paper_size ?? 'letter') === 'a4' ? 'A4 landscape' : '11in 8.5in'};
+      margin: 0.4in;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      color: ${EXPORT_INK};
+      background: white;
+    }
+
+    .playbook-header {
+      text-align: center;
+      margin-bottom: 0.15in;
+      padding-bottom: 0.1in;
+      border-bottom: ${EXPORT_ACCENT_RULE};
+    }
+
+    .playbook-title {
+      font-size: 16pt;
+      font-weight: bold;
+      color: ${EXPORT_INK};
+      margin-bottom: 2px;
+    }
+
+    .playbook-subtitle {
+      font-size: 9pt;
+      color: ${EXPORT_MUTED};
+    }
+
+    .wb-compat {
+      font-size: 6.5pt;
+      color: #888;
+      margin-top: 2px;
+    }
+
+    .wb-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 4.5in);
+      gap: 0.2in;
+      justify-content: center;
+    }
+
+    .wb-insert {
+      width: 4.5in;
+      height: 2.2in;
+      border: 1px dashed #999;
+      border-radius: 4px;
+      padding: 0.06in 0.1in;
+      background: ${EXPORT_WASH};
+      page-break-inside: avoid;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Text-only inserts: the table's own bold outer border is the cut line,
+       so drop the dashed guide + grey wash used by the diagram variant. */
+    .wb-insert-text {
+      border: none;
+      background: white;
+      border-radius: 0;
+      padding: 0;
+    }
+
+    .wb-insert-label {
+      font-size: 6.5pt;
+      color: ${EXPORT_MUTED};
+      text-align: center;
+      margin-bottom: 0.03in;
+      flex-shrink: 0;
+    }
+
+    .wb-cells {
+      flex: 1;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      grid-template-rows: repeat(2, 1fr);
+      gap: 0.04in;
+      min-height: 0;
+    }
+
+    .wb-cell {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      min-width: 0;
+      border: 1px solid #ccc;
+      border-radius: 2px;
+      overflow: hidden;
+      background: white;
+    }
+
+    .wb-cell-header {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 1px 2px;
+      background: #eee;
+      min-width: 0;
+    }
+
+    .wb-number {
+      flex-shrink: 0;
+      width: 0.15in;
+      height: 0.15in;
+      border-radius: 50%;
+      background: ${EXPORT_INK};
+      color: white;
+      font-weight: bold;
+      font-size: 5.5pt;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .wb-name {
+      flex: 1;
+      min-width: 0;
+      font-weight: bold;
+      color: ${EXPORT_INK};
+      font-size: 5.5pt;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .wb-thumb {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: white;
+      overflow: hidden;
+    }
+
+    .wb-thumb img {
+      max-width: 100%;
+      max-height: 100%;
+    }
+
+    .no-image {
+      color: #999;
+      font-size: 7pt;
+    }
+
+    /* Coach's-sheet look, matched to the supplied reference image: black
+       header bar, bold outer border, thin inner rules, alternating
+       grey/white row shading, bold centered numbers with a trailing
+       period. */
+    .wb-text-table {
+      flex: 1;
+      width: 100%;
+      height: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+      border: 3px solid ${EXPORT_INK};
+    }
+
+    .wb-text-table thead th {
+      background: ${EXPORT_INK};
+      color: #fff;
+      font-weight: bold;
+      font-size: 7.5pt;
+      padding: 0.015in 0.03in;
+      border: 1px solid ${EXPORT_INK};
+    }
+
+    .wb-h-num { text-align: center; }
+    .wb-h-name { text-align: left; }
+
+    /* 10 fixed data rows evenly fill whatever height the header leaves. */
+    .wb-text-table tbody tr { height: calc(100% / 10); }
+
+    .wb-text-table td {
+      border: 1px solid ${EXPORT_MUTED};
+      padding: 0.01in 0.03in;
+      font-size: 8pt;
+      line-height: 1.3;
+    }
+
+    /* Alternating shading, first data row shaded — matches the reference. */
+    .wb-text-table tbody tr:nth-child(odd) td {
+      background: #d9d9d9;
+    }
+
+    /* Column widths are set here, on <colgroup>'s <col> elements — the
+       authoritative, unambiguous way to size a table-layout:fixed table.
+       Setting width on the repeated .wb-num/.wb-play-name TD classes was
+       unreliable (the name column rendered far too narrow and truncated
+       aggressively — reported with a screenshot), since table-layout:fixed
+       only reads the first row's cells to fix column widths, easy to get
+       inconsistent results from cell-level CSS across 4 repeating columns. */
+    .col-num {
+      width: 10%;
+    }
+
+    .col-name {
+      width: 40%;
+    }
+
+    .wb-num {
+      font-weight: bold;
+      color: ${EXPORT_INK};
+      text-align: center;
+    }
+
+    .wb-play-name {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 0; /* forces overflow/ellipsis to respect the table column width */
+    }
+
+    @media print {
+      body { -webkit-print-color-adjust: exact !important; }
+      .wb-insert { page-break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <div class="playbook-header">
+    ${teamBrandHTML(preferences)}
+    <div class="playbook-title">${escapeHtml(title)}</div>
+    <div class="playbook-subtitle">Wristband Inserts &mdash; sized for a 4.5" &times; 2.2" wristband window &mdash; cut along dashed lines</div>
+    <div class="wb-compat">Compatible with ${WRISTBAND_PRODUCT_NAME} (${WRISTBAND_PRODUCT_URL}) and any wristband with a ${WRISTBAND_WINDOW_SIZE} play window.${SHOW_AFFILIATE_DISCLOSURE ? ' As an Amazon Associate we earn from qualifying purchases.' : ''}</div>
+  </div>
+
+  <div class="wb-grid">
+    ${inserts}
+  </div>
+
+  ${exportFooterHTML(plays.length, '0.15in')}
+</body>
+</html>`;
+}

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -114,7 +114,7 @@ export function teamBrandHTML(prefs: Pick<UserPreferences, 'team_name' | 'team_l
  *  hierarchy (a single-play sheet's title has always been bigger than a
  *  grid-view thumbnail's) instead of flattening every format to one size. */
 export function playTitleHTML(name: string, fontSize = '26pt'): string {
-  return `<div style="text-align:center; font-family: Georgia, 'Times New Roman', serif; font-size:${fontSize}; font-weight:700; color:#1e40af; letter-spacing:0.5px;">${escapeHtml(name)}</div>`;
+  return `<div style="text-align:center; font-family: Georgia, 'Times New Roman', serif; font-size:${fontSize}; font-weight:700; color:#000; letter-spacing:0.5px;">${escapeHtml(name)}</div>`;
 }
 
 /** CSS @page size value for the user's paper preference (B-15). */

--- a/tests/smoke/designer.spec.ts
+++ b/tests/smoke/designer.spec.ts
@@ -2385,6 +2385,94 @@ test('single-play export prints via a generated window, pulling in no PDF librar
   expect(heavy).toEqual([]);
 });
 
+test('single-play export: multi-line notes survive as <br>, no leftover theme color', async ({ page }) => {
+  // Every export generator used to interpolate the coach's notes raw — no
+  // escaping, no newline handling — so a multi-line description collapsed
+  // into one run-on line. Also guards the black/white chrome unification:
+  // every generator used to hand-roll its own shade of blue (#2563eb /
+  // #1e40af); they now share exportStyles.ts's tokens.
+  const opened: string[] = [];
+  await page.exposeFunction('__recordExportHTML', (html: string) => { opened.push(html); });
+  await page.addInitScript(() => {
+    window.open = () => ({
+      document: {
+        open() {}, close() {},
+        write(html: string) { (window as unknown as { __recordExportHTML: (h: string) => void }).__recordExportHTML(html); },
+      },
+      focus() {}, print() {}, closed: false,
+    } as unknown as Window);
+  });
+
+  await openDesigner(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+  await page.getByText('Single Play Sheet').click();
+  await page.getByPlaceholder('Enter play name...').fill('Trips Right Flood');
+  await page.getByPlaceholder('Describe the play execution, reads, coaching points...').fill(
+    'Read the flat defender.\nIf he sits, throw the out.',
+  );
+  await page.getByRole('button', { name: /Print Play/ }).first().click();
+
+  await expect.poll(() => opened.length, { timeout: 5000 }).toBeGreaterThan(0);
+  const html = opened.join('');
+  expect(html).toContain('Read the flat defender.<br>If he sits, throw the out.');
+  expect(html).not.toMatch(/#2563eb|#1e40af|#f59e0b/i);
+});
+
+test('wristband text-only: black header row, alternating stripes, bold outer border', async ({ page }) => {
+  // Matches a supplied reference coach-sheet: black "Play #"/"Play" header,
+  // bold 3px outer border, alternating grey/white row shading, and numbers
+  // rendered with a trailing period ("1.") — none of which existed before
+  // this styling pass (the table previously had no header row at all).
+  // Wristband is a Pro-only format, so this needs a Pro session — same
+  // pattern as the "Pro accounts see playbook formats unlocked" test below.
+  const userJson = {
+    id: '33333333-3333-3333-3333-333333333333',
+    aud: 'authenticated', role: 'authenticated', email: 'pro-coach-2@example.com',
+    app_metadata: {}, user_metadata: {}, created_at: '2025-09-01T00:00:00Z',
+  };
+  await page.addInitScript(({ user, storageKey }) => {
+    localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'test-access-token', refresh_token: 'test-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600, expires_in: 3600,
+      token_type: 'bearer', user,
+    }));
+  }, { user: userJson, storageKey: AUTH_STORAGE_KEY });
+  await page.route('**/auth/v1/user**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userJson) }));
+  await page.route('**/rest/v1/subscriptions**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ plan: 'pro', current_period_end: null }) }));
+
+  const opened: string[] = [];
+  await page.exposeFunction('__recordWristbandHTML', (html: string) => { opened.push(html); });
+  await page.addInitScript(() => {
+    window.open = () => ({
+      document: {
+        open() {}, close() {},
+        write(html: string) { (window as unknown as { __recordWristbandHTML: (h: string) => void }).__recordWristbandHTML(html); },
+      },
+      focus() {}, print() {}, closed: false,
+    } as unknown as Window);
+  });
+
+  await openDesigner(page);
+  await btn(page, 'Player Q').click();
+  const spot = await canvasPoint(page, 0.4, 0.65);
+  await page.mouse.click(spot.x, spot.y);
+
+  await page.getByRole('button', { name: 'Export' }).click();
+  await page.getByText('Wristband Sheet').click();
+  await page.getByText('Text only').click();
+  await page.getByRole('button', { name: /Print Playbook/ }).click();
+
+  await expect.poll(() => opened.length, { timeout: 5000 }).toBeGreaterThan(0);
+  const html = opened.join('');
+  expect(html).toContain('<thead>');
+  expect(html).toContain('Play #');
+  expect(html).toMatch(/border:\s*3px solid #000/);
+  expect(html).toMatch(/tbody tr:nth-child\(odd\) td\s*\{\s*background:\s*#d9d9d9/);
+  expect(html).toMatch(/class="wb-num">1\.</);
+});
+
 test('export gates (B-2): Pro accounts see playbook formats unlocked', async ({ page }) => {
   const userJson = {
     id: '22222222-2222-2222-2222-222222222222',


### PR DESCRIPTION
Two asks: restyle **Wristband (Text Only)** to match a supplied reference coach-sheet, and make every export format across Designer + Playbooks look like one product instead of nine independently-drifted ones.

## Wristband (Text Only) — matches the reference
Black `<thead>` row ("Play #" / "Play" in bold white), 3px black outer border, thin inner rules, alternating grey/white row shading, bold centered numbers with a trailing period ("1.").

| Before | After |
|---|---|
| No header row, thin grey borders, blue right-aligned numbers, dashed cut-guide box | Black header, bold outer border, alternating stripes, centered "1." — matches supplied reference |

## New shared module: `src/lib/exportStyles.ts`
Every generator now imports design tokens from one place instead of hand-rolling its own:
- **Black/white chrome** (`EXPORT_INK`, `EXPORT_ACCENT_RULE`, `EXPORT_WASH`, `EXPORT_HAIRLINE`) replaces the ad-hoc blue theme — `#2563eb`/`#1e40af` had drifted to a *different shade* in nearly every one of the 9 generators — plus one amber notes box that existed nowhere else in the app. Diagrams keep their own colors; this only governs chrome.
- **`formatPlayType()`** fixes `special_teams` printing as literal `"Special_teams"` in every export that showed play type (the card UI already stripped the underscore; no export generator did).
- **`formatNotesHTML()`/`notesBlockHTML()`** converge three bespoke notes blocks (slate, white, amber) into one — escaped, and unlike every version but one, newlines now actually become `<br>` instead of collapsing into a single line.
- **`generateWristbandHTML()`** is the ONE wristband implementation shared by `ExportModal.tsx` and `PlaybooksPage.tsx`, which previously carried **~300 duplicated lines each** — a fix to one (like the `<colgroup>` column-width commit) had to be hand-repeated in the other.

## Fixed along the way (found while tracing the "ugly" complaint)
- **The "offense Play" subtitle is gone.** `PlaybooksPage`'s Detailed export printed `${play.type} Play` under the title with a `capitalize` CSS rule that doesn't touch underscores — so special-teams plays literally printed **"Special_teams Play"**. Type now appears once, correctly formatted, in the metadata panel instead.
- **A real bug, not just a style drift:** `PlaybooksPage`'s multi-play Simple/Detailed export wrapper extracted only each page's `<body>` via regex and **discarded every `<style>` block** — so those exports printed with almost no styling at all (no header rule, no notes box, no metadata panel). Fixed by lifting the first page's `<style>` (identical across pages from the same generator) into the wrapper's `<head>` instead of dropping it.
- `VsExportModal` recolored to match. Its hardcoded `letter` paper size (ignoring the user's A4 preference) is left as a noted follow-up — `preferences` isn't currently threaded into that component without a larger prop change.

## Verification
Captured real generated HTML from a live dev server (`window.open` stub) for all 5 Designer formats plus a mocked 2-play Playbooks Detailed export, then rendered each to a screenshot:
- Wristband text-only visually matches the reference image
- Multi-line notes render with real `<br>`s, confirmed in both Designer and Playbooks output
- "Special Teams" (not "Special_teams") confirmed in rendered Playbooks output
- The Playbooks CSS-stripping bug confirmed fixed — full styling present across both pages of a multi-play export
- Zero leftover `#2563eb`/`#1e40af`/`#f59e0b` across all captured documents

Two new smoke tests in `designer.spec.ts` (reusing existing patterns already in the file): wristband text-only asserts the `<thead>`/border/stripe/period markup; single-play export asserts notes survive as `<br>` with no leftover theme color.

## Test plan
- [x] `npm run verify` passes end to end
- [x] 176/176 smoke (one unrelated test flaked once under full-suite parallel load; passed in isolation and on a clean full re-run)
- [x] Net **-574 lines** despite the new module and added tests — eliminating the wristband duplication paid for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)