### PR TITLE
Fix hamburger menu blocked under the iOS status bar as a home-screen app

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -68,8 +68,19 @@ export function Navbar() {
   // own — without it, a z-40 positioned nav would float above their z-auto container and
   // swallow clicks on their toolbar, which is the failure mode this used to avoid by
   // keeping the nav non-positioned. Check both spots before changing this z-index.
+  //
+  // pt-[env(safe-area-inset-top)]: in a normal browser tab this resolves to 0
+  // (Safari's own chrome already reserves the status-bar area) so it's a
+  // no-op there. It only matters once the site is added to the iOS home
+  // screen — apple-mobile-web-app-status-bar-style is "black-translucent"
+  // (index.html), which makes the page draw *under* the status bar in that
+  // standalone mode, and this nav had no top inset at all. That put the
+  // hamburger button directly under the status bar/notch, reported as
+  // blocked and unusable. The background still fills the inset area; only
+  // the row of actual content (logo, links, the menu button) gets pushed
+  // down below it.
   return (
-    <nav className="sticky top-0 z-40 bg-board-light border-b border-chalk/10">
+    <nav className="sticky top-0 z-40 bg-board-light border-b border-chalk/10 pt-[env(safe-area-inset-top)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16">
           <div className="flex">

--- a/src/components/designer/PlayDesigner.tsx
+++ b/src/components/designer/PlayDesigner.tsx
@@ -473,7 +473,15 @@ export function PlayDesigner() {
     <div className="fixed inset-0 z-50 flex flex-col bg-board overflow-hidden">
 
       {/* ── HEADER ─────────────────────────────────────────────── */}
-      <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 py-2 flex items-center gap-2 z-30">
+      {/* pt uses calc(...+env(safe-area-inset-top)) rather than a separate
+          pt-[...] utility alongside py-2 — both would set padding-top, and
+          which one wins depends on Tailwind's generated CSS order, not
+          className order, so stacking them is a real footgun. See the
+          longer note on this same fix in Navbar.tsx: without it, this
+          header's buttons render under the iOS status bar once the site is
+          added to the home screen (apple-mobile-web-app-status-bar-style is
+          "black-translucent" in index.html). */}
+      <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 pt-[calc(0.5rem+env(safe-area-inset-top))] pb-2 flex items-center gap-2 z-30">
         {/* Home */}
         <button
           onClick={() => navigate('/')}

--- a/src/components/vs/VsDefenseView.tsx
+++ b/src/components/vs/VsDefenseView.tsx
@@ -437,7 +437,12 @@ export function VsDefenseView() {
     // the z-index note in Navbar.tsx.
     <div className="fixed inset-0 z-50 flex flex-col bg-board overflow-hidden">
       {/* ── HEADER ─────────────────────────────────────────────── */}
-      <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 py-2 flex items-center gap-2 z-30">
+      {/* pt uses calc(...+env(safe-area-inset-top)) rather than a separate
+          pt-[...] utility alongside py-2 — see the matching note in
+          PlayDesigner.tsx / Navbar.tsx. Without it, this header's buttons
+          render under the iOS status bar once the site is added to the
+          home screen. */}
+      <header className="shrink-0 bg-board-light border-b border-chalk/10 px-3 pt-[calc(0.5rem+env(safe-area-inset-top))] pb-2 flex items-center gap-2 z-30">
         <Link
           to="/plays"
           className="p-2 text-chalk/60 hover:text-chalk rounded-lg hover:bg-white/10"

--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -136,6 +136,36 @@ test('the mobile nav toggle is labelled, reports state, and closes on navigation
   await expect(page.locator('#mobile-menu')).toHaveCount(0);
 });
 
+/* ── iOS home-screen safe area ────────────────────────────────────────────
+   Added to the home screen, the app runs standalone with
+   apple-mobile-web-app-status-bar-style: black-translucent (index.html) —
+   the page draws UNDER the iPhone status bar in that mode, unlike a normal
+   Safari tab where the browser chrome already reserves that space. Navbar
+   had a top-0 sticky bar with no top inset at all, so the hamburger button
+   rendered directly under the status bar/notch: reported as blocked and
+   unusable. `viewport-fit=cover` (also index.html) is what makes
+   env(safe-area-inset-top) resolve to a real value instead of 0 in that
+   mode; CDP's Emulation.setSafeAreaInsetsOverride simulates that value here
+   since Chromium has no real notch to report one from on its own. */
+test('mobile nav toggle clears the iOS status bar when the site is a home-screen app', async ({ page }) => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Emulation.setSafeAreaInsetsOverride', {
+    insets: { top: 59, topMax: 59, bottom: 34, bottomMax: 34, left: 0, leftMax: 0, right: 0, rightMax: 0 },
+  });
+
+  await page.goto('/');
+  const toggle = page.getByRole('button', { name: 'Open menu' });
+  const box = (await toggle.boundingBox())!;
+
+  // The button's own top edge must clear the simulated 59px status bar —
+  // this is the exact regression: the button used to sit at y < 59.
+  expect(box.y, 'menu button rendered under the simulated status bar').toBeGreaterThanOrEqual(59);
+
+  // And it must still actually work, not just be positioned correctly.
+  await toggle.click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+});
+
 test('Escape closes the mobile nav menu', async ({ page }) => {
   await page.goto('/');
 


### PR DESCRIPTION
Reported: adding the site to an iPhone home screen and opening it there left the navbar's hamburger button blocked and unusable at the top right.

## Root cause
`apple-mobile-web-app-status-bar-style` is `black-translucent` (`index.html`) — in that standalone/home-screen mode, the page draws **under** the iOS status bar/notch instead of the browser reserving that space the way Safari does in a normal tab.

The app already handles the **bottom** safe-area inset in three places (`FeedbackButton`, `ConsentBanner`, `PlayDesigner`'s toolbar) but nowhere handled the **top** inset — so `Navbar`'s `sticky top-0` bar rendered its hamburger button directly under the status bar.

## It wasn't just the Navbar
`/designer` and `/vs` render their own full-screen fixed headers that bypass `Navbar` entirely (`PlayDesigner.tsx`, `VsDefenseView.tsx`) — both had the identical bug, just not yet reported. Fixed all three together rather than leaving two live.

## Fix
`env(safe-area-inset-top)` added as top padding on all three headers — resolves to `0` in a normal browser tab (no-op there), and to the real inset once installed to the home screen.

One wrinkle: `PlayDesigner`'s and `VsDefenseView`'s headers already use `py-2`. Stacking a second `pt-[...]` utility next to it would race Tailwind's generated CSS order (whichever `padding-top` rule Tailwind emits *later* wins, independent of className order) — used `pt-[calc(0.5rem+env(safe-area-inset-top))]` with an explicit `pb-2` instead to remove that ambiguity. `Navbar` had no existing top-padding utility, so it was safe to add directly there.

## Verification
Used Chromium's CDP `Emulation.setSafeAreaInsetsOverride` — the only way to simulate a real notch inset, since nothing in a normal Chromium window reports one on its own — at a realistic 59px:
- Navbar's computed `padding-top` came back exactly `59px`
- `PlayDesigner`'s header came back `67px` (8px original `py-2` + 59px — matches the `calc()` formula exactly)
- Both buttons landed clear of the simulated bar and stayed clickable

**Confirmed the new regression test actually catches the bug**, not just passes vacuously: temporarily reverted the Navbar fix, watched the test fail on the exact assertion, then restored it and watched it pass.

## Test plan
- [x] `npm run verify` passes, 177/177 smoke
- [x] New regression test verified to fail without the fix and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)